### PR TITLE
Compulsory field names.

### DIFF
--- a/examples/date/date.ml
+++ b/examples/date/date.ml
@@ -11,15 +11,16 @@ open Foreign
 
 type tm
 let tm = structure "tm"
-let tm_sec   = tm *:* int (* seconds *)
-let tm_min   = tm *:* int (* minutes *)
-let tm_hour  = tm *:* int (* hours *)
-let tm_mday  = tm *:* int (* day of the month *)
-let tm_mon   = tm *:* int (* month *)
-let tm_year  = tm *:* int (* year *)
-let tm_wday  = tm *:* int (* day of the week *)
-let tm_yday  = tm *:* int (* day in the year *)
-let tm_isdst = tm *:* int (* daylight saving time *)
+let (-:) ty label = field tm label ty
+let tm_sec   = int -: "tm_sec"   (* seconds *)
+let tm_min   = int -: "tm_min"   (* minutes *)
+let tm_hour  = int -: "tm_hour"  (* hours *)
+let tm_mday  = int -: "tm_mday"  (* day of the month *)
+let tm_mon   = int -: "tm_mon"   (* month *)
+let tm_year  = int -: "tm_year"  (* year *)
+let tm_wday  = int -: "tm_wday"  (* day of the week *)
+let tm_yday  = int -: "tm_yday"  (* day in the year *)
+let tm_isdst = int -: "tm_isdst" (* daylight saving time *)
 let () = seal (tm : tm structure typ)
 
 let time = foreign "time" (ptr time_t @-> returning_checking_errno time_t)

--- a/examples/fts/fts.ml
+++ b/examples/fts/fts.ml
@@ -78,26 +78,27 @@ struct
 
   type ftsent
   let ftsent : ftsent structure typ = structure "ftsent"
-  let fts_cycle   = ftsent *:* ptr ftsent
-  let fts_parent  = ftsent *:* ptr ftsent
-  let fts_link    = ftsent *:* ptr ftsent
-  let fts_number  = ftsent *:* int
-  let fts_pointer = ftsent *:* ptr void
-  let fts_accpath = ftsent *:* string
-  let fts_path    = ftsent *:* string
-  let fts_errno   = ftsent *:* int
-  let fts_symfd   = ftsent *:* int
-  let fts_pathlen = ftsent *:* ushort
-  let fts_namelen = ftsent *:* ushort
-  let fts_ino     = ftsent *:* ino_t
-  let fts_dev     = ftsent *:* dev_t
-  let fts_nlink   = ftsent *:* nlink_t
-  let fts_level   = ftsent *:* short
-  let fts_info    = ftsent *:* ushort
-  let fts_flags   = ftsent *:* ushort
-  let fts_instr   = ftsent *:* ushort
-  let fts_statp   = ftsent *:* ptr void (* really a struct stat * *)
-  let fts_name    = ftsent *:* char
+  let ( -: ) ty label = field ftsent label ty
+  let fts_cycle   = ptr ftsent -: "fts_cycle"
+  let fts_parent  = ptr ftsent -: "fts_parent"
+  let fts_link    = ptr ftsent -: "fts_link"
+  let fts_number  = int        -: "fts_number"
+  let fts_pointer = ptr void   -: "fts_pointer"
+  let fts_accpath = string     -: "fts_accpath"
+  let fts_path    = string     -: "fts_path"
+  let fts_errno   = int        -: "fts_errno"
+  let fts_symfd   = int        -: "fts_symfd"
+  let fts_pathlen = ushort     -: "fts_pathlen"
+  let fts_namelen = ushort     -: "fts_namelen"
+  let fts_ino     = ino_t      -: "fts_ino"
+  let fts_dev     = dev_t      -: "fts_dev"
+  let fts_nlink   = nlink_t    -: "fts_nlink"
+  let fts_level   = short      -: "fts_level"
+  let fts_info    = ushort     -: "fts_info"
+  let fts_flags   = ushort     -: "fts_flags"
+  let fts_instr   = ushort     -: "fts_instr"
+  let fts_statp   = ptr void   -: "fts_statp" (* really a struct stat * *)
+  let fts_name    = char       -: "fts_name"
   let () = seal ftsent
 
   type t = ftsent structure ptr
@@ -151,18 +152,19 @@ struct
 
   type fts
   let fts : fts structure typ = structure "fts"
