### PR TITLE
Rename the Array module to 'CArray' and the array type to 'carray'.

### DIFF
--- a/examples/fts/fts.ml
+++ b/examples/fts/fts.ml
@@ -180,7 +180,7 @@ struct
 
   let array : t -> FTSENT.t list
     = fun { ptr } ->
-      Array.(to_list (from_ptr (getf !@ptr fts_array) (getf !@ptr fts_nitems)))
+      CArray.(to_list (from_ptr (getf !@ptr fts_array) (getf !@ptr fts_nitems)))
 
   let dev : t -> dev_t
     = fun { ptr } -> getf !@ptr fts_dev
@@ -236,12 +236,12 @@ let fts_children ~ftsp ~name_only =
 
 let null_terminated_array_of_ptr_list typ list =
   let nitems = List.length list in
-  let arr = Array.make typ (1 + nitems) in
-  List.iteri (Array.set arr) list;
-  (castp (ptr void) (Array.start arr +@ nitems)) <-@ null;
+  let arr = CArray.make typ (1 + nitems) in
+  List.iteri (CArray.set arr) list;
+  (castp (ptr void) (CArray.start arr +@ nitems)) <-@ null;
   arr
 
 let fts_open ~path_argv ?compar ~options = 
   let paths = null_terminated_array_of_ptr_list string path_argv in
   let options = crush_options fts_open_option_value options in
-  { ptr = _fts_open (Array.start paths) options compar; compar }
+  { ptr = _fts_open (CArray.start paths) options compar; compar }

--- a/src/ctypes-top/ctypes_printers.ml
+++ b/src/ctypes-top/ctypes_printers.ml
@@ -40,7 +40,7 @@ let format_struct fmt v =
 let format_union fmt v =
   Ctypes.(format (reference_type (addr v)) fmt v)
 let format_array fmt v =
-  Ctypes.(format Array.(array (length v) (reference_type (start v))) fmt v)
+  Ctypes.(format CArray.(array (length v) (reference_type (start v))) fmt v)
 let format_blkcnt_t fmt v =
   Ctypes.format PosixTypes.blkcnt_t fmt v
 let format_blksize_t fmt v =

--- a/src/ctypes-top/ctypes_printers.mli
+++ b/src/ctypes-top/ctypes_printers.mli
@@ -23,7 +23,7 @@ val format_ullong : formatter -> Unsigned.ULLong.t -> unit
 val format_pointer : formatter -> 'a Ctypes.ptr -> unit
 val format_struct : formatter -> ('a, 'b) Ctypes.structured -> unit
 val format_union : formatter -> ('a, 'b) Ctypes.structured -> unit
-val format_array : formatter -> 'a Ctypes.Array.t -> unit
+val format_array : formatter -> 'a Ctypes.CArray.t -> unit
 val format_blkcnt_t : formatter -> PosixTypes.blkcnt_t -> unit
 val format_blksize_t : formatter -> PosixTypes.blksize_t -> unit
 val format_clock_t : formatter -> PosixTypes.clock_t -> unit

--- a/src/ctypes/ctypes.mli
+++ b/src/ctypes/ctypes.mli
@@ -185,15 +185,11 @@ val string_opt : string option typ
 
 (** {4 C array types} *) 
 
