### PR TITLE
 Basic field name support.

### DIFF
--- a/src/ctypes.mli
+++ b/src/ctypes.mli
@@ -289,6 +289,10 @@ val ( +:+ ) : 's union typ -> 'a typ -> ('a, 's union) field
     Attempting to add a field to a union type that has been sealed with [seal]
     is an error, and will raise [ModifyingSealedType]. *)
 
+val field : string -> ((_, _) field as 'f) -> 'f
+(** Set the name of a field.  Field names are used in various circumstances,
+    including type printing, value printing, and stub generation. *)
+
 val seal : (_, [< `Struct | `Union]) structured typ -> unit
 (** [seal t] completes the struct or union type [t] so that no further fields
     can be added.  Struct and union types must be sealed before they can be used

--- a/src/type_printing.ml
+++ b/src/type_printing.ml
@@ -72,9 +72,13 @@ and format_fields : type a. a boxed_field list -> Format.formatter -> unit =
   fun fields fmt ->
   let open Format in
       List.iteri
-        (fun i (BoxedField {ftype=t}) ->
+        (fun i (BoxedField {ftype=t; fname}) ->
+          let name = match fname with
+            | None -> Printf.sprintf "field_%d" i
+            | Some name -> name 
+          in
           fprintf fmt "@[";
-          format_typ t (fun _ fmt -> fprintf fmt " field_%d" i) `nonarray fmt;
+          format_typ t (fun _ fmt -> fprintf fmt " %s" name) `nonarray fmt;
           fprintf fmt "@];@;")
         fields
   and format_parameter_list parameters k fmt =

--- a/src/value_printing.ml
+++ b/src/value_printing.ml
@@ -50,9 +50,15 @@ and format_fields : type a b. string -> (a, b) structured boxed_field list ->
     let last_field = List.length fields - 1 in
     let open Format in
     List.iteri
-      (fun i (BoxedField ({ftype; foffset} as f)) ->
-        fprintf fmt "@[%a@]%s@;" (format ftype) (getf s f)
-          (if i <> last_field then sep else ""))
+      (fun i (BoxedField ({ftype; foffset; fname} as f)) ->
+        let suffix = if i <> last_field then sep else "" in
+        match fname with
+        | None -> 
+          fprintf fmt "@[%a@]%s@;"
+            (format ftype) (getf s f) suffix
+        | Some name -> 
+          fprintf fmt "@[%s@] = @[%a@]%s@;"
+            name (format ftype) (getf s f) suffix)
       fields
 and format_ptr : type a. Format.formatter -> a ptr -> unit
   = fun fmt {raw_ptr; reftype; pbyte_offset} ->

--- a/tests/test_type_printing.ml
+++ b/tests/test_type_printing.ml
@@ -222,16 +222,16 @@ let test_struct_and_union_printing () =
 
     (* Structs and unions containing primitives *)
     let s_prims = structure "s_prims" in
-    let _ = s_prims *:* int in
-    let _ = s_prims *:* ulong in
-    let _ = s_prims *:* float in
+    let _ = field "i" (s_prims *:* int) in
+    let _ = field "l" (s_prims *:* ulong) in
+    let _ = field "z" (s_prims *:* float) in
     seal s_prims;
 
     assert_typ_printed_as ~name:"b"
                           "struct s_prims {
-                              int field_0;
-                              unsigned long field_1;
-                              float field_2;
+                              int i;
+                              unsigned long l;
+                              float z;
                            } b"
       s_prims;
 
@@ -277,14 +277,14 @@ let test_struct_and_union_printing () =
     (* Structs and unions containing arrays and pointers to functions *)
     let mixture = structure "mixture" in
     let _ = mixture *:* array 10 (array 12 (ptr mixture)) in
-    let _ = mixture *:* funptr (ptr mixture @-> returning void) in
+    let _ = field "fn" (mixture *:* funptr (ptr mixture @-> returning void)) in
     let _ = mixture *:* int in
     seal mixture;
       
     assert_typ_printed_as ~name:"d" 
                           "struct mixture {
                               struct mixture *field_0[10][12];
-                              void (*field_1)(struct mixture *);
+                              void (*fn)(struct mixture *);
                               int field_2;
                            } d"
       mixture;

--- a/tests/test_value_printing.ml
+++ b/tests/test_value_printing.ml
@@ -330,9 +330,9 @@ let test_pointer_printing () =
 *)
 let test_struct_printing () =
   let s = structure "s" in
-  let a = s *:* array 3 int in
-  let d = s *:* double in
-  let f = s *:* funptr (int @-> returning int) in
+  let a = field "arr" (s *:* array 3 int) in
+  let d = field "dbl" (s *:* double) in
+  let f = field "ptr" (s *:* funptr (int @-> returning int)) in
   let () = seal s in
 
   let t = structure "t" in
@@ -352,7 +352,8 @@ let test_struct_printing () =
     setf vt ti 14;
 
     assert_bool "struct printing"
-      (equal_ignoring_whitespace "{{ {4, 5, 6}, nan, <fun> }, 14}"
+      (equal_ignoring_whitespace
+         "{{ arr = {4, 5, 6}, dbl = nan, ptr = <fun> }, 14}"
          (string_of t vt))
   end
 


### PR DESCRIPTION
Support for giving names to struct and union fields

Used in type printing:

``` ocaml
# let point : point structure typ = structure "point";;
[...]
# let x = field "x" (point *:* float);;
[...]
# let y = field "y" (point *:* float);;
[...]
# seal point;;
[...]
# point;;
- : point Ctypes.structure Ctypes.typ =
struct point { float x; float y;  }
```

Used in value printing:

``` ocaml
# let p = make point in (setf p x 10.5; setf p y 12.0; p);;
- : point Ctypes.structure = { x = 10.5, y = 12  }
```

Should come in handy for stub generation.
