### PR TITLE
Foreign.foreign, give the choice of not failing if symbol is absent.

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -284,6 +284,15 @@ Executable test_ctypes_callback_lifetime
   BuildDepends:     unix,ctypes,ctypes.foreign,oUnit
   Custom:           true
 
+Executable test_stubs
+  Path:             tests
+  MainIs:           test_stubs.ml
+  Build$:           flag(tests)
+  CompiledObject:   best
+  Install:          false
+  BuildDepends:     unix,ctypes,ctypes.foreign,oUnit
+  Custom:           true
+
 Executable date_example
   Path:             examples/date
   MainIs:           date.ml
@@ -333,6 +342,11 @@ Test test_ctypes_cstdlib
 Test test_ctypes_sizeof
   Run$:             flag(tests)
   Command:          $test_ctypes_sizeof
+  WorkingDirectory: tests
+
+Test test_stubs
+  Run$:             flag(tests)
+  Command:          $test_stubs
   WorkingDirectory: tests
 
 Test test_ctypes_arrays

--- a/src/foreign.ml
+++ b/src/foreign.ml
@@ -44,7 +44,10 @@ let ptr_of_raw_ptr p =
 let foreign_value ?from symbol t =
   from_voidp t (ptr_of_raw_ptr (dlsym ?handle:from ~symbol))
 
-let foreign ?from symbol typ = let open Ctypes in
-  let p = ptr_of_raw_ptr (dlsym ?handle:from ~symbol) in
-  let pp = to_voidp (allocate (ptr void) p) in
-  !@ (from_voidp (funptr ~name:symbol typ) pp)
+let foreign ?(stub = false) ?from symbol typ = let open Ctypes in
+  try
+    let p = ptr_of_raw_ptr (dlsym ?handle:from ~symbol) in
+    let pp = to_voidp (allocate (ptr void) p) in
+    !@ (from_voidp (funptr ~name:symbol typ) pp)
+  with 
+  | exn -> if stub then fun _ -> raise exn else raise exn

--- a/src/foreign.mli
+++ b/src/foreign.mli
@@ -7,10 +7,17 @@
 
 (** High-level bindings for C functions and values *)
 
-val foreign : ?from:Dl.library -> string -> ('a -> 'b) Ctypes.fn -> ('a -> 'b)
+val foreign : ?stub:bool -> ?from:Dl.library -> string -> 
+  ('a -> 'b) Ctypes.fn -> ('a -> 'b)
 (** [foreign name typ] exposes the C function of type [typ] named by [name] as
     an OCaml value.  The argument [?from], if supplied, is a library handle
-    returned by {!Dl.dlopen}.  *)
+    returned by {!Dl.dlopen}.  The argument [?stub], if [true] (defaults to 
+    [false]), indicates that the function should not raise an exception 
+    if [name] is not found but return an OCaml value that raises an 
+    exception when called. 
+
+    @raise Dl.DL_error if [name] is not found in [?from] and [?stub] is 
+    [false]. *)
 
 val foreign_value : ?from:Dl.library -> string -> 'a Ctypes.typ -> 'a Ctypes.ptr
 (** [foreign_value name typ] exposes the C value of type [typ] named by [name]

--- a/tests/test_stubs.ml
+++ b/tests/test_stubs.ml
@@ -1,0 +1,30 @@
+(*
+ * Copyright (c) 2013 Jeremy Yallop.
+ *
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+open OUnit
+open Ctypes
+open Foreign
+
+let missing = "_60d2dd04_1b66_4b79_a2ea_8375157da563"
+
+let test_missing () = 
+  let miss = foreign missing ~stub:true (int @-> int @-> (returning int)) in
+  begin try ignore (miss 2 3); assert_failure "should raise" with exn -> () end;
+  try
+    let _ = foreign missing ~stub:false (int @-> int @-> (returning int)) in
+    assert_failure "should raise"
+  with exn -> ()
+
+  
+let suite = 
+  "Foreign value stubs" >::: 
+  [
+    "missing symbols"
+    >:: test_missing;
+  ]
+
+let _ = run_test_tt_main suite


### PR DESCRIPTION
Fixes issue #60

P.S. I don't know how you manage to develop with `oasis` in the loop, it's so painfully slow...