-(**/**)
-type 'a std_array = 'a array
-(**/**)
-
-type 'a array
-(** The type of C array values.  A value of type [t array] can be used to read
+type 'a carray
+(** The type of C array values.  A value of type [t carray] can be used to read
     and write array objects in C-managed storage. *)
 
-val array : int -> 'a typ -> 'a array typ
+val array : int -> 'a typ -> 'a carray typ
 (** Construct a sized array type from a length and an existing type (called
     the {i element type}). *)
 
@@ -207,15 +203,15 @@ val genarray :
   < element: 'a;
     ba_repr: 'b;
     bigarray: ('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t;
-    carray: 'a array;
-    dims: int std_array > bigarray_class
+    carray: 'a carray;
+    dims: int array > bigarray_class
 (** The class of {!Bigarray.Genarray.t} values *)
 
 val array1 :
   < element: 'a;
     ba_repr: 'b;
     bigarray: ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t;
-    carray: 'a array;
+    carray: 'a carray;
     dims: int > bigarray_class
 (** The class of {!Bigarray.Array1.t} values *)
 
@@ -223,7 +219,7 @@ val array2 :
   < element: 'a;
     ba_repr: 'b;
     bigarray: ('a, 'b, Bigarray.c_layout) Bigarray.Array2.t;
-    carray: 'a array array;
+    carray: 'a carray carray;
     dims: int * int > bigarray_class
 (** The class of {!Bigarray.Array2.t} values *)
 
@@ -231,7 +227,7 @@ val array3 :
   < element: 'a;
     ba_repr: 'b;
     bigarray: ('a, 'b, Bigarray.c_layout) Bigarray.Array3.t;
-    carray: 'a array array array;
+    carray: 'a carray carray carray;
     dims: int * int * int > bigarray_class
 (** The class of {!Bigarray.Array3.t} values *)
 
@@ -470,35 +466,37 @@ val raw_address_of_ptr : unit ptr -> int64
 
 (** {4 C array values} *)
 
-module Array :
+module CArray :
 sig
-  type 'a t = 'a array
+  type 'a t = 'a carray
 
   val get : 'a t -> int -> 'a
   (** [get a n] returns the [n]th element of the zero-indexed array [a].  The
       semantics for non-scalar types are non-copying, as for {!(!@)}.
 
-      You can also write [a.(n)] instead of [Array.get a n].
+      If you rebind the [CArray] module to [Array] then you can also use the
+      syntax [a.(n)] instead of [Array.get a n].
 
       Raise [Invalid_argument "index out of bounds"] if [n] is outside of the
-      range [0] to [(Array.length a - 1)]. *)
+      range [0] to [(CArray.length a - 1)]. *)
 
   val set : 'a t -> int -> 'a -> unit
   (** [set a n v] overwrites the [n]th element of the zero-indexed array [a]
       with [v].
 
-      You can also write [a.(n) <- v] instead of [Array.set a n v].
+      If you rebind the [CArray] module to [Array] then you can also use the
+      [a.(n) <- v] syntax instead of [Array.set a n v].
 
       Raise [Invalid_argument "index out of bounds"] if [n] is outside of the
-      range [0] to [(Array.length a - 1)]. *)
+      range [0] to [(CArray.length a - 1)]. *)
 
   val unsafe_get : 'a t -> int -> 'a
   (** [unsafe_get a n] behaves like [get a n] except that the check that [n]
-      between [0] and [(Array.length a - 1)] is not performed. *)
+      between [0] and [(CArray.length a - 1)] is not performed. *)
 
   val unsafe_set : 'a t -> int -> 'a -> unit
   (** [unsafe_set a n v] behaves like [set a n v] except that the check that
-      [n] between [0] and [(Array.length a - 1)] is not performed. *)
+      [n] between [0] and [(CArray.length a - 1)] is not performed. *)
 
   val of_list : 'a typ -> 'a list -> 'a t
   (** [of_list t l] builds an array of type [t] of the same length as [l], and
@@ -525,7 +523,7 @@ sig
       used to initialise every element of the array.  The argument [?finalise],
       if present, will be called just before the memory is freed. *)
 
-  val element_type : 'a array -> 'a typ
+  val element_type : 'a t -> 'a typ
 (** Retrieve the element type of an array. *)
 end
 (** Operations on C arrays. *)
@@ -557,9 +555,9 @@ val array_of_bigarray : < element: _;
 val bigarray_of_array : < element: 'a;
                           ba_repr: 'f;
                           bigarray: 'b;
-                          carray: 'c array;
+                          carray: 'c carray;
                           dims: 'i > bigarray_class ->
-    ('a, 'f) Bigarray.kind -> 'c array -> 'b
+    ('a, 'f) Bigarray.kind -> 'c carray -> 'b
 (** Convert a C array to a Bigarray value. *)
 
 

--- a/src/ctypes/memory.ml
+++ b/src/ctypes/memory.ml
@@ -152,10 +152,9 @@ let ptr_of_raw_address addr =
 
 let raw_address_of_ptr { raw_ptr } = Raw.PtrType.to_int64 raw_ptr
 
