### PR TITLE
Extend Cstubs with foreign_value support

### DIFF
--- a/Makefile.tests
+++ b/Makefile.tests
@@ -276,12 +276,38 @@ test-sizeof.subproject_deps = ctypes ctypes-foreign-base ctypes-foreign-unthread
 test-sizeof: PROJECT=test-sizeof
 test-sizeof: $$(NATIVE_TARGET)
 
+test-foreign_values-stubs.dir  = tests/test-foreign_values/stubs
+test-foreign_values-stubs.threads = yes
+test-foreign_values-stubs.subproject_deps = ctypes cstubs \
+   ctypes-foreign-base ctypes-foreign-unthreaded tests-common
+test-foreign_values-stubs: PROJECT=test-foreign_values-stubs
+test-foreign_values-stubs: $$(LIB_TARGETS)
+
+test-foreign_values-stub-generator.dir = tests/test-foreign_values/stub-generator
+test-foreign_values-stub-generator.threads = yes
+test-foreign_values-stub-generator.subproject_deps = ctypes cstubs \
+     ctypes-foreign-base ctypes-foreign-unthreaded test-foreign_values-stubs tests-common
+test-foreign_values-stub-generator.deps = str bigarray bytes
+test-foreign_values-stub-generator: PROJECT=test-foreign_values-stub-generator
+test-foreign_values-stub-generator: $$(NATIVE_TARGET)
+
 test-foreign_values.dir = tests/test-foreign_values
 test-foreign_values.threads = yes
 test-foreign_values.deps = str bigarray oUnit bytes
-test-foreign_values.subproject_deps = ctypes ctypes-foreign-base ctypes-foreign-unthreaded
+test-foreign_values.subproject_deps = ctypes ctypes-foreign-base \
+  ctypes-foreign-unthreaded cstubs tests-common test-foreign_values-stubs
+test-foreign_values.link_flags = -L$(BUILDDIR)/clib -ltest_functions
 test-foreign_values: PROJECT=test-foreign_values
 test-foreign_values: $$(NATIVE_TARGET)
+
+test-foreign_values-generated: \
+  tests/test-foreign_values/generated_bindings.ml \
+  tests/test-foreign_values/generated_stubs.c
+
+tests/test-foreign_values/generated_stubs.c: $(BUILDDIR)/test-foreign_values-stub-generator.native
+	$< --c-file $@
+tests/test-foreign_values/generated_bindings.ml: $(BUILDDIR)/test-foreign_values-stub-generator.native
+	$< --ml-file $@
 
 test-unions-stubs.dir  = tests/test-unions/stubs
 test-unions-stubs.threads = yes
@@ -722,7 +748,7 @@ TESTS += test-structs-stubs test-structs-stub-generator test-structs-generated t
 TESTS += test-finalisers
 TESTS += test-cstdlib-stubs test-cstdlib-stub-generator test-cstdlib-generated test-cstdlib
 TESTS += test-sizeof
-TESTS += test-foreign_values
+TESTS += test-foreign_values-stubs test-foreign_values-stub-generator test-foreign_values-generated test-foreign_values
 TESTS += test-unions-stubs test-unions-stub-generator test-unions-generated test-unions
 TESTS += test-custom_ops
 TESTS += test-arrays-stubs test-arrays-stub-generator test-arrays-generated test-arrays

--- a/src/cstubs/cstubs.ml
+++ b/src/cstubs/cstubs.ml
@@ -11,6 +11,7 @@ module type FOREIGN =
 sig
   type 'a fn
   val foreign : string -> ('a -> 'b) Ctypes.fn -> ('a -> 'b) fn
+  val foreign_value : string -> 'a Ctypes.typ -> 'a Ctypes.ptr fn
 end
 
 module type FOREIGN' = FOREIGN with type 'a fn = unit