-  let fts_cur     = fts *:* ptr ftsent
-  let fts_child   = fts *:* ptr ftsent
-  let fts_array   = fts *:* ptr (ptr ftsent)
-  let fts_dev     = fts *:* dev_t
-  let fts_path    = fts *:* string
-  let fts_rfd     = fts *:* int
-  let fts_pathlen = fts *:* int
-  let fts_nitems  = fts *:* int
-  let fts_compar  = fts *:* funptr
-    (ptr FTSENT.t @-> ptr FTSENT.t @-> returning int)
+  let ( -: ) ty label = field fts label ty
+  let fts_cur     = ptr ftsent       -: "fts_cur"
+  let fts_child   = ptr ftsent       -: "fts_child"
+  let fts_array   = ptr (ptr ftsent) -: "fts_array"
+  let fts_dev     = dev_t            -: "fts_dev"
+  let fts_path    = string           -: "fts_path"
+  let fts_rfd     = int              -: "fts_rfd"
+  let fts_pathlen = int              -: "fts_pathlen"
+  let fts_nitems  = int              -: "fts_nitems"
+  let fts_compar  = funptr  (ptr FTSENT.t @-> ptr FTSENT.t @-> returning int)
+                                     -: "fts_compar"
   (* fts_options would work well as a view *)
-  let fts_options = fts *:* int
+  let fts_options = int              -: "fts_options"
   let () = seal fts
 
   type t = fts structure ptr

--- a/src/common.ml
+++ b/src/common.ml
@@ -12,3 +12,8 @@ let string_of format v =
     Format.pp_print_flush fmt ();
     Buffer.contents buf
   end
+
+let warn fmt = Printf.(
+  fprintf stderr "Warning: ";
+  fprintf stderr fmt;
+  fprintf stderr "\n")

--- a/src/ctypes.mli
+++ b/src/ctypes.mli
@@ -269,29 +269,25 @@ val structure : string -> 's structure typ
     [let tagname : tagname structure typ = structure "tagname"]
 *)
 
-val ( *:* ) : 's structure typ -> 'a typ -> ('a, 's structure) field
-(** [s *:* t] adds a field of type [t] to the structure type [s] and returns
-    a field value that can be used to read and write the field in structure
-    instances (e.g. using [getf] and [setf]).
-
-    Attempting to add a field to a structure type that has been sealed with
-    [seal] is an error, and will raise [ModifyingSealedType]. *)
-
 val union : string -> 's union typ
 (** Construct a new union type.  This behaves analogously to {!structure};
     fields are added with {!(+:+)}. *)
 
-val ( +:+ ) : 's union typ -> 'a typ -> ('a, 's union) field
-(** [u +:+ t] adds a field of type [t] to the union type [u] and returns a
-    field value that can be used to read and write the field in union
-    instances (e.g. using [getf] and [setf]).
+val field : 't typ -> string -> 'a typ ->
+  ('a, (('s, [<`Struct | `Union]) structured as 't)) field
+(** [field ty label ty'] adds a field of type [ty'] with label [label] to the
+    structure or union type [ty] and returns a field value that can be used to
+    read and write the field in structure or union instances (e.g. using
+    {!getf} and {!setf}).
 
     Attempting to add a field to a union type that has been sealed with [seal]
-    is an error, and will raise [ModifyingSealedType]. *)
+    is an error, and will raise {!ModifyingSealedType}. *)
 
