### PR TITLE
Support for retrieving constants from C.

### DIFF
--- a/Makefile.tests
+++ b/Makefile.tests
@@ -229,6 +229,48 @@ $(BUILDDIR)/test-structs-ml-stub-generator.native: $(BUILDDIR)/tests/test-struct
 $(BUILDDIR)/tests/test-structs/generated_struct_stubs.c: $(BUILDDIR)/test-structs-stub-generator.native
 	$< --c-struct-file $@
 
+test-constants-stubs.dir  = tests/test-constants/stubs
+test-constants-stubs.threads = yes
+test-constants-stubs.subproject_deps = ctypes cstubs \
+   ctypes-foreign-base ctypes-foreign-unthreaded tests-common
+test-constants-stubs: PROJECT=test-constants-stubs
+test-constants-stubs: $$(LIB_TARGETS)
+
+test-constants-stub-generator.dir = tests/test-constants/stub-generator
+test-constants-stub-generator.threads = yes
+test-constants-stub-generator.subproject_deps = ctypes cstubs \
+     ctypes-foreign-base ctypes-foreign-unthreaded test-constants-stubs tests-common
+test-constants-stub-generator.deps = str bigarray bytes
+test-constants-stub-generator: PROJECT=test-constants-stub-generator
+test-constants-stub-generator: $$(NATIVE_TARGET)
+
+test-constants.dir = tests/test-constants
+test-constants.threads = yes
+test-constants.deps = str bigarray oUnit bytes
+test-constants.subproject_deps = ctypes ctypes-foreign-base \
+  ctypes-foreign-unthreaded cstubs test-constants-stubs tests-common
+test-constants.link_flags = -L$(BUILDDIR)/clib -ltest_functions
+test-constants: PROJECT=test-constants
+test-constants: $$(NATIVE_TARGET)
+
+test-constants-generated: \
+  tests/test-constants/generated_bindings.ml \
+  tests/test-constants/generated_stubs.c \
+  tests/test-constants/generated_struct_bindings.ml \
+  $(BUILDDIR)/tests/test-constants/generated_struct_stubs.c
+
+tests/test-constants/generated_stubs.c: $(BUILDDIR)/test-constants-stub-generator.native
+	$< --c-file $@
+tests/test-constants/generated_bindings.ml: $(BUILDDIR)/test-constants-stub-generator.native
+	$< --ml-file $@
+tests/test-constants/generated_struct_bindings.ml: $(BUILDDIR)/test-constants-ml-stub-generator.native
+	$< > $@
+$(BUILDDIR)/test-constants-ml-stub-generator.native: $(BUILDDIR)/tests/test-constants/generated_struct_stubs.c
+	$(CC) -I `$(OCAMLFIND) ocamlc -where | sed 's|\r$$||'` $(CFLAGS) $(LDFLAGS) $(WINLDFLAGS) -o $@ $^
+$(BUILDDIR)/tests/test-constants/generated_struct_stubs.c: $(BUILDDIR)/test-constants-stub-generator.native
+	$< --c-struct-file $@
+
+
 test-finalisers.dir = tests/test-finalisers
 test-finalisers.threads = yes
 test-finalisers.deps = str bigarray oUnit bytes
@@ -719,6 +761,7 @@ TESTS += test-builtins-stubs test-builtins-stub-generator test-builtins-generate
 TESTS += test-macros-stubs test-macros-stub-generator test-macros-generated test-macros
 TESTS += test-higher_order-stubs test-higher_order-stub-generator test-higher_order-generated test-higher_order
 TESTS += test-structs-stubs test-structs-stub-generator test-structs-generated test-structs
+TESTS += test-constants-stubs test-constants-stub-generator test-constants-generated test-constants
 TESTS += test-finalisers
 TESTS += test-cstdlib-stubs test-cstdlib-stub-generator test-cstdlib-generated test-cstdlib
 TESTS += test-sizeof

--- a/src/cstubs/cstubs.mli
+++ b/src/cstubs/cstubs.mli
@@ -14,6 +14,19 @@ sig
     include Ctypes_types.TYPE
     type 'a const
     val constant : string -> 'a typ -> 'a const