@@ -26,11 +27,14 @@ let gen_c prefix fmt : (module FOREIGN') =
      type 'a fn = unit
      let foreign cname fn =
        Cstubs_generate_c.fn ~cname ~stub_name:(var prefix cname) fmt fn
+     let foreign_value cname typ =
+       Cstubs_generate_c.value ~cname ~stub_name:(var prefix cname) fmt typ
    end)
 
 type bind = Bind : string * string * ('a -> 'b) Ctypes.fn -> bind
+type val_bind = Val_bind : string * string * 'a Ctypes.typ -> val_bind
 
-let write_foreign fmt bindings =
+let write_foreign fmt bindings val_bindings =
   Format.fprintf fmt
     "type 'a fn = 'a@\n@\n";
   Format.fprintf fmt
@@ -42,10 +46,23 @@ let write_foreign fmt bindings =
       Cstubs_generate_ml.case ~stub_name ~external_name fmt fn);
   Format.fprintf fmt "@[<hov 2>@[|@ s,@ _@ ->@]@ ";
   Format.fprintf fmt
+    " @[Printf.ksprintf@ failwith@ \"No match for %%s\" s@]@]@]@.@\n";
+  Format.fprintf fmt
+    "@\n";
+  Format.fprintf fmt
+    "let foreign_value : type a b. string -> a Ctypes.typ -> a Ctypes.ptr =@\n";
+  Format.fprintf fmt
+    "  fun name t -> match name, t with@\n@[<v>";
+  ListLabels.iter val_bindings
+    ~f:(fun (Val_bind (stub_name, external_name, typ)) ->
+      Cstubs_generate_ml.val_case ~stub_name ~external_name fmt typ);
+  Format.fprintf fmt "@[<hov 2>@[|@ s,@ _@ ->@]@ ";
+  Format.fprintf fmt
     " @[Printf.ksprintf@ failwith@ \"No match for %%s\" s@]@]@]@.@\n"
 
 let gen_ml prefix fmt : (module FOREIGN') * (unit -> unit) =
   let bindings = ref []
+  and val_bindings = ref []
   and counter = ref 0 in
   let var prefix name = incr counter;
     Printf.sprintf "%s_%d_%s" prefix !counter name in
@@ -56,8 +73,14 @@ let gen_ml prefix fmt : (module FOREIGN') * (unit -> unit) =
        let name = var prefix cname in
        bindings := Bind (cname, name, fn) :: !bindings;
        Cstubs_generate_ml.extern ~stub_name:name ~external_name:name fmt fn
+     let foreign_value cname typ =
+       let name = var prefix cname in
+       Cstubs_generate_ml.extern ~stub_name:name ~external_name:name fmt
+         Ctypes.(void @-> returning (ptr void));
+       val_bindings := Val_bind (cname, name, typ) :: !val_bindings
    end),
-  fun () -> write_foreign fmt !bindings
+  fun () ->
+    write_foreign fmt !bindings !val_bindings
 
 let write_c fmt ~prefix (module B : BINDINGS) =
   Format.fprintf fmt

--- a/src/cstubs/cstubs.ml
+++ b/src/cstubs/cstubs.ml
@@ -41,8 +41,8 @@ let write_foreign fmt bindings =
     ~f:(fun (Bind (stub_name, external_name, fn)) ->
       Cstubs_generate_ml.case ~stub_name ~external_name fmt fn);
   Format.fprintf fmt "@[<hov 2>@[|@ s,@ _@ ->@]@ ";
-  Format.fprintf fmt " @[@[Printf.fprintf@ stderr@ \"No match for %%s\" s@];";
-  Format.fprintf fmt "@ @[assert false@]@]@]@]@."
+  Format.fprintf fmt
+    " @[Printf.ksprintf@ failwith@ \"No match for %%s\" s@]@]@]@.@\n"
 
 let gen_ml prefix fmt : (module FOREIGN') * (unit -> unit) =
   let bindings = ref []

--- a/src/cstubs/cstubs.mli
+++ b/src/cstubs/cstubs.mli
@@ -19,6 +19,7 @@ module type FOREIGN =
 sig
   type 'a fn
   val foreign : string -> ('a -> 'b) Ctypes.fn -> ('a -> 'b) fn
+  val foreign_value : string -> 'a Ctypes.typ -> 'a Ctypes.ptr fn
 end
 
 module type BINDINGS = functor (F : FOREIGN with type 'a fn = unit) -> sig end

--- a/src/cstubs/cstubs_c_language.ml
+++ b/src/cstubs/cstubs_c_language.ml
@@ -37,7 +37,7 @@ type cconst = [ `Int of int ]
 type cexp = [ cconst
             | clocal
             | `Cast of ty * cexp
-            | `Addr of cexp ]
+            | `Addr of cvar ]
 type clvalue = [ clocal | `Index of clvalue * cexp ]
 type camlop = [ `CAMLparam0
               | `CAMLlocalN of cexp * cexp ]
@@ -72,7 +72,8 @@ struct
     | `Int _ -> Ty int
     | `Local (_, ty) -> ty
     | `Cast (Ty ty, _) -> Ty ty
-    | `Addr e -> let Ty ty = cexp e in Ty (Pointer ty)
+    | `Addr (`Global { typ = Ty ty }) -> Ty (Pointer ty)
+    | `Addr (`Local (_,  Ty ty)) -> Ty (Pointer ty)
 
   let camlop : camlop -> ty = function
     | `CAMLparam0

--- a/src/cstubs/cstubs_emit_c.ml
+++ b/src/cstubs/cstubs_emit_c.ml
@@ -44,7 +44,8 @@ let rec cexp fmt : cexp -> unit = function
   | `Local _ as x -> cvar fmt x
   | `Cast (ty, e) when cast_unnecessary ty e -> cexp fmt e
   | `Cast (ty, e) -> fprintf fmt "@[@[(%a)@]%a@]" format_ty ty cexp e
-  | `Addr e -> fprintf fmt "@[&@[%a@]@]" cexp e
+  | `Addr (`Global { name })
+  | `Addr (`Local (name, _)) -> fprintf fmt "@[&@[%s@]@]" name
 
 let rec clvalue fmt : clvalue -> unit = function
   | `Local _ as x -> cvar fmt x

--- a/src/cstubs/cstubs_generate_c.ml
+++ b/src/cstubs/cstubs_generate_c.ml
@@ -308,6 +308,16 @@ struct
                   `CAMLlocalN (local "locals" (array (List.length args) value),
                                local "nargs" int) >>
                     body))
+
+  let value : type a. cname:string -> stub_name:string -> a Static.typ -> cfundef =
+    fun ~cname ~stub_name typ ->
+      let (e, ty) = (`Addr (`Global { name = cname; typ = Ty typ;
+                                      references_ocaml_heap = false }), (ptr typ)) in
+      let x = fresh_var () in
+      `Function (`Fundec (stub_name, ["_", Ty value], Ty value),
+                 `Let ((local x ty, e),
+                       (inj (ptr typ) (local x ty) :> ccomp)))
+
 end
 
 let fn ~cname  ~stub_name fmt fn =
@@ -321,6 +331,10 @@ let fn ~cname  ~stub_name fmt fn =
   end
   else
     Cstubs_emit_c.cfundef fmt dec
+
+let value ~cname ~stub_name fmt typ =
+  let dec = Generate_C.value ~cname ~stub_name typ in
+  Cstubs_emit_c.cfundef fmt dec
 
 let inverse_fn ~stub_name fmt fn : unit =
   Cstubs_emit_c.cfundef fmt (Generate_C.inverse_fn ~stub_name fn)

--- a/src/cstubs/cstubs_generate_c.mli
+++ b/src/cstubs/cstubs_generate_c.mli
@@ -10,6 +10,9 @@
 val fn : cname:string -> stub_name:string -> Format.formatter ->
          'a Ctypes.fn -> unit
 
+val value : cname:string -> stub_name:string -> Format.formatter ->
+         'a Ctypes.typ -> unit
+
 val inverse_fn : stub_name:string -> Format.formatter ->
          'a Ctypes.fn -> unit
 

--- a/src/cstubs/cstubs_generate_ml.mli
+++ b/src/cstubs/cstubs_generate_ml.mli
@@ -13,6 +13,9 @@ val extern : stub_name:string -> external_name:string -> Format.formatter ->
 val case : stub_name:string -> external_name:string -> Format.formatter ->
          ('a -> 'b) Ctypes.fn -> unit
 
+val val_case : stub_name:string -> external_name:string -> Format.formatter ->
+         'a Ctypes.typ -> unit
+
 val constructor_decl : string -> 'a Ctypes.fn -> Format.formatter -> unit
 
 val inverse_case : register_name:string -> constructor:string -> string ->

--- a/tests/test-callback_lifetime/test_callback_lifetime.ml
+++ b/tests/test-callback_lifetime/test_callback_lifetime.ml
@@ -107,27 +107,27 @@ struct
     (* First, the naive implementation.  This should fail, because arg is
        collected before ret is called. *)
     let ret = Naive.make ~arg:(closure 3) in
-    Gc.major ();
+    Gc.full_major ();
     assert_raises CallToExpiredClosure
       (fun () -> Naive.get ret 5);
 
     (* Now a more careful implementation.  This succeeds, because we keep a
        reference to arg around with the reference to ret *)
     let ret = Better.make ~arg:(closure 3) in
-    Gc.major ();
+    Gc.full_major ();
     assert_equal 15 (Better.get ret 5);
 
     (* However, even with the careful implementation things can go wrong if we
        keep a reference to ret beyond the lifetime of the pair. *)
     let ret = Better.get (Better.make ~arg:(closure 3)) in
-    Gc.major ();
+    Gc.full_major ();
     assert_raises CallToExpiredClosure
       (fun () -> ret 5);
 
     (* The most careful implementation calls ret rather than returning it,
        so arg cannot be collected prematurely. *)
     let ret = Careful.get (Careful.make ~arg:(closure 3)) in
-    Gc.major ();
+    Gc.full_major ();
     assert_equal 15 (ret 5)
 end
 

--- a/tests/test-foreign_values/stub-generator/driver.ml
+++ b/tests/test-foreign_values/stub-generator/driver.ml
@@ -1,0 +1,10 @@
+(*
+ * Copyright (c) 2014 Jeremy Yallop.
+ *
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+(* Stub generation driver for the foreign value tests. *)
+
+let () = Tests_common.run Sys.argv (module Functions.Stubs)

--- a/tests/test-foreign_values/stub-generator/driver.ml
+++ b/tests/test-foreign_values/stub-generator/driver.ml
@@ -7,4 +7,6 @@
 
 (* Stub generation driver for the foreign value tests. *)
 
-let () = Tests_common.run Sys.argv (module Functions.Stubs)
+let cheader = "extern char **environ;"
+
+let () = Tests_common.run ~cheader Sys.argv (module Functions.Stubs)

--- a/tests/test-foreign_values/stubs/functions.ml
+++ b/tests/test-foreign_values/stubs/functions.ml
@@ -1,0 +1,28 @@
+(*
+ * Copyright (c) 2014 Jeremy Yallop.
+ *
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+(* Bindings for the foreign value tests. *)
+
+open Ctypes
+
+module Stubs (F: Cstubs.FOREIGN) =
+struct
+  let s : [`global_struct] structure typ = structure "global_struct"
+  let (-:) ty label = field s label ty
+  let len = size_t       -: "len"
+  let str = array 1 char -: "str"
+  let () = seal s
+
+  let global_struct = F.foreign_value "global_struct" s
+
+  let plus =
+    F.foreign_value "plus_callback"
+      (Foreign.funptr_opt (int @-> int @-> returning int))
+
+  let sum = F.foreign "sum_range_with_plus_callback"
+      (int @-> int @-> returning int)
+end

