### PR TITLE
play with alignment; add compact mode

### DIFF
--- a/src/ctypes/ctypes.mli
+++ b/src/ctypes/ctypes.mli
@@ -307,7 +307,7 @@ type ('a, 't) field = ('a, 't) Static.field
     here).  A value of type [(a, s) field] represents a field of type [a] in a
     struct or union of type [s]. *)
 
-val structure : string -> 's structure typ
+val structure : ?compact:bool -> string -> 's structure typ
 (** Construct a new structure type.  The type value returned is incomplete and
     can be updated using {!field} until it is passed to {!seal}, at which point
     the set of fields is fixed.

--- a/src/ctypes/static.ml
+++ b/src/ctypes/static.ml
@@ -13,7 +13,7 @@ exception Unsupported of string
 
 let unsupported fmt = Printf.ksprintf (fun s -> raise (Unsupported s)) fmt
 
-type incomplete_size = { mutable isize: int }
+type incomplete_size = { mutable isize: int; compact : bool }
 
 type structured_spec = { size: int; align: int; }
 
@@ -218,8 +218,8 @@ let returning v =
   else
     Returns v
 
-let structure tag =
-  Struct { spec = Incomplete { isize = 0 }; tag; fields = [] }
+let structure ?(compact=false) tag =
+  Struct { spec = Incomplete { isize = 0; compact }; tag; fields = [] }
 
 let union utag = Union { utag; uspec = None; ufields = [] }
 

--- a/src/ctypes/static.mli
+++ b/src/ctypes/static.mli
@@ -18,7 +18,7 @@ type _ ocaml_type =
 | Bytes      : Bytes.t ocaml_type
 | FloatArray : float array ocaml_type
 
-type incomplete_size = { mutable isize: int }
+type incomplete_size = { mutable isize: int; compact: bool }
 
 type structured_spec = { size: int; align: int; }
 
@@ -153,7 +153,7 @@ val bigarray : < ba_repr : 'c;
                  element : 'a > bigarray_class ->
                'b -> ('a, 'c) Bigarray.kind -> 'd typ
 val returning : 'a typ -> 'a fn
-val structure : string -> 'a structure typ
+val structure : ?compact:bool -> string -> 'a structure typ
 val union : string -> 'a union typ
 val offsetof : ('a, 'b) field -> int
 val field_type : ('a, 'b) field -> 'a typ


### PR DESCRIPTION
DO NOT MERGE
This PR aims to expose our need&workaround and start a  discussion about the best way to add this feature upstream.

One of the lib we use (on windows) requires structures to be packed with 1-byte alignment.

This patch does not deal with generated stubs.
Still need to manually add the following when generating stubs:
`#pragma pack(push, ..., 1)`
