### PR TITLE
Add Ctypes.string_start.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ distclean: clean
 ctypes.public = static primitives unsigned signed structs ctypes posixTypes
 ctypes.dir = src/ctypes
 ctypes.extra_mls = ctypes_primitives.ml
-ctypes.deps = str bigarray
+ctypes.deps = str bigarray bytes
 ctypes.install = yes
 ctypes.install_native_objects = yes
 

--- a/src/cstubs/cstubs_internals.ml
+++ b/src/cstubs/cstubs_internals.ml
@@ -16,10 +16,10 @@ let make_structured reftype buf =
   let pmanaged = Some (Obj.repr buf) in
   let raw_ptr = Memory_stubs.block_address buf in
   let pbyte_offset = 0 in
-  { structured = { reftype; pmanaged; pbyte_offset; raw_ptr } }
+  { structured = CPointer { reftype; pmanaged; pbyte_offset; raw_ptr; } }
 
 include Static
 include Primitives
 
 let make_ptr reftype raw_ptr =
-  { reftype; raw_ptr; pmanaged = None; pbyte_offset = 0 }
+  CPointer { reftype; raw_ptr; pmanaged = None; pbyte_offset = 0; }

--- a/src/cstubs/cstubs_internals.mli
+++ b/src/cstubs/cstubs_internals.mli
@@ -18,17 +18,16 @@ type managed_buffer = Memory_stubs.managed_buffer
 val make_structured :
   ('a, 's) structured typ -> managed_buffer -> ('a, 's) structured
 
-type 'a ptr = 'a Static.ptr
-  = { reftype      : 'a typ;
-      raw_ptr      : voidp;
-      pmanaged     : Obj.t option;
-      pbyte_offset : int }
-
 val make_ptr : 'a typ -> voidp -> 'a ptr
+
+type 'a ocaml_type = 'a Static.ocaml_type =
+  String     : string ocaml_type
+| Bytes      : Bytes.t ocaml_type
+| FloatArray : float array ocaml_type
 
 type 'a typ = 'a Static.typ =
     Void            :                              unit typ
-  | Primitive       : 'a Primitives.prim        -> 'a typ 
+  | Primitive       : 'a Primitives.prim        -> 'a typ
   | Pointer         : 'a typ                    -> 'a ptr typ
   | Struct          : 'a Static.structure_type  -> 'a Static.structure typ
   | Union           : 'a Static.union_type      -> 'a Static.union typ
