### PR TITLE
Fix typo in Makefile for install_native_objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ ctypes-foreign-unthreaded.subproject_deps = ctypes ctypes-foreign-base
 ctypes-foreign-unthreaded.link_flags = $(libffi_lib)
 ctypes-foreign-unthreaded.cmo_opts = $(OCAML_FFI_INCOPTS:%=-ccopt %)
 ctypes-foreign-unthreaded.cmx_opts = $(OCAML_FFI_INCOPTS:%=-ccopt %)
-ctypes-foreign-threaded.install_native_objects = no
+ctypes-foreign-unthreaded.install_native_objects = no
 
 ctypes-foreign-unthreaded: PROJECT=ctypes-foreign-unthreaded
 ctypes-foreign-unthreaded: $$(LIB_TARGETS)


### PR DESCRIPTION
I was editing the makefiles while trying to pack Ctypes modules to resolve #100, when I noticed what looked like a typo. This typo is innocuous because it fails to set `ctypes-foreign-unthreaded.install_native_objects` to 'no', while the test later on checks whether it was set to 'yes', so we end up with the desired behaviour anyway.