-module Std_array = Array
-module Array =
+module CArray =
 struct
-  type 'a t = 'a array
+  type 'a t = 'a carray
 
   let check_bound { alength } i =
     if i >= alength then
@@ -266,16 +265,16 @@ let array_of_bigarray : type a b c d e.
     match spec with
   | Genarray ->
     let ds = Genarray.dims ba in
-    Array.from_ptr element_ptr (Std_array.fold_left ( * ) 1 ds)
+    CArray.from_ptr element_ptr (Array.fold_left ( * ) 1 ds)
   | Array1 ->
     let d = Array1.dim ba in
-    Array.from_ptr element_ptr d
+    CArray.from_ptr element_ptr d
   | Array2 ->
     let d1 = Array2.dim1 ba and d2 = Array2.dim2 ba in
-    Array.from_ptr (castp (array d2 reftype) element_ptr) d1
+    CArray.from_ptr (castp (array d2 reftype) element_ptr) d1
   | Array3 ->
     let d1 = Array3.dim1 ba and d2 = Array3.dim2 ba and d3 = Array3.dim3 ba in
-    Array.from_ptr (castp (array d2 (array d3 reftype)) element_ptr) d1
+    CArray.from_ptr (castp (array d2 (array d3 reftype)) element_ptr) d1
 
 let bigarray_elements : type a b c d f.
    < element: a;
@@ -284,7 +283,7 @@ let bigarray_elements : type a b c d f.
      carray: c;
      dims: d > bigarray_class -> d -> int
   = fun spec dims -> match spec, dims with
-   | Genarray, ds -> Std_array.fold_left ( * ) 1 ds
+   | Genarray, ds -> Array.fold_left ( * ) 1 ds
    | Array1, d -> d
    | Array2, (d1, d2) -> d1 * d2
    | Array3, (d1, d2, d3) -> d1 * d2 * d3
@@ -296,8 +295,8 @@ let array_dims : type a b c d f.
    < element: a;
      ba_repr: f;
      bigarray: b;
-     carray: c array;
-     dims: d > bigarray_class -> c array -> d =
+     carray: c carray;
+     dims: d > bigarray_class -> c carray -> d =
    fun spec a -> match spec with
    | Genarray -> [| a.alength |]
    | Array1 -> a.alength
@@ -314,7 +313,7 @@ let array_dims : type a b c d f.
 
 let bigarray_of_array spec kind a =
   let dims = array_dims spec a in
-  !@ (castp (bigarray spec dims kind) (Array.start a))
+  !@ (castp (bigarray spec dims kind) (CArray.start a))
 
 let genarray = Genarray
 let array1 = Array1

--- a/src/ctypes/static.ml
+++ b/src/ctypes/static.ml
@@ -25,8 +25,6 @@ type abstract_type = {
   aalignment : int;
 }
 
-type 'a std_array = 'a array
-
 type _ typ =
     Void            :                       unit typ
   | Primitive       : 'a Primitives.prim -> 'a typ 
@@ -35,14 +33,14 @@ type _ typ =
   | Union           : 'a union_type      -> 'a union typ
   | Abstract        : abstract_type      -> 'a abstract typ
   | View            : ('a, 'b) view      -> 'a typ
-  | Array           : 'a typ * int       -> 'a array typ
+  | Array           : 'a typ * int       -> 'a carray typ
   | Bigarray        : (_, 'a) Ctypes_bigarray.t
                                          -> 'a typ
 and 'a ptr = { reftype      : 'a typ;
                raw_ptr      : Ctypes_raw.voidp;
                pmanaged     : Obj.t option;
                pbyte_offset : int }
-and 'a array = { astart : 'a ptr; alength : int }
+and 'a carray = { astart : 'a ptr; alength : int }
 and ('a, 'kind) structured = { structured : ('a, 'kind) structured ptr }
 and 'a union = ('a, [`Union]) structured
 and 'a structure = ('a, [`Struct]) structured
@@ -75,28 +73,28 @@ and 's boxed_field = BoxedField : ('a, 's) field -> 's boxed_field
 type _ bigarray_class =
   Genarray :
   < element: 'a;
