### PR TITLE
safely remove output_file, which may not exist

### DIFF
--- a/src/libffi-abigen/libffi_abigen.ml
+++ b/src/libffi-abigen/libffi_abigen.ml
@@ -95,7 +95,7 @@ let determine_code symbol =
   let result = read_output_int input_file output_file in
   begin
     Sys.remove input_file;
-    (try Sys.remove output_file with _ -> ());
+    if Sys.file_exists output_file then Sys.remove output_file;
     result
   end
 


### PR DESCRIPTION
For example, in clang-425.0.28 (what Apple ships as `cc` on OS X 10.7),
a failed compilation does not generate an output file. But in
clang-503.0.40 (OS X 10.9), it does create a zero-sized output file.