+    (** [constant name typ] retrieves the value of the compile-time constant
+        [name] of type [typ].  It can be used to retrieve enum constants,
+        #defined values and other integer constant expressions.
+
+        The type [typ] must be either an integer type such as [bool], [char],
+        [int], [uint8], etc., or a view (or perhaps multiple views) where the
+        underlying type is an integer type.
+
+        When the value of the constant cannot be represented in the type there
+        will typically be a diagnostic from either the C compiler or the OCaml
+        compiler.  For example, gcc will say
+
+           warning: overflow in implicit constant conversion *)
   end
 
   module type BINDINGS = functor (F : TYPE) -> sig end

--- a/src/cstubs/cstubs.mli
+++ b/src/cstubs/cstubs.mli
@@ -9,7 +9,14 @@
 
 module Types :
 sig
-  module type BINDINGS = functor (F : Ctypes_types.TYPE) -> sig end
+  module type TYPE =
+  sig
+    include Ctypes_types.TYPE
+    type 'a const
+    val constant : string -> 'a typ -> 'a const
+  end
+
+  module type BINDINGS = functor (F : TYPE) -> sig end
 
   val write_c : Format.formatter -> (module BINDINGS) -> unit
 end

--- a/src/cstubs/cstubs_c_language.ml
+++ b/src/cstubs/cstubs_c_language.ml
@@ -11,9 +11,9 @@ open Static
 
 let fresh_var =
   let var_counter = ref 0 in
-  fun () ->
+  fun ?(prefix="x") () ->
     incr var_counter;
-    Printf.sprintf "x%d" !var_counter
+    Printf.sprintf "%s%d" prefix !var_counter
 
 type ty = Ty : _ typ -> ty
 type tfn = Fn : _ fn -> tfn

--- a/src/cstubs/cstubs_structs.ml
+++ b/src/cstubs/cstubs_structs.ml
@@ -7,7 +7,15 @@
 
 open Ctypes
 
-module type BINDINGS = functor (F : Ctypes_types.TYPE) -> sig end
+module type TYPE =
+sig
+  include Ctypes_types.TYPE
+
+  type 'a const
+  val constant : string -> 'a typ -> 'a const
+end
+
+module type BINDINGS = functor (F : TYPE) -> sig end
 
 let cstring s =
   (* Format a string for output as a C string literal. *)
@@ -114,64 +122,112 @@ let write_seal fmt specs =
      "  | _ ->";
      "    raise (Unsupported \"Sealing a non-structured type\")"]
 
