### PR TITLE
Findlib package rationalization

### DIFF
--- a/META
+++ b/META
@@ -29,27 +29,27 @@ package "stubs" (
   exists_if = "cstubs.cma"
 )
 
-package "foreign-base" (
- version = "0.3"
- description = "Dynamic linking of C functions"
- requires = "ctypes"
- archive(byte) = "ctypes-foreign-base.cma"
- archive(byte, plugin) = "ctypes-foreign-base.cma"
- archive(native) = "ctypes-foreign-base.cmxa"
- archive(native, plugin) = "ctypes-foreign-base.cmxs"
- exists_if = "ctypes-foreign-base.cma"
-)
-
 package "foreign" (
  version = "0.3"
  description = "Dynamic linking of C functions"
  requires(-mt) = "ctypes.foreign.unthreaded"
  requires(mt) = "ctypes.foreign.threaded"
 
+ package "base" (
+  version = "0.3"
+  description = "Dynamic linking of C functions (base package)"
+  requires = "ctypes"
+  archive(byte) = "ctypes-foreign-base.cma"
+  archive(byte, plugin) = "ctypes-foreign-base.cma"
+  archive(native) = "ctypes-foreign-base.cmxa"
+  archive(native, plugin) = "ctypes-foreign-base.cmxs"
+  exists_if = "ctypes-foreign-base.cma"
+ )
+
  package "threaded" (
   version = "0.3"
   description = "Dynamic linking of C functions (for use in threaded programs)"
-  requires = "threads ctypes ctypes.foreign-base"
+  requires = "threads ctypes ctypes.foreign.base"
   archive(byte) = "ctypes-foreign-threaded.cma"
   archive(byte, plugin) = "ctypes-foreign-threaded.cma"
   archive(native) = "ctypes-foreign-threaded.cmxa"
@@ -60,7 +60,7 @@ package "foreign" (
  package "unthreaded" (
   version = "0.3"
   description = "Dynamic linking of C functions (for use in unthreaded programs)"
-  requires = "ctypes ctypes.foreign-base"
+  requires = "ctypes ctypes.foreign.base"
   archive(byte) = "ctypes-foreign-unthreaded.cma"
   archive(byte, plugin) = "ctypes-foreign-unthreaded.cma"
   archive(native) = "ctypes-foreign-unthreaded.cmxa"


### PR DESCRIPTION
Rationalize the 'foreign' findlib package.  Changes:
- Use predicate negation `-mt` to detect unthreaded code rather than relying on match ordering (6bf2e1b4).
- Introduce subpackages `ctypes.foreign.threaded` and `ctypes.foreign.threaded` so that clients can explicitly select the appropriate implementation (271fdf5).
- Move `ctypes.foreign-base` to `ctypes.foreign.base` (94ba66b).