-    dims: int std_array;
+    dims: int array;
     ba_repr: 'b;
     bigarray: ('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t;
-    carray: 'a array > bigarray_class
+    carray: 'a carray > bigarray_class
 | Array1 :
   < element: 'a;
     dims: int;
     ba_repr: 'b;
     bigarray: ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t;
-    carray: 'a array > bigarray_class
+    carray: 'a carray > bigarray_class
 | Array2 :
   < element: 'a;
     dims: int * int;
     ba_repr: 'b;
     bigarray: ('a, 'b, Bigarray.c_layout) Bigarray.Array2.t;
-    carray: 'a array array > bigarray_class
+    carray: 'a carray carray > bigarray_class
 | Array3 :
   < element: 'a;
     dims: int * int * int;
     ba_repr: 'b;
     bigarray: ('a, 'b, Bigarray.c_layout) Bigarray.Array3.t;
-    carray: 'a array array array > bigarray_class
+    carray: 'a carray carray carray > bigarray_class
 
 type _ fn =
   | Returns  : 'a typ   -> 'a fn

--- a/src/ctypes/value_printing.ml
+++ b/src/ctypes/value_printing.ml
@@ -36,12 +36,12 @@ and format_structured : type a b. Format.formatter -> (a, b) structured -> unit
     | Abstract abs ->
       pp_print_string fmt "<abstract>"
     | _ -> raise (Unsupported "unknown structured type")
-and format_array : type a. Format.formatter -> a array -> unit
+and format_array : type a. Format.formatter -> a carray -> unit
   = fun fmt ({astart = {reftype}; alength} as arr) ->
     let open Format in
     fprintf fmt "{@;<1 2>@[";
     for i = 0 to alength - 1 do
-      format reftype fmt (Array.get arr i);
+      format reftype fmt (CArray.get arr i);
       if i <> alength - 1 then
         fprintf fmt ",@;"
     done;

--- a/tests/test-bigarrays/test_bigarrays.ml
+++ b/tests/test-bigarrays/test_bigarrays.ml
@@ -19,16 +19,16 @@ let testlib = Dl.(dlopen ~filename:"clib/test_functions.so" ~flags:[RTLD_NOW])
 let array_of_list2 typ list2 =
   let dim2 = List.length (List.hd list2) in
   let atyp = array dim2 typ in
-  Array.of_list atyp (List.map (Array.of_list typ) list2)
+  CArray.of_list atyp (List.map (CArray.of_list typ) list2)
 
 let array_of_list3 typ list3 =
   let dim2 = List.length (List.hd list3)
   and dim3 = List.length (List.hd (List.hd list3)) in
   let atyp = array dim2 (array dim3 typ) in
-  Array.of_list atyp (List.map (array_of_list2 typ) list3)
+  CArray.of_list atyp (List.map (array_of_list2 typ) list3)
 
 let list2_of_array array =
-  List.map Array.to_list (Array.to_list array)
+  List.map CArray.to_list (CArray.to_list array)
 
 let matrix l = bigarray_of_array array2 BA.float64 (array_of_list2 double l)
 
@@ -42,6 +42,7 @@ let castp typ p = from_voidp typ (to_voidp p)
 *)
 let test_bigarray_of_ctypes_array () =
   (* One-dimensional Genarrays *)
+  let module Array = CArray in
   let a1 = Array.of_list int8_t [10; 20; 30; 40] in
   let b1 = bigarray_of_array genarray BA.int8_signed a1 in
   let () = begin
@@ -160,6 +161,7 @@ let test_bigarray_of_ctypes_array () =
   View bigarray-managed memory through a ctypes lens
 *)
 let test_ctypes_array_of_bigarray () =
+  let module Array = CArray in
 
   (* One-dimensional Genarrays *)
   let b1_dim = 6 in
@@ -427,6 +429,7 @@ let test_bigarray_lifetime_with_ctypes_reference () =
   associated with it.
 *)
 let test_ctypes_memory_lifetime_with_bigarray_reference () =
