### PR TITLE
Use paths relative to the current directory in cstubs_internals.h.

### DIFF
--- a/src/ctypes/cstubs_internals.h
+++ b/src/ctypes/cstubs_internals.h
@@ -10,10 +10,10 @@
 
 /* Types and functions used by generated C code. */
 
-#include "ctypes/primitives.h"
-#include "ctypes/complex_stubs.h"
-#include "ctypes/raw_pointer.h"
-#include "ctypes/managed_buffer_stubs.h"
+#include "primitives.h"
+#include "complex_stubs.h"
+#include "raw_pointer.h"
+#include "managed_buffer_stubs.h"
 #define CTYPES_PTR_OF_OCAML_STRING(s) \
   (String_val(Field(s, 1)) + Int_val(Field(s, 0)))
 


### PR DESCRIPTION
Fixes an issue raised in #151.