--- a/tests/test-foreign_values/stubs/functions.ml
+++ b/tests/test-foreign_values/stubs/functions.ml
@@ -9,7 +9,7 @@
 
 open Ctypes
 
-module Stubs (F: Cstubs.FOREIGN) =
+module Common (F: Cstubs.FOREIGN) =
 struct
   let s : [`global_struct] structure typ = structure "global_struct"
   let (-:) ty label = field s label ty
@@ -25,6 +25,11 @@ struct
 
   let sum = F.foreign "sum_range_with_plus_callback"
       (int @-> int @-> returning int)
+end
 
+
+module Stubs (F: Cstubs.FOREIGN) =
+struct
+  include Common(F)
   let environ = F.foreign_value "environ" (ptr string_opt)
 end

--- a/tests/test-foreign_values/stubs/functions.ml
+++ b/tests/test-foreign_values/stubs/functions.ml
@@ -25,4 +25,6 @@ struct
 
   let sum = F.foreign "sum_range_with_plus_callback"
       (int @-> int @-> returning int)
+
+  let environ = F.foreign_value "environ" (ptr string_opt)
 end

--- a/tests/test-foreign_values/test_foreign_values.ml
+++ b/tests/test-foreign_values/test_foreign_values.ml
@@ -1,5 +1,5 @@
 (*
- * Copyright (c) 2013 Jeremy Yallop.
+ * Copyright (c) 2013-2014 Jeremy Yallop.
  *
  * This file is distributed under the terms of the MIT License.
  * See the file LICENSE for details.
@@ -9,60 +9,58 @@ open OUnit2
 open Ctypes
 
 
-let testlib = Dl.(dlopen ~filename:"clib/libtest_functions.so" ~flags:[RTLD_NOW])
+module Common_tests(S : Cstubs.FOREIGN with type 'a fn = 'a) =
+struct
+  module M = Functions.Stubs(S)
+  open M
+
+  (*
+    Retrieve a struct exposed as a global value. 
+  *)
+  let test_retrieving_struct _ =
+    let p = CArray.start (getf !@global_struct str) in
+    let stringp = from_voidp string (to_voidp (allocate (ptr char) p)) in
+    begin
+      let expected = "global string" in
+      assert_equal expected !@stringp;
+      assert_equal
+        (Unsigned.Size_t.of_int (String.length expected))
+        (getf !@global_struct len)
+    end
 
 
-(*
-  Retrieve a struct exposed as a global value. 
-*)
-let test_retrieving_struct _ =
-  let s = structure "global_struct" in
-  let (-:) ty label = field s label ty in
-  let len = size_t       -: "len" in
-  let str = array 1 char -: "str" in
-  let () = seal s in
-  let global_struct = Foreign.foreign_value "global_struct" s ~from:testlib in
-  let p = CArray.start (getf !@global_struct str) in
-  let stringp = from_voidp string (to_voidp (allocate (ptr char) p)) in
-  begin
-    let expected = "global string" in
-    assert_equal expected !@stringp;
-    assert_equal
-      (Unsigned.Size_t.of_int (String.length expected))
-      (getf !@global_struct len)
-  end
+  (*
+    Store a reference to an OCaml function as a global function pointer.
+  *)
+  let test_global_callback _ =
+    begin
+      assert_equal !@plus None;
+
+      plus <-@ Some (+);
+
+      assert_equal (sum 1 10) 55;
+
+      plus <-@ None;
+    end
+end
 
 
-(*
-  Store a reference to an OCaml function as a global function pointer.
-*)
-let test_global_callback _ =
-  let open Foreign in
-
-  let plus =
-    foreign_value ~from:testlib "plus_callback"
-      (funptr_opt (int @-> int @-> returning int)) in
-
-  let sum =
-    foreign ~from:testlib "sum_range_with_plus_callback"
-      (int @-> int @-> returning int) in
-  
-  begin
-    assert_equal !@plus None;
-    
-    plus <-@ Some (+);
-    
-    assert_equal (sum 1 10) 55;
-  end
-
+module Foreign_tests = Common_tests(Tests_common.Foreign_binder)
+module Stub_tests = Common_tests(Generated_bindings)
 
 
 let suite = "Foreign value tests" >:::
-  ["retrieving global struct"
-    >:: test_retrieving_struct;
+  ["retrieving global struct (foreign)"
+    >:: Foreign_tests.test_retrieving_struct;
 
-   "global callback function"
-    >:: test_global_callback;
+   "global callback function (foreign)"
+    >:: Foreign_tests.test_global_callback;
+
+   "retrieving global struct (stubs)"
+    >:: Stub_tests.test_retrieving_struct;
+
+   "global callback function (stubs)"
+    >:: Stub_tests.test_global_callback;
   ]
 
 

--- a/tests/test-foreign_values/test_foreign_values.ml
+++ b/tests/test-foreign_values/test_foreign_values.ml
@@ -11,7 +11,7 @@ open Ctypes
 
 module Common_tests(S : Cstubs.FOREIGN with type 'a fn = 'a) =
 struct
-  module M = Functions.Stubs(S)
+  module M = Functions.Common(S)
   open M
 
   (*
@@ -42,7 +42,13 @@ struct
 
       plus <-@ None;
     end
+end
 
+
+module Make_stub_tests(S : Cstubs.FOREIGN with type 'a fn = 'a) =
+struct
+  module N = Functions.Stubs(S)
+  open N
 
   (*
     Read environment variables from the 'environ' global.
@@ -69,7 +75,11 @@ end
 
 
 module Foreign_tests = Common_tests(Tests_common.Foreign_binder)
-module Stub_tests = Common_tests(Generated_bindings)
+module Stub_tests =
+struct
+  include Common_tests(Generated_bindings)
+  include Make_stub_tests(Generated_bindings)
+end
 
 
 let suite = "Foreign value tests" >:::
@@ -78,9 +88,6 @@ let suite = "Foreign value tests" >:::
 
    "global callback function (foreign)"
     >:: Foreign_tests.test_global_callback;
-
-   "reading from 'environ' (foreign)"
-    >:: Foreign_tests.test_environ;
 
    "retrieving global struct (stubs)"
     >:: Stub_tests.test_retrieving_struct;

--- a/tests/tests-common/tests_common.ml
+++ b/tests/tests-common/tests_common.ml
@@ -31,6 +31,7 @@ module Foreign_binder : Cstubs.FOREIGN with type 'a fn = 'a =
 struct
   type 'a fn = 'a
   let foreign name fn = Foreign.foreign name fn
+  let foreign_value name fn = Foreign.foreign_value name fn
 end
 
 module type STUBS = functor  (F : Cstubs.FOREIGN) -> sig end


### PR DESCRIPTION
Add a `foreign_value` function to Cstubs for accessing global variables:

```ocaml
val foreign_value : string -> 'a Ctypes.typ -> 'a Ctypes.ptr fn
```

The behaviour is analogous to [Foreign.foreign_value][foreign-foreign-value]: given a type representation `t` and the name of a global value `n`, `foreign_value t n` returns the address of the global.  For example, POSIX specifies a global variable holding the process environment:

```C
char **environ;
```

To bind to `environ` we might write

```ocaml
foreign_value "environ" (ptr string_opt)
```

which returns a value of type `string option ptr ptr` (corresponding to `char ***`) which can be used to read and write to `environ`.

Closes #136.

[foreign-foreign-value]: http://ocamllabs.github.io/ocaml-ctypes/Foreign.html#VALforeign_value