+  let module Array = CArray in
   let state = ref `Not_safe_to_collect in
   let finalise a =
     begin

--- a/tests/test-cstdlib/test_cstdlib.ml
+++ b/tests/test-cstdlib/test_cstdlib.ml
@@ -176,7 +176,7 @@ let test_qsort () =
      returning void) in
 
   let sortby (type a) (typ : a typ) (f : a -> a -> int) (l : a list) =
-    let open Array in
+    let open CArray in
     let open Size_t in
     let open Infix in
     let arr = of_list typ l in
@@ -236,8 +236,9 @@ let test_bsearch () =
     let name = ptr char -: "name"
     let () = seal (mi : mi structure typ)
 
-  let of_string : string -> char array =
+  let of_string : string -> char carray =
     fun s ->
+      let module Array = CArray in
       let len = String.length s in
       let arr = Array.make char (len + 1) in
       for i = 0 to len - 1 do
@@ -258,7 +259,7 @@ let test_bsearch () =
   let mkmi n s =
     let m = make mi in
     setf m mr n;
-    setf m name (Array.start s);
+    setf m name (CArray.start s);
     m
 
   let cmpi m1 m2 =
@@ -281,7 +282,7 @@ let test_bsearch () =
   let nov = of_string "nov"
   let dec = of_string "dec"
 
-  let months = Array.of_list mi [
+  let months = CArray.of_list mi [
     mkmi 1 jan;
     mkmi 2 feb;
     mkmi 3 mar;
@@ -297,24 +298,24 @@ let test_bsearch () =
   ]
 
   let () = qsort
-    (to_voidp (Array.start months))
-    (Size_t.of_int (Array.length months))
+    (to_voidp (CArray.start months))
+    (Size_t.of_int (CArray.length months))
     (Size_t.of_int (sizeof mi))
     cmpi
 
-  let search : mi structure -> mi structure array -> mi structure option
+  let search : mi structure -> mi structure carray -> mi structure option
     = fun key array ->
-      let len = Size_t.of_int (Array.length array) in
+      let len = Size_t.of_int (CArray.length array) in
       let size = Size_t.of_int (sizeof mi) in
       let r : unit ptr =
         bsearch
           (to_voidp (addr key))
-          (to_voidp (Array.start array))
+          (to_voidp (CArray.start array))
           len size cmpi in
       if r = null then None
       else Some (!@(from_voidp mi r))
 
-  let find_month_by_name : char array -> mi structure option =
+  let find_month_by_name : char carray -> mi structure option =
     fun s -> search (mkmi 0 s) months
 
   let () = match find_month_by_name dec with

--- a/tests/test-finalisers/test_finalisers.ml
+++ b/tests/test-finalisers/test_finalisers.ml
@@ -13,6 +13,7 @@ open Ctypes
   Simple finalisation test for arrays.
 *)
 let test_array_finaliser () =
+  let module Array = CArray in
   let finaliser_completed = ref false in
   let finalise a =
     begin

--- a/tests/test-pointers/test_pointers.ml
+++ b/tests/test-pointers/test_pointers.ml
@@ -274,6 +274,7 @@ let test_dereferencing_pointers_to_incomplete_types () =
   Writing through a pointer to an abstract type
 *)
 let test_writing_through_pointer_to_abstract_type () =
+  let module Array = CArray in
   let arra = Array.make int 2 in
   let arrb = Array.make int 2 in
   let absptr a =
@@ -390,6 +391,7 @@ let test_passing_pointer_through () =
   Tests for various aspects of pointer arithmetic.
 *)
 let test_pointer_arithmetic () =
+  let module Array = CArray in
   let arr = Array.of_list int [1;2;3;4;5;6;7;8] in
 
   (* Traverse the array using an int pointer *)

--- a/tests/test-structs/test_structs.ml
+++ b/tests/test-structs/test_structs.ml
@@ -234,6 +234,7 @@ let test_structs_with_array_members () =
 
     let s = make styp
 
+    module Array = CArray
     let arr = Array.of_list double [3.3; 4.4; 5.5]
 
     let () = begin

--- a/tests/test-unions/test_unions.ml
+++ b/tests/test-unions/test_unions.ml
@@ -74,6 +74,7 @@ let test_endian_detection () =
 
     let arr = getf e c
 
+    module Array = CArray
     let () = assert_equal
       ~msg:"the byte that we expected to change was changed"
       arr.(updated_char_index) UChar.one
@@ -109,7 +110,7 @@ let test_union_padding () =
         setf u i x;
         u
 
-    let arr = Array.of_list padded [
+    let arr = CArray.of_list padded [
       mkPadded 1L;
       mkPadded 2L;
       mkPadded 3L;
@@ -118,8 +119,8 @@ let test_union_padding () =
     ]
       
     let sum = sum_union_components
-      (Array.start arr)
-      (Unsigned.Size_t.of_int (Array.length arr))
+      (CArray.start arr)
+      (Unsigned.Size_t.of_int (CArray.length arr))
 
     let () = assert_equal
       ~msg:"padded union members accessed correctly"

--- a/tests/test-value_printing/test_value_printing.ml
+++ b/tests/test-value_printing/test_value_printing.ml
@@ -317,8 +317,8 @@ let test_pointer_printing () =
      implementation-dependent.  We can at least run the pointer-formatting
      code, and test that pointers of different types are printed
      equivalently. *)
-  let arr = Array.make int 10 in
-  let p = Array.start arr in
+  let arr = CArray.make int 10 in
+  let p = CArray.start arr in
 
   assert_equal
     (string_of (ptr (reference_type p)) p)
@@ -346,7 +346,7 @@ let test_struct_printing () =
   let vs = make s in
 
   begin
-    setf vs a (Array.of_list int [4; 5; 6]);
+    setf vs a (CArray.of_list int [4; 5; 6]);
     setf vs d nan;
     setf vs c 'a';
 
@@ -376,7 +376,7 @@ let test_union_printing () =
   let () = seal u in
   let v = make u in
   ignore (i, j, us);
-  setf v ua (Array.make ~initial:(Unsigned.UInt8.of_int 0) uint8_t 4);
+  setf v ua (CArray.make ~initial:(Unsigned.UInt8.of_int 0) uint8_t 4);
   assert_bool "union printing"
     (equal_ignoring_whitespace "{ us = {i = 0, j = 0} | ua = {0, 0, 0, 0}}" (string_of u v))
 
@@ -385,8 +385,8 @@ let test_union_printing () =
   Test the printing of array types.
 *)
 let test_array_printing () =
-  let arr = Array.of_list int [-1; 0; 1] in
-  let arrarr = Array.of_list (array 3 int) [arr; arr] in
+  let arr = CArray.of_list int [-1; 0; 1] in
+  let arrarr = CArray.of_list (array 3 int) [arr; arr] in
   assert_bool "array printing"
     (equal_ignoring_whitespace "{{-1, 0, 1}, {-1, 0, 1}}"
        (string_of (array 2 (array 3 int)) arrarr))

--- a/tests/test-views/test_views.ml
+++ b/tests/test-views/test_views.ml
@@ -25,13 +25,13 @@ let test_passing_string_array () =
     (ptr string @-> int @-> ptr char @-> returning void) in
 
   let l = ["the "; "quick "; "brown "; "fox "; "etc. "; "etc. "; ] in
-  let arr = Array.of_list string l in
+  let arr = CArray.of_list string l in
 
   let outlen = List.fold_left (fun a s -> String.length s + a) 1 l in
-  let buf = Array.make char outlen in
+  let buf = CArray.make char outlen in
 
-  let () = Array.(concat (start arr) (length arr) (start buf)) in
-  let buf_addr = allocate (ptr char) (Array.start buf) in
+  let () = CArray.(concat (start arr) (length arr) (start buf)) in
+  let buf_addr = allocate (ptr char) (CArray.start buf) in
   let s = from_voidp string (to_voidp buf_addr) in
 
   assert_equal ~msg:"Check output"


### PR DESCRIPTION
This is not backwards incompatible but it's probably a better default, since
it doesn't hide the standard Array module or array type.  It's still possible
to rebind CArray to Array to enable the index syntax:

```
   let module Array = CArray in begin
      a.(i) <- a.(j) + y
   end
```

Fixes #115.