-val field : string -> ((_, _) field as 'f) -> 'f
-(** Set the name of a field.  Field names are used in various circumstances,
-    including type printing, value printing, and stub generation. *)
+val ( *:* ) : 't typ -> 'a typ -> ('a, (('s, [`Struct]) structured as 't)) field
+(** @deprecated Add an anonymous field to a structure.  Use {!field} instead. *)
+
+val ( +:+ ) : 't typ -> 'a typ -> ('a, (('s, [`Union]) structured as 't)) field
+(** @deprecated Add an anonymous field to a union.  Use {!field} instead. *)
 
 val seal : (_, [< `Struct | `Union]) structured typ -> unit
 (** [seal t] completes the struct or union type [t] so that no further fields

--- a/src/type_printing.ml
+++ b/src/type_printing.ml
@@ -73,12 +73,8 @@ and format_fields : type a. a boxed_field list -> Format.formatter -> unit =
   let open Format in
       List.iteri
         (fun i (BoxedField {ftype=t; fname}) ->
-          let name = match fname with
-            | None -> Printf.sprintf "field_%d" i
-            | Some name -> name 
-          in
           fprintf fmt "@[";
-          format_typ t (fun _ fmt -> fprintf fmt " %s" name) `nonarray fmt;
+          format_typ t (fun _ fmt -> fprintf fmt " %s" fname) `nonarray fmt;
           fprintf fmt "@];@;")
         fields
   and format_parameter_list parameters k fmt =

--- a/src/value_printing.ml
+++ b/src/value_printing.ml
@@ -51,14 +51,8 @@ and format_fields : type a b. string -> (a, b) structured boxed_field list ->
     let open Format in
     List.iteri
       (fun i (BoxedField ({ftype; foffset; fname} as f)) ->
-        let suffix = if i <> last_field then sep else "" in
-        match fname with
-        | None -> 
-          fprintf fmt "@[%a@]%s@;"
-            (format ftype) (getf s f) suffix
-        | Some name -> 
-          fprintf fmt "@[%s@] = @[%a@]%s@;"
-            name (format ftype) (getf s f) suffix)
+        fprintf fmt "@[%s@] = @[%a@]%s@;" fname (format ftype) (getf s f)
+          (if i <> last_field then sep else ""))
       fields
 and format_ptr : type a. Format.formatter -> a ptr -> unit
   = fun fmt {raw_ptr; reftype; pbyte_offset} ->

--- a/tests/test_alignment.ml
+++ b/tests/test_alignment.ml
@@ -73,8 +73,8 @@ let test_incomplete_alignment () =
 
   let module M = struct
     let t = structure "t"
-    let i = t *:* int
-      
+    let i = field t "i" int
+
     let () =
       assert_raises IncompleteType
         (fun () -> alignment t)
@@ -82,8 +82,8 @@ let test_incomplete_alignment () =
 
   let module M = struct
     let u = union "u"
-    let i = u +:+ int
-      
+    let i = field u "i" int
+
     let () =
       assert_raises IncompleteType
         (fun () -> alignment u)
@@ -102,9 +102,10 @@ let test_struct_alignment () =
     let maximum = List.fold_left max 0
 
     let struct_a = structure "A"
-    let _ = struct_a *:* char
-    let _ = struct_a *:* int
-    let _ = struct_a *:* double
+    let (-:) ty label = field struct_a label ty
+    let _ = char   -: "_"
+    let _ = int    -: "_"
+    let _ = double -: "_"
     let () = seal struct_a
 
     let () = assert_equal
@@ -117,10 +118,11 @@ let test_struct_alignment () =
     let charish = view ~read:(fun _ -> ()) ~write:(fun () -> 'c') char
 
     let struct_b = structure "A"
-    let _ = struct_b *:* charish
-    let _ = struct_b *:* funptr (int @-> returning int)
-    let _ = struct_b *:* abs
-    let _ = struct_b *:* double
+    let (-:) ty label = field struct_b label ty
+    let _ = charish                        -: "_"
+    let _ = funptr (int @-> returning int) -: "_"
+    let _ = abs                            -: "_"
+    let _ = double                         -: "_"
     let () = seal struct_b
 
     let () = assert_equal
@@ -155,18 +157,21 @@ let test_struct_tail_padding () =
     type a and b and u
 
     let struct_a = structure "A"
-    let a = struct_a *:* char
-    let b = struct_a *:* int
-    let c = struct_a *:* char
+    let (-:) ty label = field struct_a label ty
+    let a = char -: "a"
+    let b = int  -: "b"
+    let c = char -: "c"
     let () = seal (struct_a : a structure typ)
 
     let u = union "U"
-    let x = u +:+ char
+    let (-:) ty label = field u label ty
+    let x = char -: "x"
     let () = seal (u : u union typ)
 
     let struct_b = structure "B"
-    let d = struct_b *:* struct_a
-    let e = struct_b *:* u
+    let (-:) ty label = field struct_b label ty
+    let d = struct_a -: "d"
+    let e = u        -: "e"
     let () = seal (struct_b : b structure typ)
 
     let char_ptr p = from_voidp char (to_voidp p)

--- a/tests/test_array.ml
+++ b/tests/test_array.ml
@@ -139,8 +139,9 @@ let test_passing_pointer_to_array_of_structs () =
      }
   *)
   let u = union "u" in
-  let i = u +:+ int in
-  let d = u +:+ double in
+  let (-:) ty label = field u label ty in
+  let i = int    -: "i" in
+  let d = double -: "d" in
   let () = seal u in
 
   (* struct s {
@@ -149,8 +150,9 @@ let test_passing_pointer_to_array_of_structs () =
      }
   *)
   let s = structure "s" in