@@ -36,6 +35,17 @@ type 'a typ = 'a Static.typ =
   | View            : ('a, 'b) view             -> 'a typ
   | Array           : 'a typ * int              -> 'a Static.carray typ
   | Bigarray        : (_, 'a) Ctypes_bigarray.t -> 'a typ
+  | OCaml           : 'a ocaml_type             -> 'a ocaml typ
+and 'a cptr = 'a Static.cptr
+  = { reftype      : 'a typ;
+      raw_ptr      : voidp;
+      pmanaged     : Obj.t option;
+      pbyte_offset : int; }
+and ('a, 'b) pointer = ('a, 'b) Static.pointer =
+  CPointer : 'a cptr -> ('a, [`C]) pointer
+| OCamlRef : int * 'a -> ('a, [`OCaml]) pointer
+and 'a ptr = ('a, [`C]) pointer
+and 'a ocaml = ('a, [`OCaml]) pointer
 and ('a, 'b) view = ('a, 'b) Static.view = {
   read : 'b -> 'a;
   write : 'a -> 'b;

--- a/src/ctypes-foreign-base/ffi_stubs.ml
+++ b/src/ctypes-foreign-base/ffi_stubs.ml
@@ -55,13 +55,13 @@ external prep_callspec : callspec -> int -> _ ffitype -> unit
 (* Call the function specified by `callspec' at the given address.
    The callback functions write the arguments to the buffer and read
    the return value. *)
-external call : voidp -> callspec -> (voidp -> unit) ->
-  (voidp -> 'a) -> 'a
+external call : voidp -> callspec ->
+  (voidp -> (Obj.t * int) array -> unit) -> (voidp -> 'a) -> 'a
   = "ctypes_call"
 
 (* As ctypes_call, but check errno and raise Unix_error if the call failed. *)
 external call_errno : string -> voidp -> callspec ->
-  (voidp -> unit) -> (voidp -> 'a) -> 'a
+  (voidp -> (Obj.t * int) array -> unit) -> (voidp -> 'a) -> 'a
   = "ctypes_call_errno"
 
 

--- a/src/ctypes/coerce.ml
+++ b/src/ctypes/coerce.ml
@@ -19,7 +19,7 @@ type (_, _) coercion =
 
 let ml_prim_coercion :
   type a b. a Primitives.ml_prim -> b Primitives.ml_prim -> (a, b) coercion =
-  let open Primitives in 
+  let open Primitives in
   fun l r -> match l, r with
   | ML_char, ML_char -> Id
   | ML_complex, ML_complex -> Id
@@ -46,7 +46,7 @@ let rec coercion : type a b. a typ -> b typ -> (a, b) coercion =
   fun atyp btyp -> match atyp, btyp with
   | _, Void -> Coercion ignore
   | Primitive l, Primitive r ->
-    Primitives.(ml_prim_coercion (ml_prim l) (ml_prim r)) 
+    Primitives.(ml_prim_coercion (ml_prim l) (ml_prim r))
   | View av, b ->
     begin match coercion av.ty b with
     | Id -> Coercion av.write
@@ -62,12 +62,12 @@ let rec coercion : type a b. a typ -> b typ -> (a, b) coercion =
       try
         begin match coercion a b with
         | Id -> Id
-        | Coercion _ -> Coercion (fun p -> { p with reftype = b })
+        | Coercion _ -> Coercion (fun (CPointer p) -> CPointer { p with reftype = b })
         end
       with Uncoercible ->
-        Coercion (fun p -> { p with reftype = b })
+        Coercion (fun (CPointer p) -> CPointer { p with reftype = b })
     end
-  | _ -> raise Uncoercible 
+  | _ -> raise Uncoercible
 
 let rec fn_coercion : type a b. a fn -> b fn -> (a, b) coercion =
   fun afn bfn -> match afn, bfn with

--- a/src/ctypes/std_views.ml
+++ b/src/ctypes/std_views.ml
@@ -5,15 +5,16 @@
  * See the file LICENSE for details.
  *)
 
-let string_of_char_ptr {Static.raw_ptr; pbyte_offset} =
+let string_of_char_ptr (Static.CPointer {Static.raw_ptr; pbyte_offset}) =
   Std_view_stubs.string_of_cstring raw_ptr pbyte_offset
 
 let char_ptr_of_string s =
   let buf = Std_view_stubs.cstring_of_string s in
-  { Static.reftype = Static.char;
+  Static.CPointer {
+    Static.reftype = Static.char;
     pmanaged = Some (Obj.repr buf);
     raw_ptr = Memory_stubs.block_address buf;
-    pbyte_offset = 0 }
+    pbyte_offset = 0; }
 
 let string = Static.(view (ptr char))
   ~read:string_of_char_ptr ~write:char_ptr_of_string

--- a/src/ctypes/type_printing.ml
+++ b/src/ctypes/type_printing.ml
@@ -26,7 +26,7 @@ type format_context = [
 let rec format_typ : type a. a typ ->
   (format_context -> Format.formatter -> unit) ->
   (format_context -> Format.formatter -> unit) =
-  let fprintf = Format.fprintf in 
+  let fprintf = Format.fprintf in
   fun t k context fmt -> match t with
     | Void ->
       fprintf fmt "void%t" (k `nonarray)
@@ -75,6 +75,7 @@ let rec format_typ : type a. a typ ->
       let name = Ctypes_primitives.name elem in
       fprintf fmt "%s%t%t" name (k `array)
         (fun fmt -> (Array.iter (Format.fprintf fmt "[%d]") dims))
+    | OCaml ty -> assert false (* TODO *)
 
 and format_fields : type a. a boxed_field list -> Format.formatter -> unit =
   fun fields fmt ->

--- a/src/ctypes/value_printing.ml
+++ b/src/ctypes/value_printing.ml
@@ -20,10 +20,13 @@ let rec format : type a. a typ -> Format.formatter -> a -> unit
   | Bigarray ba -> Format.fprintf fmt "<bigarray %a>"
     (fun fmt -> Type_printing.format_typ fmt) typ
   | Abstract _ -> format_structured fmt v
+  | OCaml String -> Format.pp_print_string fmt "<string>"
+  | OCaml Bytes -> Format.pp_print_string fmt "<bytes>"
+  | OCaml FloatArray -> Format.pp_print_string fmt "<float array>"
     (* For now, just print the underlying value in a view *)
   | View {write; ty} -> format ty fmt (write v)
 and format_structured : type a b. Format.formatter -> (a, b) structured -> unit
-  = fun fmt ({structured = {reftype}} as s) ->
+  = fun fmt ({structured = CPointer {reftype}} as s) ->
     let open Format in
     match reftype with
     | Struct {fields} ->
@@ -38,7 +41,7 @@ and format_structured : type a b. Format.formatter -> (a, b) structured -> unit
       pp_print_string fmt "<abstract>"
     | _ -> raise (Unsupported "unknown structured type")
 and format_array : type a. Format.formatter -> a carray -> unit
-  = fun fmt ({astart = {reftype}; alength} as arr) ->
+  = fun fmt ({astart = CPointer {reftype}; alength} as arr) ->
     let open Format in
     fprintf fmt "{@;<1 2>@[";
     for i = 0 to alength - 1 do
@@ -58,7 +61,7 @@ and format_fields : type a b. string -> (a, b) structured boxed_field list ->
           (if i <> last_field then sep else ""))
       fields
 and format_ptr : type a. Format.formatter -> a ptr -> unit
-  = fun fmt {raw_ptr; reftype; pbyte_offset} ->
+  = fun fmt (CPointer {raw_ptr; reftype; pbyte_offset}) ->
     Format.fprintf fmt "%s"
       (Value_printing_stubs.string_of_pointer
          (Raw.PtrType.(add raw_ptr (of_int pbyte_offset))))


### PR DESCRIPTION
Ctypes.string_start works like Ctypes.bigarray_start--it returns
a pointer to the start of the string. Existence of this function
is motivated by the C APIs which mutate strings passed to them,
but do not capture the pointers.

In particular, I've worked on wrappers for such libraries as libsodium and libzmq, and they both would benefit from this API.
