### PR TITLE
Obtain struct layout details from C to help avoid runtime mismatches.

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -27,10 +27,10 @@ Library "ctypes-foreign"
   Path:             src/
   Findlibname:      foreign
   Findlibparent:    ctypes
-  Modules:          Dl,Foreign
+  Modules:          Dl,Foreign,Verify_struct_layout
   CSources:         dl_stubs.c
   CCOpt:            -fPIC -Wall -Wno-unused-variable -g
-  BuildDepends:     unix,ctypes
+  BuildDepends:     unix,str,ctypes
   Install:          true
 
 Library fts

--- a/_tags
+++ b/_tags
@@ -1,5 +1,5 @@
 # OASIS_START
-# DO NOT EDIT (digest: 56640850f6c23433eb2be17847567ce4)
+# DO NOT EDIT (digest: 55d3a06ecde950f6f1e9505d756ad14d)
 # Ignore VCS directories, you can use the same kind of rule outside 
 # OASIS_START/STOP if you want to exclude directories that contains 
 # useless stuff for the build process
@@ -34,8 +34,10 @@
 <src/ctypes-foreign.{cma,cmxa}>: use_libctypes-foreign_stubs
 <src/*.ml{,i}>: use_ctypes
 <src/*.ml{,i}>: pkg_unix
+<src/*.ml{,i}>: pkg_str
 "src/dl_stubs.c": use_ctypes
 "src/dl_stubs.c": pkg_unix
+"src/dl_stubs.c": pkg_str
 # Library fts
 "examples/fts/fts.cmxs": use_fts
 # Library sigset
@@ -43,6 +45,7 @@
 <examples/sigset/*.ml{,i}>: use_ctypes-foreign
 <examples/sigset/*.ml{,i}>: use_ctypes
 <examples/sigset/*.ml{,i}>: pkg_unix
+<examples/sigset/*.ml{,i}>: pkg_str
 # Library ncurses
 "examples/ncurses/ncurses.cmxs": use_ncurses
 <examples/ncurses/ncurses.{cma,cmxa}>: oasis_library_ncurses_cclib
@@ -51,124 +54,146 @@
 <examples/ncurses/ncurses_cmd.{native,byte}>: use_ctypes-foreign
 <examples/ncurses/ncurses_cmd.{native,byte}>: use_ctypes
 <examples/ncurses/ncurses_cmd.{native,byte}>: pkg_unix
+<examples/ncurses/ncurses_cmd.{native,byte}>: pkg_str
 <examples/ncurses/*.ml{,i}>: use_ncurses
 <examples/ncurses/*.ml{,i}>: use_ctypes-foreign
 <examples/ncurses/*.ml{,i}>: use_ctypes
 <examples/ncurses/*.ml{,i}>: pkg_unix
+<examples/ncurses/*.ml{,i}>: pkg_str
 <examples/ncurses/ncurses_cmd.{native,byte}>: custom
 # Executable fts_cmd
 <examples/fts/fts_cmd.{native,byte}>: use_fts
 <examples/fts/fts_cmd.{native,byte}>: use_ctypes-foreign
 <examples/fts/fts_cmd.{native,byte}>: use_ctypes
 <examples/fts/fts_cmd.{native,byte}>: pkg_unix
+<examples/fts/fts_cmd.{native,byte}>: pkg_str
 <examples/fts/*.ml{,i}>: use_fts
 <examples/fts/*.ml{,i}>: use_ctypes-foreign
 <examples/fts/*.ml{,i}>: use_ctypes
 <examples/fts/*.ml{,i}>: pkg_unix
+<examples/fts/*.ml{,i}>: pkg_str
 <examples/fts/fts_cmd.{native,byte}>: custom
 # Executable test_ctypes_raw
 <tests/test_raw.{native,byte}>: use_ctypes-foreign
 <tests/test_raw.{native,byte}>: use_ctypes
 <tests/test_raw.{native,byte}>: pkg_unix
 <tests/test_raw.{native,byte}>: pkg_oUnit
+<tests/test_raw.{native,byte}>: pkg_str
 <tests/test_raw.{native,byte}>: custom
 # Executable test_ctypes_pointers
 <tests/test_pointers.{native,byte}>: use_ctypes-foreign
 <tests/test_pointers.{native,byte}>: use_ctypes
 <tests/test_pointers.{native,byte}>: pkg_unix
 <tests/test_pointers.{native,byte}>: pkg_oUnit
+<tests/test_pointers.{native,byte}>: pkg_str
 <tests/test_pointers.{native,byte}>: custom
 # Executable test_ctypes_higher_order
 <tests/test_higher_order.{native,byte}>: use_ctypes-foreign
 <tests/test_higher_order.{native,byte}>: use_ctypes
 <tests/test_higher_order.{native,byte}>: pkg_unix
 <tests/test_higher_order.{native,byte}>: pkg_oUnit
+<tests/test_higher_order.{native,byte}>: pkg_str
 <tests/test_higher_order.{native,byte}>: custom
 # Executable test_ctypes_structs
 <tests/test_structs.{native,byte}>: use_ctypes-foreign
 <tests/test_structs.{native,byte}>: use_ctypes
 <tests/test_structs.{native,byte}>: pkg_unix
 <tests/test_structs.{native,byte}>: pkg_oUnit
+<tests/test_structs.{native,byte}>: pkg_str
 <tests/test_structs.{native,byte}>: custom
 # Executable test_ctypes_cstdlib
 <tests/test_cstdlib.{native,byte}>: use_ctypes-foreign
 <tests/test_cstdlib.{native,byte}>: use_ctypes
 <tests/test_cstdlib.{native,byte}>: pkg_unix
 <tests/test_cstdlib.{native,byte}>: pkg_oUnit
+<tests/test_cstdlib.{native,byte}>: pkg_str
 <tests/test_cstdlib.{native,byte}>: custom
 # Executable test_ctypes_sizeof
 <tests/test_sizeof.{native,byte}>: use_ctypes-foreign
 <tests/test_sizeof.{native,byte}>: use_ctypes
 <tests/test_sizeof.{native,byte}>: pkg_unix
 <tests/test_sizeof.{native,byte}>: pkg_oUnit
+<tests/test_sizeof.{native,byte}>: pkg_str
 <tests/test_sizeof.{native,byte}>: custom
 # Executable test_ctypes_unions
 <tests/test_unions.{native,byte}>: use_ctypes-foreign
 <tests/test_unions.{native,byte}>: use_ctypes
 <tests/test_unions.{native,byte}>: pkg_unix
 <tests/test_unions.{native,byte}>: pkg_oUnit
+<tests/test_unions.{native,byte}>: pkg_str
 <tests/test_unions.{native,byte}>: custom
 # Executable test_ctypes_custom_ops
 <tests/test_custom_ops.{native,byte}>: use_ctypes-foreign
 <tests/test_custom_ops.{native,byte}>: use_ctypes
 <tests/test_custom_ops.{native,byte}>: pkg_unix
 <tests/test_custom_ops.{native,byte}>: pkg_oUnit
+<tests/test_custom_ops.{native,byte}>: pkg_str
 <tests/test_custom_ops.{native,byte}>: custom
 # Executable test_ctypes_arrays
 <tests/test_array.{native,byte}>: use_ctypes-foreign
 <tests/test_array.{native,byte}>: use_ctypes
 <tests/test_array.{native,byte}>: pkg_unix
 <tests/test_array.{native,byte}>: pkg_oUnit
+<tests/test_array.{native,byte}>: pkg_str
 <tests/test_array.{native,byte}>: custom
 # Executable test_ctypes_errno
 <tests/test_errno.{native,byte}>: use_ctypes-foreign
 <tests/test_errno.{native,byte}>: use_ctypes
 <tests/test_errno.{native,byte}>: pkg_unix
 <tests/test_errno.{native,byte}>: pkg_oUnit
+<tests/test_errno.{native,byte}>: pkg_str
 <tests/test_errno.{native,byte}>: custom
 # Executable test_ctypes_passable
 <tests/test_passable.{native,byte}>: use_ctypes-foreign
 <tests/test_passable.{native,byte}>: use_ctypes
 <tests/test_passable.{native,byte}>: pkg_unix
 <tests/test_passable.{native,byte}>: pkg_oUnit
+<tests/test_passable.{native,byte}>: pkg_str
 <tests/test_passable.{native,byte}>: custom
 # Executable test_ctypes_alignment
 <tests/test_alignment.{native,byte}>: use_ctypes-foreign
 <tests/test_alignment.{native,byte}>: use_ctypes
 <tests/test_alignment.{native,byte}>: pkg_unix
 <tests/test_alignment.{native,byte}>: pkg_oUnit
+<tests/test_alignment.{native,byte}>: pkg_str
 <tests/test_alignment.{native,byte}>: custom
 # Executable test_ctypes_views
 <tests/test_views.{native,byte}>: use_ctypes-foreign
 <tests/test_views.{native,byte}>: use_ctypes
 <tests/test_views.{native,byte}>: pkg_unix
 <tests/test_views.{native,byte}>: pkg_oUnit
+<tests/test_views.{native,byte}>: pkg_str
 <tests/test_views.{native,byte}>: custom
 # Executable test_ctypes_global_values
 <tests/test_foreign_values.{native,byte}>: use_ctypes-foreign
 <tests/test_foreign_values.{native,byte}>: use_ctypes
 <tests/test_foreign_values.{native,byte}>: pkg_unix
 <tests/test_foreign_values.{native,byte}>: pkg_oUnit
+<tests/test_foreign_values.{native,byte}>: pkg_str
 <tests/test_foreign_values.{native,byte}>: custom
 # Executable test_ctypes_oo_style
 <tests/test_oo_style.{native,byte}>: use_ctypes-foreign
 <tests/test_oo_style.{native,byte}>: use_ctypes
 <tests/test_oo_style.{native,byte}>: pkg_unix
 <tests/test_oo_style.{native,byte}>: pkg_oUnit
+<tests/test_oo_style.{native,byte}>: pkg_str
 <tests/*.ml{,i}>: use_ctypes-foreign
 <tests/*.ml{,i}>: use_ctypes
 <tests/*.ml{,i}>: pkg_unix
 <tests/*.ml{,i}>: pkg_oUnit
+<tests/*.ml{,i}>: pkg_str
 <tests/test_oo_style.{native,byte}>: custom
 # Executable date_example
 <examples/date/date.{native,byte}>: use_ctypes-foreign
 <examples/date/date.{native,byte}>: use_ctypes
 <examples/date/date.{native,byte}>: pkg_unix
 <examples/date/date.{native,byte}>: pkg_oUnit
+<examples/date/date.{native,byte}>: pkg_str
 <examples/date/*.ml{,i}>: use_ctypes-foreign
 <examples/date/*.ml{,i}>: use_ctypes
 <examples/date/*.ml{,i}>: pkg_unix
 <examples/date/*.ml{,i}>: pkg_oUnit
+<examples/date/*.ml{,i}>: pkg_str
 <examples/date/date.{native,byte}>: custom
 # OASIS_STOP
 <tests/clib/*>: not_hygienic

--- a/src/verify_struct_layout.ml
+++ b/src/verify_struct_layout.ml
@@ -1,0 +1,64 @@
+open Printf
+
+(* Obtain basic struct layout information.
+
+   No attempt to verify field types for the moment.
+*)
+
+type field_info = {
+  label: string;
+  offset: int;
+  size : int;
+}
+
+type struct_info = {
+  tag : string;
+  fields : field_info list;
+  size: int
+}
+
+exception UnknownStruct of string
+exception UnknownField of string
+exception CompilationError of exn
+
+let _integer_value ~headers expr : int =
+  (* Proof-of-concept implementation. *)
+  let prologue = String.concat "\n"
+    (List.map (Printf.sprintf "#include \"%s\"") headers)
+  in
+  let id = Str.(global_replace (regexp "\\.") "_"
+                  (sprintf "x_%f" (Unix.gettimeofday ()))) in
+  let ouch = open_out (sprintf "/tmp/%s.c" id) in
+  begin
+    fprintf ouch "#include <stddef.h>\n%s\n\n int %s = (%s);" prologue id expr;
+    close_out ouch;
+    ignore (Sys.command (sprintf "gcc -shared -fPIC -o /tmp/%s.so /tmp/%s.c" id id));
+    let lib = Dl.(dlopen ~filename:(sprintf "/tmp/%s.so" id) ~flags:[RTLD_NOW]) in
+    Ctypes.(!@ (Foreign.foreign_value ~from:lib id int))
+  end
+
+let integer_value ~headers expr =
+  try _integer_value ~headers expr
+  with e -> raise (CompilationError e)
+
+let struct_size ~headers tag = 
+  try integer_value ~headers (sprintf "sizeof (struct %s)" tag)
+  with CompilationError _ -> raise (UnknownStruct tag)
+
+let field_size ~headers ~tag label =
+  integer_value ~headers (sprintf "sizeof (((struct %s *)NULL)->%s)" tag label)
+
+let field_offset ~headers ~tag label =
+  integer_value ~headers (sprintf "offsetof (struct %s, %s)" tag label)
+
+let field_info ~headers ~tag label =
+  try { label ;
+        offset = field_offset ~headers ~tag label ;
+        size = field_size ~headers ~tag label }
+  with CompilationError _ -> raise (UnknownField label)
+    
+let struct_info ?(headers=[]) ~tag ~fields : struct_info =
+  let size = struct_size ~headers tag in
+  let fields = List.sort (fun {offset=l} {offset=r} -> compare l r)
+    (List.map (field_info ~headers ~tag) fields) in
+  { tag; size; fields }


### PR DESCRIPTION
``` ocaml
   # module V = Verify_struct_layout
   [...]
   # V.struct_info ~headers:["sys/types.h"] ~tag:"timeval"
       ~fields:["tv_sec"; "tv_usec"];;
   - : V.struct_info =
   {V.tag = "timeval";
    fields =
     [{V.label = "tv_sec"; offset = 0; size = 8};
      {V.label = "tv_usec"; offset = 8; size = 8}];
    size = 16}
   # V.struct_info ~headers:["time.h"] ~tag:"tm"
       ~fields:["tm_isdst"; "tm_mday"; "tm_mon"; "tm_year";
                "tm_wday"; "tm_yday"; "tm_sec"; "tm_min"; "tm_hour"];;
   - : V.struct_info =
   {V.tag = "tm";
    fields =
     [{V.label = "tm_sec"; offset = 0; size = 4};
      {V.label = "tm_min"; offset = 4; size = 4};
      {V.label = "tm_hour"; offset = 8; size = 4};
      {V.label = "tm_mday"; offset = 12; size = 4};
      {V.label = "tm_mon"; offset = 16; size = 4};
      {V.label = "tm_year"; offset = 20; size = 4};
      {V.label = "tm_wday"; offset = 24; size = 4};
      {V.label = "tm_yday"; offset = 28; size = 4};
      {V.label = "tm_isdst"; offset = 32; size = 4}];
    size = 56}
```

Currently just a comically inefficient proof-of-concept implementation.