-  let tag = s *:* char in
-  let data = s *:* u in
+  let (-:) ty label = field s label ty in
+  let tag  = char -: "tag" in
+  let data = u    -: "data" in
   let () = seal s in
 
   let box_int x =

--- a/tests/test_cstdlib.ml
+++ b/tests/test_cstdlib.ml
@@ -144,8 +144,9 @@ let test_div () =
   let module M = struct
     type div_t
     let div_t : div_t structure typ = structure "div_t"
-    let quot = div_t *:* int
-    let rem = div_t *:* int
+    let (-:) ty label = field div_t label ty
+    let quot = int -: "quot"
+    let rem  = int -: "rem"
     let () = seal div_t
 
     let div = foreign "div" (int @-> int @-> returning div_t)
@@ -230,8 +231,9 @@ let test_bsearch () =
     *)
     type mi
     let mi = structure "mi"
-    let mr   = mi *:* int
-    let name = mi *:* ptr char
+    let (-:) ty label = field mi label ty
+    let mr   = int      -: "mr"
+    let name = ptr char -: "name"
     let () = seal (mi : mi structure typ)
 
   let of_string : string -> char array =

--- a/tests/test_custom_ops.ml
+++ b/tests/test_custom_ops.ml
@@ -44,17 +44,17 @@ let test_type_info_hashing_and_equality () =
     type s
     let s : s structure typ = structure "s"
     let _ = begin
-      ignore (s *:* double);
-      ignore (s *:* ptr s);
-      ignore (seal s)
+      ignore (field s "d" double);
+      ignore (field s "p" (ptr s));
+      seal s
     end
       
     type t
     let t : t structure typ = structure "s"
     let _ = begin
-      ignore (t *:* double);
-      ignore (t *:* ptr t);
-      ignore (seal t)
+      ignore (field t "d" double);
+      ignore (field t "p" (ptr t));
+      seal t
     end
       
     let () = begin

--- a/tests/test_finalisers.ml
+++ b/tests/test_finalisers.ml
@@ -47,8 +47,8 @@ let test_struct_finaliser () =
   let module M = struct
     type s
     let s : s structure typ = structure "s"
-    let i = s *:* int32_t
-    let c = s *:* char
+    let i = field s "i" int32_t
+    let c = field s "c" char
     let () = seal s
 
     let finaliser_completed = ref false

--- a/tests/test_foreign_values.ml
+++ b/tests/test_foreign_values.ml
@@ -17,8 +17,9 @@ let testlib = Dl.(dlopen ~filename:"clib/test_functions.so" ~flags:[RTLD_NOW])
 *)
 let test_retrieving_struct () =
   let s = structure "global_struct" in
-  let len = s *:* size_t in
-  let str = s *:* array 1 char in
+  let (-:) ty label = field s label ty in
+  let len = size_t       -: "len" in
+  let str = array 1 char -: "str" in
   let () = seal s in
   let global_struct = Foreign.foreign_value "global_struct" s ~from:testlib in
   let p = Array.start (getf !@global_struct str) in

--- a/tests/test_oo_style.ml
+++ b/tests/test_oo_style.ml
@@ -35,12 +35,13 @@ let test_oo_hierarchy () =
     and animal : animal structure typ = structure "animal" 
 
     (* class layout (vtable pointer, no instance variables) *)
-    let animal_vtable = animal *:* ptr animal_methods
+    let animal_vtable = field animal "animal_vtable" (ptr animal_methods)
     let () = seal animal
       
     (* method table layout (two virtual methods) *)
-    let say = animal_methods *:* funptr (ptr animal @-> returning string)
-    let identify = animal_methods *:* funptr (ptr animal @-> returning string)
+    let (-:) ty label = field animal_methods label ty
+    let say = funptr (ptr animal @-> returning string)      -: "say"
+    let identify = funptr (ptr animal @-> returning string) -: "identify"
     let () = seal animal_methods
 
     let call_say cinstance =
@@ -62,13 +63,15 @@ let test_oo_hierarchy () =
     and camel : camel structure typ = structure "camel"
 
     (* class layout (vtable pointer, one instance variable) *)
-    let camel_vtable = camel *:* ptr camel_methods
-    let nhumps = camel *:* int
+    let (-:) ty label = field camel label ty 
+    let camel_vtable = ptr camel_methods -: "camel_vtable"
+    let nhumps       = int               -: "nhumps"
     let () = seal camel
 
     (* method table layout (one additional virtual method) *) 