-let write_ml fmt fields structures =
+let primitive_format_string : type a. a Primitives.prim -> string =
+  fun p ->
+    let open Primitives in
+    let sprintf = Printf.sprintf in
+    let fail () =
+      Printf.kprintf failwith "Cannot retrieve constants of type %s"
+        (Ctypes_primitives.name p)
+    in
+    match p, Ctypes_primitives.format_string p with
+    | _, None -> fail ()
+    | Char, Some fmt -> sprintf "Char.chr (((%s) + 256) mod 256)" fmt
+    | Schar, Some fmt -> fmt
+    | Uchar, Some fmt -> sprintf "Unsigned.UChar.of_string \"%s\"" fmt
+    | Bool, Some fmt -> sprintf "((%s) <> 0)" fmt
+    | Short, Some fmt -> fmt
+    | Int, Some fmt -> fmt
+    | Long, Some fmt -> sprintf "Signed.Long.of_string \"%s\"" fmt
+    | Llong, Some fmt -> sprintf "Signed.LLong.of_string \"%s\"" fmt
+    | Ushort, Some fmt -> sprintf "Unsigned.UShort.of_string \"%s\"" fmt
+    | Uint, Some fmt -> sprintf "Unsigned.UInt.of_string \"%s\"" fmt
+    | Ulong, Some fmt -> sprintf "Unsigned.ULong.of_string \"%s\"" fmt
+    | Ullong, Some fmt -> sprintf "Unsigned.ULLong.of_string \"%s\"" fmt
+    | Size_t, Some fmt -> sprintf "Unsigned.Size_t.of_string \"%s\"" fmt
+    | Int8_t, Some fmt -> fmt
+    | Int16_t, Some fmt -> fmt
+    | Int32_t, Some fmt -> fmt ^"l"
+    | Int64_t, Some fmt -> fmt ^"L"
+    | Uint8_t, Some fmt -> sprintf "Unsigned.UInt8.of_string \"%s\"" fmt
+    | Uint16_t, Some fmt -> sprintf "Unsigned.UInt16.of_string \"%s\"" fmt
+    | Uint32_t, Some fmt -> sprintf "Unsigned.UInt32.of_string \"%s\"" fmt
+    | Uint64_t, Some fmt -> sprintf "Unsigned.UInt64.of_string \"%s\"" fmt
+    | Camlint, Some fmt -> fmt
+    | Nativeint, Some fmt -> fmt ^"n"
+    (* Integer constant expressions cannot have non-integer type *)
+    | Complex32, _ -> fail ()
+    | Complex64, _ -> fail ()
+    | Float, _ -> fail ()
+    | Double, _ -> fail ()
+
+let ml_pat_and_exp_of_typ : type a. a typ -> string * string =
+  fun ty -> 
+    match ty with
+    | Static.Primitive p ->
+      let pat = 
+        (Common.asprintf "Static.Primitive %a"
+           Ctypes_path.format_path
+           (Cstubs_public_name.constructor_cident_of_prim p))
+      and exp = primitive_format_string p in
+      (pat, exp)
+    | _ -> failwith "constant of non-primitive"
+
+let write_consts fmt consts =
+  let case =
+    function (name, Static.BoxedType ty) ->
+      let p, e = ml_pat_and_exp_of_typ ty in
+      Format.fprintf fmt "{@[<v 2>@\n";
+      (* Since printf is variadic we can't rely on implicit conversions.
+         We'll use assignment rather than casts to coerce to the correct type
+         because casts typically result in silent truncation whereas narrowing
+         assignments typically trigger warnings even on default compiler
+         settings. *)
+      Format.fprintf fmt "%a = (%s);@\n" (Ctypes.format_typ ~name:"v") ty name;
+      printf1 ~fmt
+        (Common.asprintf "  | %S, %s ->@\n    %s\n" name p e)
+        (fun fmt -> Format.fprintf fmt "v");
+      Format.fprintf fmt "@]@\n}@\n"
+  in
+  cases fmt consts
+    ["type 'a const = 'a";
+     "let constant (type t) name (t : t typ) : t = match name, t with"]
+    ~case
+    ["  | s, _ -> failwith (\"unmatched constant: \"^ s)"] 
+    
+
+let write_ml fmt fields structures consts =
   List.iter (puts ~fmt) mlprologue;
   write_field fmt fields;
-  write_seal fmt structures
+  write_seal fmt structures;
+  write_consts fmt consts
 
 let gen_c () =
