### PR TITLE
typedef support (Closes #135)

### DIFF
--- a/src/ctypes/ctypes.mli
+++ b/src/ctypes/ctypes.mli
@@ -381,6 +381,14 @@ val view : ?format_typ:((Format.formatter -> unit) -> Format.formatter -> unit) 
 
 *)
 
+val typedef : 'a typ -> string -> 'a typ
+(** [typedef t name] creates a C type representation [t'] which
+    is equivalent to [t] except its name is printed as [name].
+
+    This is useful when generating C stubs involving "anonymous" types, for
+    example: [typedef struct { int f } typedef_name;]
+*)
+
 (** {3 Abstract types} *)
 
 type 'a abstract

--- a/src/ctypes/static.ml
+++ b/src/ctypes/static.ml
@@ -199,6 +199,10 @@ let abstract ~name ~size ~alignment =
   Abstract { aname = name; asize = size; aalignment = alignment }
 let view ?format_typ ?format ~read ~write ty =
   View { read; write; format_typ; format; ty }
+let id v = v
+let typedef old name =
+  view ~format_typ:(fun k fmt -> Format.fprintf fmt "%s%t" name k)
+    ~read:id ~write:id old
 let bigarray : type a b c d e.
   < element: a;
     dims: b;

--- a/src/ctypes/static.mli
+++ b/src/ctypes/static.mli
@@ -147,6 +147,7 @@ val view : ?format_typ:((Format.formatter -> unit) ->
                         Format.formatter -> unit) ->
            ?format: (Format.formatter -> 'b -> unit) ->
            read:('a -> 'b) -> write:('b -> 'a) -> 'a typ -> 'b typ
+val typedef: 'a typ -> string -> 'a typ
 val bigarray : < ba_repr : 'c;
                  bigarray : 'd;
                  carray : 'e;


### PR DESCRIPTION
Preserve the view type formatter when projecting types.
Also introduce a convenience wrapper that just typedefs.

With these changes it is possible to support "anonymous" types in C stubs
as in issue #135, for example given:
typedef struct { ... } SDL_JoystickGUID

let joystick_guid : joystick_guid typ = structure "_SDL_JoystickGUID"
(\* ... *)
let joystick_guid =
  typedef "SDL_JoystickGUID" joystick_guid

let joystick_get_guid_string =
  foreign "SDL_JoystickGetGUIDString"
    (joystick_guid @-> ptr char @-> int @-> returning void)

Ctypes should generate 'SDL_JoystickGUID x1696 = ...' instead of
'struct _SDL_JoystickGUID x1696 = ...' which would fail to compile.