-    let _ = camel_methods *:* animal_methods
-    let humps = camel_methods *:* funptr (ptr camel @-> returning int)
+    let (-:) ty label = field camel_methods label ty 
+    let _     = animal_methods                       -: "_"
+    let humps = funptr (ptr camel @-> returning int) -: "humps"
     let () = seal camel_methods
 
     let call_humps cinstance =

--- a/tests/test_passable.ml
+++ b/tests/test_passable.ml
@@ -46,9 +46,10 @@ let test_unions_are_not_passable () =
     type u
 
     let u : u union typ = union "u"
-    let c = u +:+ int
-    let f = u +:+ double
-    let p = u +:+ ptr u
+    let (-:) ty label = field u label ty
+    let c = int    -: "c"
+    let f = double -: "f"
+    let p = ptr u  -: "p"
     let () = seal u
 
     let _ = begin
@@ -112,12 +113,12 @@ let test_pointers_are_passable () =
     type s1 and u
 
     let s1 : s1 structure typ = structure "s1"
-    let _ = s1 *:* int
-    let _ = s1 *:* ptr s1
+    let _ = field s1 "_" int
+    let _ = field s1 "_" (ptr s1)
     let () = seal s1
 
     let u : u union typ = union "u"
-    let _ = u +:+ int
+    let _ = field u "_" int
     let () = seal u
   end in
   let open M in
@@ -161,36 +162,43 @@ let test_struct_passability () =
     type s1 and s2 and s3 and s4 and s5 and s6 and u
 
     let s1 : s1 structure typ = structure "s1"
-    let _ = s1 *:* int
-    let _ = s1 *:* double
-    let _ = s1 *:* ptr s1
-    let _ = s1 *:* funptr (int @-> returning int)
+    let (-:) ty label = field s1 label ty
+    let _ = int -: "_"
+    let _ = double -: "_"
+    let _ = ptr s1 -: "_"
+    let _ = funptr (int @-> returning int) -: "_"
     let () = seal s1
 
     let s2 : s2 structure typ = structure "s2"
-    let _ = s2 *:* s1
-    let _ = s2 *:* double
-    let _ = s2 *:* ptr (array 10 int)
+    let (-:) ty label = field s2 label ty
+    let _ = s1 -: "_"
+    let _ = double -: "_"
+    let _ = ptr (array 10 int) -: "_"
     let () = seal s2
 
     let s3 : s3 structure typ = structure "s3"
-    let _ = s3 *:* array 10 (ptr char)
+    let (-:) ty label = field s3 label ty
+    let _ = array 10 (ptr char) -: "_"
     let () = seal s3
 
     let s4 : s4 structure typ = structure "s4"
-    let _ = s4 *:* s3
+    let (-:) ty label = field s4 label ty
+    let _ = s3 -: "_"
     let () = seal s4
 
     let u : u union typ = union "u"
-    let _ = u +:+ int
+    let (-:) ty label = field u label ty
+    let _ = int -: "_"
     let () = seal u
 
     let s5 : s5 structure typ = structure "s5"
-    let _ = s5 *:* u
+    let (-:) ty label = field s5 label ty
+    let _ = u -: "_"
     let () = seal s5
 
     let s6 : s6 structure typ = structure "s6"
-    let _ = s6 *:* abstract ~name:"abstract" ~size:1 ~alignment:1
+    let (-:) ty label = field s6 label ty
+    let _ = abstract ~name:"abstract" ~size:1 ~alignment:1 -: "_"
     let () = seal s6
 
     let _ = begin

--- a/tests/test_pointers.ml
+++ b/tests/test_pointers.ml
@@ -399,8 +399,8 @@ let test_pointer_arithmetic () =
   done;
 
   let twoints = structure "s" in
-  let i1 = twoints *:* int in
-  let i2 = twoints *:* int in
+  let i1 = field twoints "i" int in
+  let i2 = field twoints "j" int in
   let () = seal twoints in
   
   (* Traverse the array using a 'struct twoints' pointer *)
@@ -462,9 +462,9 @@ let test_pointer_comparison () =
     (canonicalize p > canonicalize (p -@ 1));
 
   let s3 = structure "s3" in