-  let fields = ref [] and structures = ref [] in
-  let finally fmt = write_c fmt (fun fmt -> write_ml fmt !fields !structures) in
+  let fields = ref [] and structures = ref [] and consts = ref [] in
+  let finally fmt = write_c fmt (fun fmt -> write_ml fmt !fields !structures !consts) in
   let m = 
     (module struct
-      type _ typ = [`Struct of string | `Union of string | `Other]
-      type (_, _) field = unit
-      let structure tag = `Struct tag
-      let union tag = `Union tag
-      let field (s : _ typ) name _ = fields := (s, name) :: !fields
-      let seal (structure : _ typ) = structures := structure :: !structures
-      let abstract ~name ~size ~alignment = `Other
-      let view ?format_typ ?format ~read ~write _ = `Other
-      let typedef _ _ = `Other
-      let typ_of_bigarray_kind _ = `Other
-      let bigarray _ _ _ = `Other
-      let array _ _ = `Other
-      let ocaml_bytes = `Other
-      let ocaml_string = `Other
-      let string_opt = `Other
-      let string = `Other
-      let ptr_opt _ = `Other
-      let ptr _ = `Other
-      let complex64 = `Other
-      let complex32 = `Other
-      let double = `Other
-      let float = `Other
-      let ullong = `Other
-      let ulong = `Other
-      let uint = `Other
-      let ushort = `Other
-      let size_t = `Other
-      let uint64_t = `Other
-      let uint32_t = `Other
-      let uint16_t = `Other
-      let uint8_t = `Other
-      let bool = `Other
-      let uchar = `Other
-      let camlint = `Other
-      let int64_t = `Other
-      let int32_t = `Other
-      let int16_t = `Other
-      let int8_t = `Other
-      let nativeint = `Other
-      let llong = `Other
-      let long = `Other
-      let int = `Other
-      let short = `Other
-      let schar = `Other
-      let char = `Other
-      let void = `Other
-      let lift_typ _ = `Other
-     end : Ctypes_types.TYPE)
+      include Ctypes
+      let field (type s) (s : (_, s) structured typ) fname ftype =
+        let () = match s with 
+        | Static.Struct { Static.tag } ->
+          fields := (`Struct tag, fname) :: !fields
+        | Static.Union { Static.utag } ->
+          fields := (`Union utag, fname) :: !fields
+        | _ ->
+          ()
+        in { Static.ftype; foffset = -1; fname}
+      let seal (type s) (s : (_, s) structured typ) =
+        match s with
+        | Static.Struct { Static.tag } ->
+          structures := `Struct tag :: !structures
+        | Static.Union { Static.utag } ->
+          structures := `Union utag :: !structures
+        | _ ->
+          ()
+      type _ const = unit
+      let constant name ty  = consts := (name, Static.BoxedType ty) :: !consts
+     end : TYPE)
   in (m, finally)
 
 let write_c fmt (module B : BINDINGS) =

--- a/src/cstubs/cstubs_structs.ml
+++ b/src/cstubs/cstubs_structs.ml
@@ -161,9 +161,15 @@ let primitive_format_string : type a. a Primitives.prim -> string =
     | Float, _ -> fail ()
     | Double, _ -> fail ()
 
-let ml_pat_and_exp_of_typ : type a. a typ -> string * string =
+let rec ml_pat_and_exp_of_typ : type a. a typ -> string * string =
   fun ty -> 
     match ty with
