### PR TITLE
added feature test macro _XOPEN_SOURCE 500 to enable blksize.

### DIFF
--- a/src/ctypes/posix_types_stubs.c
+++ b/src/ctypes/posix_types_stubs.c
@@ -4,7 +4,7 @@
  * This file is distributed under the terms of the MIT License.
  * See the file LICENSE for details.
  */
-
+#define _XOPEN_SOURCE 500
 #include <caml/mlvalues.h>
 
 #include <assert.h>


### PR DESCRIPTION
I'm not sure that it is a correct and portable way, but it works.