-  let i = s3 *:* int in
-  let j = s3 *:* int in
-  let k = s3 *:* int in
+  let i = field s3 "i" int in
+  let j = field s3 "j" int in
+  let k = field s3 "k" int in
   let () = seal s3 in
 
   let sp = addr (make s3) in
@@ -526,10 +526,11 @@ let test_pointer_differences () =
   in
 
   let s = structure "s" in
-  let i = s *:* int in
-  let j = s *:* array 17 char in
-  let k = s *:* double in
-  let l = s *:* char in
+  let (-:) ty label = field s label ty in
+  let i = int           -: "i" in
+  let j = array 17 char -: "j" in
+  let k = double        -: "k" in
+  let l = char          -: "l" in
   let () = seal s in
 
   let v = make s in

--- a/tests/test_sizeof.ml
+++ b/tests/test_sizeof.ml
@@ -75,15 +75,15 @@ end
 *)
 let test_sizeof_unions () =
   let int_char = union "int_char" in
-  let _ = int_char +:+ int in
-  let _ = int_char +:+ char in
+  let _ = field int_char "_" int in
+  let _ = field int_char "_" char in
   let _ = seal int_char in
   
   assert_equal (sizeof int) (sizeof int_char);
 
 
   let char17 = union "char17" in
-  let _ = char17 +:+ array 17 char in
+  let _ = field char17 "_" (array 17 char) in
   let _ = seal char17 in
   
   assert_equal 17 (sizeof char17)
@@ -101,7 +101,7 @@ let test_sizeof_structs () =
       for i = 1 to 10 do
         let homogeneous : h structure typ = structure "h" in
         for j = 1 to i do
-          ignore (homogeneous *:* int);
+          ignore (field homogeneous "_" int);
         done;
         seal homogeneous;
         assert_equal (i * sizeof int) (sizeof homogeneous)
@@ -164,8 +164,8 @@ let test_sizeof_pointers () = begin
   let module M = struct
     type t
     let t : t structure typ = structure "t"
-    let c = t *:* int
-    let f = t *:* double
+    let c = field t "c" int
+    let f = field t "f" double
     let () = seal t
   end in
   assert_equal pointer_size (sizeof (ptr M.t))

--- a/tests/test_structs.ml
+++ b/tests/test_structs.ml
@@ -29,9 +29,10 @@ let test_passing_struct () =
   let module M = struct
     type simple
     let simple : simple structure typ = structure "simple"
-    let c = simple *:* int
-    let f = simple *:* double
-    let p = simple *:* ptr simple
+    let (-:) ty label = field simple label ty
+    let c = int        -: "c"
+    let f = double     -: "f"
+    let p = ptr simple -: "p"
     let () = seal simple
       
     let accept_struct = Foreign.foreign "accept_struct" ~from:testlib
@@ -71,9 +72,10 @@ let test_returning_struct () =
     type simple
 
     let simple : simple structure typ = structure "simple"
-    let c = simple *:* int
-    let f = simple *:* double
-    let p = simple *:* ptr simple
+    let (-:) ty label = field simple label ty
+    let c = int        -: "c"
+    let f = double     -: "f"
+    let p = ptr simple -: "p"
     let () = seal simple
 
     let return_struct = Foreign.foreign "return_struct" ~from:testlib
@@ -103,13 +105,13 @@ let test_incomplete_struct_members () =
   let s = structure "s" in begin
 
     assert_raises IncompleteType
-      (fun () -> s *:* void);
+      (fun () -> field s "_" void);
 
     assert_raises IncompleteType
-      (fun () -> s *:* structure "incomplete");
+      (fun () -> field s "_" (structure "incomplete"));
 
     assert_raises IncompleteType
-      (fun () -> s *:* union "incomplete");
+      (fun () -> field s "_" (union "incomplete"));
   end
 
 
@@ -121,9 +123,10 @@ let test_pointers_to_struct_members () =
     type s
 
     let styp : s structure typ = structure "s"
-    let i = styp *:* int
-    let j = styp *:* int
-    let k = styp *:* ptr int
+    let (-:) ty label = field styp label ty
+    let i = int     -: "i"
+    let j = int     -: "j"
+    let k = ptr int -: "k"
     let () = seal styp
 
     let s = make styp
@@ -167,9 +170,10 @@ let test_structs_with_union_members () =
         abs_float (lre -. rre) < eps && abs_float (lim -. rim) < eps
 
     let utyp : u union typ = union "u"