+    | Static.View { Static.ty } ->
+      let p, e = ml_pat_and_exp_of_typ ty in
+      let x = Cstubs_c_language.fresh_var ~prefix:"read" () in
+      let p' = Printf.sprintf "Static.View { Static.read = %s; ty = %s }" x p
+      and e' = Printf.sprintf "(%s (%s))" x e in
+      (p', e')
     | Static.Primitive p ->
       let pat = 
         (Common.asprintf "Static.Primitive %a"

--- a/src/cstubs/cstubs_structs.ml
+++ b/src/cstubs/cstubs_structs.ml
@@ -184,6 +184,7 @@ let write_consts fmt consts =
     function (name, Static.BoxedType ty) ->
       let p, e = ml_pat_and_exp_of_typ ty in
       Format.fprintf fmt "{@[<v 2>@\n";
+      Format.fprintf fmt "enum { check_%s_const = (int)%s };@\n" name name;
       (* Since printf is variadic we can't rely on implicit conversions.
          We'll use assignment rather than casts to coerce to the correct type
          because casts typically result in silent truncation whereas narrowing

--- a/src/cstubs/cstubs_structs.mli
+++ b/src/cstubs/cstubs_structs.mli
@@ -5,6 +5,14 @@
  * See the file LICENSE for details.
  *)
 
-module type BINDINGS = functor (F : Ctypes_types.TYPE) -> sig end
+module type TYPE =
+sig
+  include Ctypes_types.TYPE
+
+  type 'a const
+  val constant : string -> 'a typ -> 'a const
+end
+
+module type BINDINGS = functor (F : TYPE) -> sig end
 
 val write_c : Format.formatter -> (module BINDINGS) -> unit

--- a/src/ctypes/type_info_stubs.c
+++ b/src/ctypes/type_info_stubs.c
@@ -40,7 +40,7 @@ value ctypes_read(value prim_, value buffer_)
   void *buf = CTYPES_ADDR_OF_FATPTR(buffer_);
   switch (Int_val(prim_))
   {
-   case Char: b = Val_int(*(char *)buf); break;
+   case Char: b = Val_int(*(unsigned char*)buf); break;
    case Schar: b = Val_int(*(signed char *)buf); break;
    case Uchar: b = ctypes_copy_uint8(*(unsigned char *)buf); break;
    case Bool: b = Val_bool(*(bool *)buf); break;
@@ -81,7 +81,7 @@ value ctypes_write(value prim_, value v, value buffer_)
   void *buf = CTYPES_ADDR_OF_FATPTR(buffer_);
   switch (Int_val(prim_))
   {
-   case Char: *(char *)buf = Int_val(v); break;
+   case Char: *(unsigned char *)buf = Int_val(v); break;
    case Schar: *(signed char *)buf = Int_val(v); break;
    case Uchar: *(unsigned char *)buf = Uint8_val(v); break;
    case Bool: *(bool *)buf = Bool_val(v); break;

--- a/tests/clib/test_functions.h
+++ b/tests/clib/test_functions.h
@@ -201,4 +201,6 @@ size_t alignmentof_u1(void);
 bool bool_and(bool, bool);
 int call_s5(struct s1 *, struct s5 *);
 
+enum letter { A, B, C = 10, D };
+
 #endif /* TEST_FUNCTIONS_H */

--- a/tests/test-constants/stub-generator/driver.ml
+++ b/tests/test-constants/stub-generator/driver.ml
@@ -1,0 +1,15 @@
+(*
+ * Copyright (c) 2014 Jeremy Yallop.
+ *
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+(* Stub generation driver for the constants tests. *)
+
+let cheader = "#include <limits.h>\n#include <stdbool.h>"
+
+let () = Tests_common.run Sys.argv
+   ~cheader
+   ~structs:(module Types.Struct_stubs)
+   (module functor (S: Cstubs.FOREIGN) -> struct end)

--- a/tests/test-constants/stubs/types.ml
+++ b/tests/test-constants/stubs/types.ml
@@ -48,4 +48,9 @@ struct
       ~read:Int32.neg ~write:Int32.neg
   let neg_INT16_MAX = constant "INT16_MAX" i32_inverted
   let neg_INT16_MIN = constant "INT16_MIN" i32_inverted
+
+  let _A = constant "A" int
+  let _B = constant "B" int
+  let _C = constant "C" int
+  let _D = constant "D" int
 end

--- a/tests/test-constants/stubs/types.ml
+++ b/tests/test-constants/stubs/types.ml
@@ -44,7 +44,7 @@ struct
   let _true = constant "true" bool
   let _false = constant "false" bool
 
-  let i32_inverted = Ctypes.view Ctypes.int32_t
+  let i32_inverted = view int32_t
       ~read:Int32.neg ~write:Int32.neg
   let neg_INT16_MAX = constant "INT16_MAX" i32_inverted
   let neg_INT16_MIN = constant "INT16_MIN" i32_inverted

--- a/tests/test-constants/stubs/types.ml
+++ b/tests/test-constants/stubs/types.ml
@@ -1,0 +1,51 @@
+(*
+ * Copyright (c) 2014 Jeremy Yallop.
+ *
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+open Ctypes
+
+module Struct_stubs(S : Cstubs.Types.TYPE) =
+struct
+  open S
+
+  let _SCHAR_MIN = constant "SCHAR_MIN" schar
+  let _SCHAR_MAX = constant "SCHAR_MAX" schar
+  let _UCHAR_MAX = constant "UCHAR_MAX" uchar
+  let _CHAR_MIN = constant "CHAR_MIN" char
+  let _CHAR_MAX = constant "CHAR_MAX" char
+  let _SHRT_MIN = constant "SHRT_MIN" short
+  let _SHRT_MAX = constant "SHRT_MAX" short
+  let _USHRT_MAX = constant "USHRT_MAX" ushort
+  let _INT_MIN = constant "INT_MIN" long
+  let _INT_MAX = constant "INT_MAX" long
+  let _UINT_MAX = constant "UINT_MAX" uint
+  let _LONG_MAX = constant "LONG_MAX" long
+  let _LONG_MIN = constant "LONG_MIN" long
+  let _ULONG_MAX = constant "ULONG_MAX" ulong
+  let _LLONG_MAX = constant "LLONG_MAX" llong
+  let _LLONG_MIN = constant "LLONG_MIN" llong
+  let _ULLONG_MAX = constant "ULLONG_MAX" ullong
+  let _INT8_MIN = constant "INT8_MIN" int8_t
+  let _INT16_MIN = constant "INT16_MIN" int16_t
+  let _INT32_MIN = constant "INT32_MIN" int32_t
+  let _INT64_MIN = constant "INT64_MIN" int64_t
+  let _INT8_MAX = constant "INT8_MAX" int8_t
+  let _INT16_MAX = constant "INT16_MAX" int16_t
+  let _INT32_MAX = constant "INT32_MAX" int32_t
+  let _INT64_MAX = constant "INT64_MAX" int64_t
+  let _UINT8_MAX = constant "UINT8_MAX" uint8_t
+  let _UINT16_MAX = constant "UINT16_MAX" uint16_t
+  let _UINT32_MAX = constant "UINT32_MAX" uint32_t
+  let _UINT64_MAX = constant "UINT64_MAX" uint64_t
+  let _SIZE_MAX = constant "SIZE_MAX" size_t
+  let _true = constant "true" bool
+  let _false = constant "false" bool
+
+  let i32_inverted = Ctypes.view Ctypes.int32_t
+      ~read:Int32.neg ~write:Int32.neg
+  let neg_INT16_MAX = constant "INT16_MAX" i32_inverted
+  let neg_INT16_MIN = constant "INT16_MIN" i32_inverted
+end

--- a/tests/test-constants/test_constants.ml
+++ b/tests/test-constants/test_constants.ml
@@ -15,10 +15,11 @@ let testlib = Dl.(dlopen ~filename:"clib/libtest_functions.so" ~flags:[RTLD_NOW]
 module Constants = Types.Struct_stubs(Generated_struct_bindings)
 
 
+let constant name typ =
+  Foreign.foreign ~from:testlib ("retrieve_"^ name) (void @-> returning typ) ()
+
+
 let test_retrieve_constants _ =
-  let constant name typ =
-    Foreign.foreign ~from:testlib ("retrieve_"^ name) (void @-> returning typ) ()
-  in
   begin
     assert_equal Constants._LONG_MIN (constant "LONG_MIN" long);
     assert_equal Constants._SCHAR_MIN (constant "SCHAR_MIN" Ctypes.schar);
@@ -54,9 +55,26 @@ let test_retrieve_constants _ =
   end
 
 
+let test_retrieve_views _ =
+  begin
+    assert_equal
+      Constants.neg_INT16_MAX
+      (Int32.(neg (of_int (constant "INT16_MAX" Ctypes.int16_t))))
+    ;
+      
+    assert_equal
+      Constants.neg_INT16_MIN
+      (Int32.(neg (of_int (constant "INT16_MIN" Ctypes.int16_t))))
+    ;
+  end
+
+
 let suite = "Constant tests" >:::
   ["retrieving values of various integer types"
    >:: test_retrieve_constants;
+
+   "retrieving values of view type"
+   >:: test_retrieve_views;
   ]
 
 

--- a/tests/test-constants/test_constants.ml
+++ b/tests/test-constants/test_constants.ml
@@ -1,0 +1,64 @@
+(*
+ * Copyright (c) 2014 Jeremy Yallop.
+ *
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+open OUnit2
+open Ctypes
+
+
+let testlib = Dl.(dlopen ~filename:"clib/libtest_functions.so" ~flags:[RTLD_NOW])
+
+
+module Constants = Types.Struct_stubs(Generated_struct_bindings)
+
+
+let test_retrieve_constants _ =
+  let constant name typ =
+    Foreign.foreign ~from:testlib ("retrieve_"^ name) (void @-> returning typ) ()
+  in
+  begin
+    assert_equal Constants._LONG_MIN (constant "LONG_MIN" long);
+    assert_equal Constants._SCHAR_MIN (constant "SCHAR_MIN" Ctypes.schar);
+    assert_equal Constants._SCHAR_MAX (constant "SCHAR_MAX" Ctypes.schar);
+    assert_equal Constants._UCHAR_MAX (constant "UCHAR_MAX" Ctypes.uchar);
+    assert_equal Constants._CHAR_MIN (constant "CHAR_MIN" Ctypes.char);
+    assert_equal Constants._CHAR_MAX (constant "CHAR_MAX" Ctypes.char);
+    assert_equal Constants._SHRT_MIN (constant "SHRT_MIN" Ctypes.short);
+    assert_equal Constants._SHRT_MAX (constant "SHRT_MAX" Ctypes.short);
+    assert_equal Constants._USHRT_MAX (constant "USHRT_MAX" Ctypes.ushort);
+    assert_equal Constants._UINT_MAX (constant "UINT_MAX" Ctypes.uint);
+    assert_equal Constants._LONG_MAX (constant "LONG_MAX" Ctypes.long);
+    assert_equal Constants._LONG_MIN (constant "LONG_MIN" Ctypes.long);
+    assert_equal Constants._ULONG_MAX (constant "ULONG_MAX" Ctypes.ulong);
+    assert_equal Constants._LLONG_MAX (constant "LLONG_MAX" Ctypes.llong);
+    assert_equal Constants._LLONG_MIN (constant "LLONG_MIN" Ctypes.llong);
+    assert_equal Constants._ULLONG_MAX (constant "ULLONG_MAX" Ctypes.ullong);
+    assert_equal Constants._INT8_MIN (constant "INT8_MIN" Ctypes.int8_t);
+    assert_equal Constants._INT16_MIN (constant "INT16_MIN" Ctypes.int16_t);
+    assert_equal Constants._INT32_MIN (constant "INT32_MIN" Ctypes.int32_t);
+    assert_equal Constants._INT64_MIN (constant "INT64_MIN" Ctypes.int64_t);
+    assert_equal Constants._INT8_MAX (constant "INT8_MAX" Ctypes.int8_t);
+    assert_equal Constants._INT16_MAX (constant "INT16_MAX" Ctypes.int16_t);
+    assert_equal Constants._INT32_MAX (constant "INT32_MAX" Ctypes.int32_t);
+    assert_equal Constants._INT64_MAX (constant "INT64_MAX" Ctypes.int64_t);
+    assert_equal Constants._UINT8_MAX (constant "UINT8_MAX" Ctypes.uint8_t);
+    assert_equal Constants._UINT16_MAX (constant "UINT16_MAX" Ctypes.uint16_t);
+    assert_equal Constants._UINT32_MAX (constant "UINT32_MAX" Ctypes.uint32_t);
+    assert_equal Constants._UINT64_MAX (constant "UINT64_MAX" Ctypes.uint64_t);
+    assert_equal Constants._SIZE_MAX (constant "SIZE_MAX" Ctypes.size_t);
+    assert_equal Constants._true true;
+    assert_equal Constants._false false;
+  end
+
+
+let suite = "Constant tests" >:::
+  ["retrieving values of various integer types"
+   >:: test_retrieve_constants;
+  ]
+
+
+let _ =
+  run_test_tt_main suite

--- a/tests/test-constants/test_constants.ml
+++ b/tests/test-constants/test_constants.ml
@@ -69,12 +69,23 @@ let test_retrieve_views _ =
   end
 
 
+let test_retrieve_enums _ =
+  begin
+    assert_equal
+      [0; 1; 10; 11]
+      Constants.([_A; _B; _C; _D])
+  end
+
+
 let suite = "Constant tests" >:::
   ["retrieving values of various integer types"
    >:: test_retrieve_constants;
 
    "retrieving values of view type"
    >:: test_retrieve_views;
+
+   "retrieving enumeration constants"
+   >:: test_retrieve_enums;
   ]
 
 


### PR DESCRIPTION
This pull request adds support for retrieving constants (`#define`s, enums, etc.) from C.

There's a new function

```ocaml
val constant : string -> 'a typ -> 'a const
```

which retrieves the value of a named compile-time constant of a given type.  It can be used to retrieve enum constants, #defined values and other integer constant expressions.

The type `typ` must be either an integer type such as `bool`, `char`, `int`, `uint8`, etc., or a view (or perhaps multiple views) where the underlying type is an integer type.

When the value of the constant cannot be represented in the type there will typically be a diagnostic from either the C compiler or the OCaml compiler.  For example, gcc will say

```
warning: overflow in implicit constant conversion
```

Closes #235.
