### PR TITLE
fix: long != intnat

### DIFF
--- a/src/ctypes/managed_buffer_stubs.c
+++ b/src/ctypes/managed_buffer_stubs.c
@@ -28,10 +28,10 @@ static int compare_pointers(value l_, value r_)
   return (l > r) - (l < r);
 }
 
-static long hash_address(value l)
+static intnat hash_address(value l)
 {
   /* address hashing */
-  return (long)*(void **)Data_custom_val(l);
+  return (intnat)*(void **)Data_custom_val(l);
 }
 
 static struct custom_operations managed_buffer_custom_ops = {

--- a/src/ctypes/unsigned_stubs.c
+++ b/src/ctypes/unsigned_stubs.c
@@ -36,20 +36,20 @@
     return (u1 > u2) - (u1 < u2);                                            \
   }                                                                          \
                                                                              \
-  static long uint ## BITS ## _hash(value v)                                 \
+  static intnat uint ## BITS ## _hash(value v)                               \
   {                                                                          \
     return Uint_custom_val(TYPE(BITS), v);                                   \
   }                                                                          \
                                                                              \
   static void uint ## BITS ## _serialize(value v,                            \
-                                         unsigned long *wsize_32,            \
-                                         unsigned long *wsize_64)            \
+                                         uintnat *wsize_32,                  \
+                                         uintnat *wsize_64)                  \
   {                                                                          \
     caml_serialize_int_ ## BYTES(Uint_custom_val(TYPE(BITS), v));            \
     *wsize_32 = *wsize_64 = BYTES;                                           \
   }                                                                          \
                                                                              \
-  static unsigned long uint ## BITS ## _deserialize(void *dst)               \
+  static uintnat uint ## BITS ## _deserialize(void *dst)                     \
   {                                                                          \
     *(TYPE(BITS) *)dst = caml_deserialize_uint_ ## BYTES();                  \
     return BYTES;                                                            \


### PR DESCRIPTION
`sizeof long` is not necessarily identical to `sizeof intnat` (e.g. on windows64, long is 32bit and and intnat 64bit). The changes follow the prototypes in `caml/custom.h`.