-    let uc = utyp +:+ char
-    let ui = utyp +:+ int
-    let uz = utyp +:+ complex64
+    let (-:) ty label = field utyp label ty
+    let uc = char      -: "uc"
+    let ui = int       -: "ui"
+    let uz = complex64 -: "uz"
     let () = seal utyp
 
     let u = make utyp
@@ -189,9 +193,10 @@ let test_structs_with_union_members () =
     end
 
     let styp : s structure typ = structure "s"
-    let si = styp *:* int
-    let su = styp *:* utyp
-    let sc = styp *:* char
+    let (-:) ty label = field styp label ty
+    let si = int  -: "si"
+    let su = utyp -: "su"
+    let sc = char -: "sc"
     let () = seal styp
 
     let s = make styp
@@ -221,9 +226,10 @@ let test_structs_with_array_members () =
     type u and s
 
     let styp : s structure typ = structure "s"
-    let i = styp *:* int
-    let a = styp *:* array 3 double
-    let c = styp *:* char
+    let (-:) ty label = field styp label ty
+    let i = int            -: "i"
+    let a = array 3 double -: "a"
+    let c = char           -: "c"
     let () = seal styp
 
     let s = make styp
@@ -280,11 +286,11 @@ let test_structs_with_array_members () =
 *)
 let test_updating_sealed_struct () =
   let styp = structure "sealed" in
-  let _ = styp *:* int in
+  let _ = field styp "_" int in
   let () = seal styp in
 
   assert_raises (ModifyingSealedType "sealed")
-    (fun () -> styp *:* char)
+    (fun () -> field styp "_" char)
 
 
 (*
@@ -315,9 +321,9 @@ let test_field_references_not_invalidated () =
     let s1 : s1 structure typ = structure "s1"
     let () = (fun () ->
       let s2 : s2 structure typ = structure "s2" in
-      let _ = s2 *:* int in
+      let _ = field s2 "i" int in
       let () = seal s2 in
-      let _ = s1 *:* s2 in
+      let _ = field s1 "_" s2 in
       ()
     ) ()
     let () = begin
@@ -355,10 +361,11 @@ let test_folding_over_struct_fields () =
 
     type s
     let s : s structure typ = structure "s"
-    let a = s *:* int
-    let b = s *:* array 3 float
-    let c = s *:* ptr void
-    let d = s *:* ptr (ptr s)
+    let (-:) ty label = field s label ty
+    let a = int           -: "a"
+    let b = array 3 float -: "b"
+    let c = ptr void      -: "c"
+    let d = ptr (ptr s)   -: "d"
     let () = seal s
       
     let expected = List.fold_right FieldSet.add

--- a/tests/test_unions.ml
+++ b/tests/test_unions.ml
@@ -26,8 +26,9 @@ let test_inspecting_float () =
   let module M = struct
     type u
     let utyp : u union typ = union "u"
-    let f = utyp +:+ double
-    let i = utyp +:+ int64_t
+    let (-:) ty label = field utyp label ty
+    let f = double  -: "f"
+    let i = int64_t -: "i"
     let () = seal utyp
 
     let pi = 3.14
@@ -59,8 +60,9 @@ let test_endian_detection () =
   let module M = struct
     type e
     let etyp : e union typ = union "e"
-    let i = etyp +:+ int64_t
-    let c = etyp +:+ array (sizeof int64_t) uchar
+    let (-:) ty label = field etyp label ty
+    let i = int64_t                      -: "i"
+    let c = array (sizeof int64_t) uchar -: "c"
     let () = seal etyp
 
     let updated_char_index =
@@ -92,8 +94,9 @@ let test_union_padding () =
   let module M = struct
     type padded
     let padded : padded union typ = union "padded"
-    let i = padded +:+ int64_t
-    let a = padded +:+ array (sizeof int64_t + 1) char
+    let (-:) ty label = field padded label ty
+    let i = int64_t                         -: "i"
+    let a = array (sizeof int64_t + 1) char -: "a"
     let () = seal padded
 
     let sum_union_components = Foreign.foreign "sum_union_components"
@@ -132,9 +135,10 @@ let test_union_address () =
   let module M = struct
     type u
     let u : u union typ = union "u"
-    let i = u +:+ int64_t
-    let c = u +:+ char
-    let s = u +:+ ptr (structure "incomplete")
+    let (-:) ty label = field u label ty
+    let i = int64_t                      -: "i"
+    let c = char                         -: "c"
+    let s = ptr (structure "incomplete") -: "s"
     let () = seal u
 
     let up = addr (make u)
@@ -158,11 +162,11 @@ let test_union_address () =
 *)
 let test_updating_sealed_union () =
   let utyp = union "sealed" in
