### PR TITLE
Allow calling bindings from views when generating C stubs

### DIFF
--- a/src/cstubs/cstubs.mli
+++ b/src/cstubs/cstubs.mli
@@ -11,6 +11,14 @@ module type FOREIGN =
 sig
   type 'a fn
   val foreign : string -> ('a -> 'b) Ctypes.fn -> ('a -> 'b) fn
+  val view_invoke : ('a -> 'b) fn -> 'a -> 'b
+ (** [view_invoke f] is intended to be used when implementing the
+   read and write functions for a view.
+   When generating C stubs you cannot call the [foreign] functions
+   when defining the bindings themselves, but you may need to declare views
+   where the [read] and [write] functions would in turn call some
+   of the just defined bindings.
+ *)
 end
 
 module type BINDINGS = functor (F : FOREIGN with type 'a fn = unit) -> sig end

--- a/src/ctypes-foreign-base/foreign_basis.ml
+++ b/src/ctypes-foreign-base/foreign_basis.ml
@@ -44,4 +44,7 @@ struct
       coerce (ptr_of_raw_ptr (dlsym ?handle:from ~symbol))
     with 
     | exn -> if stub then fun _ -> raise exn else raise exn
+
+  type 'a fn = 'a
+  let view_invoke f x = f x
 end

--- a/src/ctypes-foreign-threaded/foreign.mli
+++ b/src/ctypes-foreign-threaded/foreign.mli
@@ -88,3 +88,10 @@ val funptr_opt :
 exception CallToExpiredClosure
 (** A closure passed to C was collected by the OCaml garbage collector before
     it was called. *)
+
+type 'a fn = 'a
+val view_invoke : ('a -> 'b) fn -> 'a -> 'b
+(** [view_invoke f] for compatibility with Cstubs.FOREIGN.
+    Usually you are not allowed to call the just defined bindings when
+    generating C stubs (because they are not real functions yet), but you
+    need the correct type for defining views *)

--- a/src/ctypes-foreign-unthreaded/foreign.mli
+++ b/src/ctypes-foreign-unthreaded/foreign.mli
@@ -85,3 +85,10 @@ val funptr_opt :
 exception CallToExpiredClosure
 (** A closure passed to C was collected by the OCaml garbage collector before
     it was called. *)
+
+type 'a fn = 'a
+val view_invoke : ('a -> 'b) fn -> 'a -> 'b
+(** [view_invoke f] for compatibility with Cstubs.FOREIGN.
+    Usually you are not allowed to call the just defined bindings when
+    generating C stubs (because they are not real functions yet), but you
+    need the correct type for defining views *)

--- a/tests/tests-common/tests_common.ml
+++ b/tests/tests-common/tests_common.ml
@@ -31,6 +31,7 @@ module Foreign_binder : Cstubs.FOREIGN with type 'a fn = 'a =
 struct
   type 'a fn = 'a
   let foreign name fn = Foreign.foreign name fn
+  let view_invoke f v = f v
 end
 
 module type STUBS = functor  (F : Cstubs.FOREIGN) -> sig end


### PR DESCRIPTION
Usually you are not allowed to call the just defined bindings when
generating C stubs (because they are not real functions yet).
For example the call to 'error ()' should be replaced by '(view_invoke error)
()' here: https://github.com/dbuenzli/tsdl/blob/bc18d14b1a28af99ebc30b61e303ee5304055d31/src/tsdl.ml#L82-L89
