### PR TITLE
Include `pthread.h` before using pthreads functions

### DIFF
--- a/src/ctypes/posix_types_stubs.c
+++ b/src/ctypes/posix_types_stubs.c
@@ -12,6 +12,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <signal.h>
+#include <pthread.h>
 
 #include <stdint.h>
 


### PR DESCRIPTION
Fixes build on OpenBSD