-  let _ = utyp +:+ int in
+  let _ = field utyp "_" int in
   let () = seal utyp in
 
   assert_raises (ModifyingSealedType "sealed")
-    (fun () -> utyp +:+ char)
+    (fun () -> field utyp "_" char)
 
 
 (*
@@ -199,10 +203,11 @@ let test_folding_over_union_fields () =
 
     type u
     let u : u union typ = union "u"
-    let a = u +:+ int
-    let b = u +:+ array 3 float
-    let c = u +:+ ptr void
-    let d = u +:+ ptr (ptr u)
+    let (-:) ty label = field u label ty
+    let a = int           -: "a"
+    let b = array 3 float -: "b"
+    let c = ptr void      -: "c"
+    let d = ptr (ptr u)   -: "d"
     let () = seal u
       
     let expected = List.fold_right FieldSet.add

--- a/tests/test_value_printing.ml
+++ b/tests/test_value_printing.ml
@@ -330,14 +330,16 @@ let test_pointer_printing () =
 *)
 let test_struct_printing () =
   let s = structure "s" in
-  let a = field "arr" (s *:* array 3 int) in
-  let d = field "dbl" (s *:* double) in
-  let f = field "ptr" (s *:* funptr (int @-> returning int)) in
+  let (-:) ty label = field s label ty in
+  let a = array 3 int                    -: "arr" in
+  let d = double                         -: "dbl" in
+  let f = funptr (int @-> returning int) -: "ptr" in
   let () = seal s in
 
   let t = structure "t" in
-  let ts = t *:* s in
-  let ti = t *:* int in
+  let (-:) ty label = field t label ty in
+  let ts = s   -: "ts" in
+  let ti = int -: "ti" in
   let () = seal t in
 
   let vt = make t in
@@ -353,7 +355,7 @@ let test_struct_printing () =
 
     assert_bool "struct printing"
       (equal_ignoring_whitespace
-         "{{ arr = {4, 5, 6}, dbl = nan, ptr = <fun> }, 14}"
+         "{ts = { arr = {4, 5, 6}, dbl = nan, ptr = <fun> }, ti = 14}"
          (string_of t vt))
   end
 
@@ -363,18 +365,20 @@ let test_struct_printing () =
 *)
 let test_union_printing () =
   let s = structure "s" in
-  let i = s *:* uint16_t in
-  let j = s *:* uint16_t in
+  let (-:) ty label = field s label ty in
+  let i = uint16_t -: "i" in
+  let j = uint16_t -: "j" in
   let () = seal s in
   let u = union "u" in
-  let us = u +:+ s in
-  let ua = u +:+ array 4 uint8_t in
+  let (-:) ty label = field u label ty in
+  let us = s               -: "us" in
+  let ua = array 4 uint8_t -: "ua" in
   let () = seal u in
   let v = make u in
   ignore (i, j, us);
   setf v ua (Array.make ~initial:(Unsigned.UInt8.of_int 0) uint8_t 4);
   assert_bool "union printing"
-    (equal_ignoring_whitespace "{{0, 0} | {0, 0, 0, 0}}" (string_of u v))
+    (equal_ignoring_whitespace "{ us = {i = 0, j = 0} | ua = {0, 0, 0, 0}}" (string_of u v))
 
 
 (*


### PR DESCRIPTION
Make struct and union field names compulsory, to make stub generation a possibility, and improve formatting in the top level.  The syntax is slightly heavier, since the field addition operator is now ternary (taking the struct or union, the label and the field type).  You might write:

``` ocaml
let tm = structure "tm"
let (-:) ty = field tm ty
let tm_sec   = int -: "tm_sec"
let tm_min   = int -: "tm_min"
let tm_hour  = int -: "tm_hour"
...
let () = seal tm
```

or perhaps

``` ocaml
let tm = structure "tm"
let tm_sec   = field tm int "tm_sec"
let tm_min   = field tm int "tm_min"
let tm_hour  = field tm int "tm_hour"
...
let () = seal tm
```

instead of what we had previously:

``` ocaml
let tm = structure "tm"
let tm_sec   = tm *:* int
let tm_min   = tm *:* int
let tm_hour  = tm *:* int
...
let () = seal tm
```

`(*:*)` and `(+:+)` are still supported for the moment, but deprecated.
