### PR TITLE
Add support for enum types

### DIFF
--- a/Makefile.tests
+++ b/Makefile.tests
@@ -188,6 +188,68 @@ tests/test-higher_order/generated_stubs.c: $(BUILDDIR)/test-higher_order-stub-ge
 tests/test-higher_order/generated_bindings.ml: $(BUILDDIR)/test-higher_order-stub-generator.native
 	$< --ml-file $@
 
+test-enums-struct-stubs.dir  = tests/test-enums/struct-stubs
+test-enums-struct-stubs.threads = yes
+test-enums-struct-stubs.subproject_deps = ctypes cstubs \
+   ctypes-foreign-base ctypes-foreign-unthreaded tests-common
+test-enums-struct-stubs: PROJECT=test-enums-struct-stubs
+test-enums-struct-stubs: $$(LIB_TARGETS)
+
+test-enums-stubs.dir  = tests/test-enums/stubs
+test-enums-stubs.threads = yes
+test-enums-stubs.extra_mls = generated_struct_bindings.ml
+test-enums-stubs.subproject_deps = ctypes cstubs \
+   test-enums-struct-stubs \
+   test-enums-struct-stubs-generator \
+   ctypes-foreign-base ctypes-foreign-unthreaded tests-common
+test-enums-stubs: PROJECT=test-enums-stubs
+test-enums-stubs: $$(LIB_TARGETS)
+
+test-enums-stub-generator.dir = tests/test-enums/stub-generator
+test-enums-stub-generator.threads = yes
+test-enums-stub-generator.subproject_deps = ctypes cstubs \
+     test-enums-struct-stubs \
+     ctypes-foreign-base ctypes-foreign-unthreaded test-enums-stubs tests-common
+test-enums-stub-generator.deps = str bigarray bytes
+test-enums-stub-generator: PROJECT=test-enums-stub-generator
+test-enums-stub-generator: $$(NATIVE_TARGET)
+
+test-enums-struct-stub-generator.dir = tests/test-enums/struct-stub-generator
+test-enums-struct-stub-generator.threads = yes
+test-enums-struct-stub-generator.subproject_deps = ctypes cstubs \
+     ctypes-foreign-base ctypes-foreign-unthreaded test-enums-struct-stubs tests-common
+test-enums-struct-stub-generator.deps = str bigarray bytes
+test-enums-struct-stub-generator: PROJECT=test-enums-struct-stub-generator
+test-enums-struct-stub-generator: $$(NATIVE_TARGET)
+
+test-enums.dir = tests/test-enums
+test-enums.threads = yes
+test-enums.deps = str bigarray oUnit bytes
+test-enums.subproject_deps = ctypes ctypes-foreign-base \
+  ctypes-foreign-unthreaded cstubs test-enums-struct-stubs test-enums-stubs tests-common
+test-enums.link_flags = -L$(BUILDDIR)/clib -ltest_functions
+test-enums: PROJECT=test-enums
+test-enums: $$(NATIVE_TARGET)
+
+test-enums-structs-generated: \
+  tests/test-enums/stubs/generated_struct_bindings.ml \
+  $(BUILDDIR)/tests/test-enums/generated_struct_stubs.c
+
+test-enums-generated: \
+  tests/test-enums/generated_bindings.ml \
+  tests/test-enums/generated_stubs.c \
+
+tests/test-enums/generated_stubs.c: $(BUILDDIR)/test-enums-stub-generator.native
+	$< --c-file $@
+tests/test-enums/generated_bindings.ml: $(BUILDDIR)/test-enums-stub-generator.native
+	$< --ml-file $@
+tests/test-enums/stubs/generated_struct_bindings.ml: $(BUILDDIR)/test-enums-ml-struct-stub-generator.native
+	$< > $@
+$(BUILDDIR)/test-enums-ml-struct-stub-generator.native: $(BUILDDIR)/tests/test-enums/generated_struct_stubs.c
+	$(CC) -I `$(OCAMLFIND) ocamlc -where | sed 's|\r$$||'` $(CFLAGS) $(LDFLAGS) $(WINLDFLAGS) -o $@ $^
+$(BUILDDIR)/tests/test-enums/generated_struct_stubs.c: $(BUILDDIR)/test-enums-struct-stub-generator.native
+	$< --c-struct-file $@
+
 test-structs-stubs.dir  = tests/test-structs/stubs
 test-structs-stubs.threads = yes
 test-structs-stubs.subproject_deps = ctypes cstubs \
@@ -786,6 +848,7 @@ TESTS += test-variadic-stubs test-variadic-stub-generator test-variadic-generate
 TESTS += test-builtins-stubs test-builtins-stub-generator test-builtins-generated test-builtins
 TESTS += test-macros-stubs test-macros-stub-generator test-macros-generated test-macros
 TESTS += test-higher_order-stubs test-higher_order-stub-generator test-higher_order-generated test-higher_order
+TESTS += test-enums-struct-stubs test-enums-struct-stub-generator test-enums-structs-generated test-enums-stubs test-enums-stub-generator test-enums-generated test-enums
 TESTS += test-structs-stubs test-structs-stub-generator test-structs-generated test-structs
 TESTS += test-constants-stubs test-constants-stub-generator test-constants-generated test-constants
 TESTS += test-finalisers

--- a/src/cstubs/cstubs.mli
+++ b/src/cstubs/cstubs.mli
@@ -30,6 +30,37 @@ sig
            warning: overflow in implicit constant conversion *)
 
     val enum : string -> ?unexpected:(int64 -> 'a) -> ('a * int64 const) list -> 'a typ
+    (** [enum name ?unexpected alist] builds a type representation for the
+        enum named [name].  The size and alignment are retrieved so that the
+        resulting type can be used everywhere an integer type can be used: as
+        an array element or struct member, as an argument or return value,
+        etc.
+
+        The value [alist] is an association list of OCaml values and values
+        retrieved by the [constant] function.  For example, to expose the enum
+
+          enum letters { A, B, C = 10, D }; 
+
+        you might first retrieve the values of the enumeration constants:
+
+          let a = constant "A" int64_t
+          and b = constant "B" int64_t
+          and c = constant "C" int64_t
+          and d = constant "D" int64_t
+
+        and then build the enumeration type
+
+          let letters = enum "letters" [
+             `A, a;
+             `B, b;
+             `C, c;
+             `D, d;
+          ] ~unexpected:(fun i -> `E i)
+
+        The [unexpected] function specifies the value to return in the case
+        that some unexpected value is encountered -- for example, if a
+        function with the return type 'enum letters' actually returns the
+        value [-1]. *)
   end
 
   module type BINDINGS = functor (F : TYPE) -> sig end

--- a/src/cstubs/cstubs.mli
+++ b/src/cstubs/cstubs.mli
@@ -12,6 +12,7 @@ sig
   module type TYPE =
   sig
     include Ctypes_types.TYPE
+
     type 'a const
     val constant : string -> 'a typ -> 'a const
     (** [constant name typ] retrieves the value of the compile-time constant
@@ -27,6 +28,8 @@ sig
         compiler.  For example, gcc will say
 
            warning: overflow in implicit constant conversion *)
+
+    val enum : string -> ?unexpected:(int64 -> 'a) -> ('a * int64 const) list -> 'a typ
   end
 
   module type BINDINGS = functor (F : TYPE) -> sig end

--- a/src/cstubs/cstubs_internals.mli
+++ b/src/cstubs/cstubs_internals.mli
@@ -84,3 +84,6 @@ type 'a prim = 'a Primitives.prim =
 | Double : float prim
 | Complex32 : Complex.t prim
 | Complex64 : Complex.t prim
+
+val build_enum_type :
+  string -> Static.arithmetic -> ?unexpected:(int64 -> 'a) -> ('a * int64) list -> 'a typ

--- a/src/cstubs/cstubs_structs.mli
+++ b/src/cstubs/cstubs_structs.mli
@@ -11,6 +11,8 @@ sig
 
   type 'a const
   val constant : string -> 'a typ -> 'a const
+
+  val enum : string -> ?unexpected:(int64 -> 'a) -> ('a * int64 const) list -> 'a typ
 end
 
 module type BINDINGS = functor (F : TYPE) -> sig end

--- a/src/ctypes/ctypes_primitives.h
+++ b/src/ctypes/ctypes_primitives.h
@@ -9,6 +9,8 @@
 #define CTYPES_PRIMITIVES_H
 
 #include <limits.h>
+#include <assert.h>
+
 #include <stdint.h>
 
 #include "ctypes_unsigned_stubs.h"
@@ -109,5 +111,73 @@ enum ctypes_primitive {
 #else
 # error "No suitable OCaml type available for representing size_t values"
 #endif
+
+
+/* Detection of arithmetic types */
+enum ctypes_arithmetic_type {
+  Ctypes_Int8,
+  Ctypes_Int16,
+  Ctypes_Int32,
+  Ctypes_Int64,
+  Ctypes_Uint8,
+  Ctypes_Uint16,
+  Ctypes_Uint32,
+  Ctypes_Uint64,
+  Ctypes_Float,
+  Ctypes_Double
+};
+
+#define CTYPES_FLOATING_FLAG_BIT 15
+#define CTYPES_UNSIGNED_FLAG_BIT 14
+#define CTYPES_FLOATING ((size_t)1u << CTYPES_FLOATING_FLAG_BIT)
+#define CTYPES_UNSIGNED ((size_t)1u << CTYPES_UNSIGNED_FLAG_BIT)
+#define CTYPES_CHECK_FLOATING(TYPENAME) \
+  ((unsigned)(((TYPENAME) 0.5) != 0) << CTYPES_FLOATING_FLAG_BIT)
+#define CTYPES_CHECK_UNSIGNED(TYPENAME) \
+  ((unsigned)(((TYPENAME) -1) > 0) << CTYPES_UNSIGNED_FLAG_BIT)
+#define CTYPES_CLASSIFY(TYPENAME) (CTYPES_CHECK_FLOATING(TYPENAME) \
+                                 | CTYPES_CHECK_UNSIGNED(TYPENAME))
+#define CTYPES_ARITHMETIC_TYPEINFO(TYPENAME) (CTYPES_CLASSIFY(TYPENAME) \
+                                            | sizeof(TYPENAME))
+#define CTYPES_CLASSIFY_ARITHMETIC_TYPE(TYPENAME) \
+  ctypes_classify_arithmetic_type(CTYPES_ARITHMETIC_TYPEINFO(TYPENAME))
+
+static inline
+enum ctypes_arithmetic_type ctypes_classify_arithmetic_type(size_t typeinfo)
+{
+  switch (typeinfo)
+  {
+  case CTYPES_FLOATING | sizeof(float):    return Ctypes_Float;
+  case CTYPES_FLOATING | sizeof(double):   return Ctypes_Double;
+  case CTYPES_UNSIGNED | sizeof(uint8_t):  return Ctypes_Uint8;
+  case CTYPES_UNSIGNED | sizeof(uint16_t): return Ctypes_Uint16;
+  case CTYPES_UNSIGNED | sizeof(uint32_t): return Ctypes_Uint32;
+  case CTYPES_UNSIGNED | sizeof(uint64_t): return Ctypes_Uint64;
+  case                   sizeof(int8_t):   return Ctypes_Int8;
+  case                   sizeof(int16_t):  return Ctypes_Int16;
+  case                   sizeof(int32_t):  return Ctypes_Int32;
+  case                   sizeof(int64_t):  return Ctypes_Int64;
+  default: assert(0);
+  }
+}
+
+static inline
+const char *ctypes_arithmetic_type_name(enum ctypes_arithmetic_type t)
+{
+  switch (t)
+  {
+  case Ctypes_Int8:   return "Int8";
+  case Ctypes_Int16:  return "Int16";
+  case Ctypes_Int32:  return "Int32";
+  case Ctypes_Int64:  return "Int64";
+  case Ctypes_Uint8:  return "Uint8";
+  case Ctypes_Uint16: return "Uint16";
+  case Ctypes_Uint32: return "Uint32";
+  case Ctypes_Uint64: return "Uint64";
+  case Ctypes_Float:  return "Float";
+  case Ctypes_Double: return "Double";
+  default: assert(0);
+  }
+}
 
 #endif /* CTYPES_PRIMITIVES_H */

--- a/src/ctypes/posixTypes.ml
+++ b/src/ctypes/posixTypes.ml
@@ -28,42 +28,30 @@ let mkAbstractSized : name:string -> size:int -> alignment:int -> (module Abstra
        let t = abstract ~name ~size ~alignment:a
      end : Abstract)
 
-type arithmetic =
-    Int8
-  | Int16
-  | Int32
-  | Int64
-  | Uint8
-  | Uint16
-  | Uint32
-  | Uint64
-  | Float
-  | Double
-
 let mkArithmetic = 
   let open Ctypes in function
-    Int8   -> mkAbstract int8_t
-  | Int16  -> mkAbstract int16_t
-  | Int32  -> mkAbstract int32_t
-  | Int64  -> mkAbstract int64_t
-  | Uint8  -> mkAbstract uint8_t
-  | Uint16 -> mkAbstract uint16_t
-  | Uint32 -> mkAbstract uint32_t
-  | Uint64 -> mkAbstract uint64_t
-  | Float  -> mkAbstract float
-  | Double -> mkAbstract double
+    Static.Int8   -> mkAbstract int8_t
+  | Static.Int16  -> mkAbstract int16_t
+  | Static.Int32  -> mkAbstract int32_t
+  | Static.Int64  -> mkAbstract int64_t
+  | Static.Uint8  -> mkAbstract uint8_t
+  | Static.Uint16 -> mkAbstract uint16_t
+  | Static.Uint32 -> mkAbstract uint32_t
+  | Static.Uint64 -> mkAbstract uint64_t
+  | Static.Float  -> mkAbstract float
+  | Static.Double -> mkAbstract double
 
 (* Arithmetic types *)
-external typeof_clock_t : unit -> arithmetic = "ctypes_typeof_clock_t"
-external typeof_dev_t : unit -> arithmetic = "ctypes_typeof_dev_t"
-external typeof_ino_t : unit -> arithmetic = "ctypes_typeof_ino_t"
-external typeof_mode_t : unit -> arithmetic = "ctypes_typeof_mode_t"
-external typeof_nlink_t : unit -> arithmetic = "ctypes_typeof_nlink_t"
-external typeof_off_t : unit -> arithmetic = "ctypes_typeof_off_t"
-external typeof_pid_t : unit -> arithmetic = "ctypes_typeof_pid_t"
-external typeof_ssize_t : unit -> arithmetic = "ctypes_typeof_ssize_t"
-external typeof_time_t : unit -> arithmetic = "ctypes_typeof_time_t"
-external typeof_useconds_t : unit -> arithmetic = "ctypes_typeof_useconds_t"
+external typeof_clock_t : unit -> Static.arithmetic = "ctypes_typeof_clock_t"
+external typeof_dev_t : unit -> Static.arithmetic = "ctypes_typeof_dev_t"
+external typeof_ino_t : unit -> Static.arithmetic = "ctypes_typeof_ino_t"
+external typeof_mode_t : unit -> Static.arithmetic = "ctypes_typeof_mode_t"
+external typeof_nlink_t : unit -> Static.arithmetic = "ctypes_typeof_nlink_t"
+external typeof_off_t : unit -> Static.arithmetic = "ctypes_typeof_off_t"
+external typeof_pid_t : unit -> Static.arithmetic = "ctypes_typeof_pid_t"
+external typeof_ssize_t : unit -> Static.arithmetic = "ctypes_typeof_ssize_t"
+external typeof_time_t : unit -> Static.arithmetic = "ctypes_typeof_time_t"
+external typeof_useconds_t : unit -> Static.arithmetic = "ctypes_typeof_useconds_t"
 
 module Clock = (val mkArithmetic (typeof_clock_t ()) : Abstract)
 module Dev = (val mkArithmetic (typeof_dev_t ()) : Abstract)

--- a/src/ctypes/posix_types_stubs.c
+++ b/src/ctypes/posix_types_stubs.c
@@ -4,6 +4,9 @@
  * This file is distributed under the terms of the MIT License.
  * See the file LICENSE for details.
  */
+
+#include "ctypes_primitives.h"
+
 #define _XOPEN_SOURCE 500
 #include <caml/mlvalues.h>
 
@@ -19,53 +22,11 @@
 
 #include <stdint.h>
 
-enum arithmetic {
-  Int8,
-  Int16,
-  Int32,
-  Int64,
-  Uint8,
-  Uint16,
-  Uint32,
-  Uint64,
-  Float,
-  Double,
-};
-
-#define FLOATING_FLAG_BIT 15
-#define UNSIGNED_FLAG_BIT 14
-#define FLOATING ((size_t)1u << FLOATING_FLAG_BIT)
-#define UNSIGNED ((size_t)1u << UNSIGNED_FLAG_BIT)
-#define CHECK_FLOATING(TYPENAME) \
-  ((unsigned)(((TYPENAME) 0.5) != 0) << FLOATING_FLAG_BIT)
-#define CHECK_UNSIGNED(TYPENAME) \
-  ((unsigned)(((TYPENAME) -1) > 0) << UNSIGNED_FLAG_BIT)
-#define CLASSIFY(TYPENAME) (CHECK_FLOATING(TYPENAME) | CHECK_UNSIGNED(TYPENAME))
-#define ARITHMETIC_TYPEINFO(TYPENAME) (CLASSIFY(TYPENAME) | sizeof(TYPENAME))
-
-static enum arithmetic _underlying_type(size_t typeinfo)
-{
-  switch (typeinfo)
-  {
-  case FLOATING | sizeof(float):    return Float;
-  case FLOATING | sizeof(double):   return Double;
-  case UNSIGNED | sizeof(uint8_t):  return Uint8;
-  case UNSIGNED | sizeof(uint16_t): return Uint16;
-  case UNSIGNED | sizeof(uint32_t): return Uint32;
-  case UNSIGNED | sizeof(uint64_t): return Uint64;
-  case            sizeof(int8_t):   return Int8;
-  case            sizeof(int16_t):  return Int16;
-  case            sizeof(int32_t):  return Int32;
-  case            sizeof(int64_t):  return Int64;
-  default: assert(0);
-  }
-}
-
 #define EXPOSE_TYPEINFO_COMMON(TYPENAME,STYPENAME)           \
   value ctypes_typeof_ ## TYPENAME(value unit)               \
   {                                                          \
-    size_t typeinfo = ARITHMETIC_TYPEINFO(STYPENAME);        \
-    enum arithmetic underlying = _underlying_type(typeinfo); \
+    enum ctypes_arithmetic_type underlying =                 \
+      CTYPES_CLASSIFY_ARITHMETIC_TYPE(STYPENAME);            \
     return Val_int(underlying);                              \
   }
 

--- a/src/ctypes/static.ml
+++ b/src/ctypes/static.ml
@@ -231,3 +231,16 @@ let union utag = Union { utag; uspec = None; ufields = [] }
 let offsetof { foffset } = foffset
 let field_type { ftype } = ftype
 let field_name { fname } = fname
+
+(* This corresponds to the enum in ctypes_primitives.h *)
+type arithmetic =
+    Int8
+  | Int16
+  | Int32
+  | Int64
+  | Uint8
+  | Uint16
+  | Uint32
+  | Uint64
+  | Float
+  | Double

--- a/src/ctypes/static.mli
+++ b/src/ctypes/static.mli
@@ -166,3 +166,16 @@ exception ModifyingSealedType of string
 exception Unsupported of string
 
 val unsupported : ('a, unit, string, _) format4 -> 'a
+
+(* This corresponds to the enum in ctypes_primitives.h *)
+type arithmetic =
+    Int8
+  | Int16
+  | Int32
+  | Int64
+  | Uint8
+  | Uint16
+  | Uint32
+  | Uint64
+  | Float
+  | Double

--- a/tests/clib/test_functions.c
+++ b/tests/clib/test_functions.c
@@ -578,3 +578,25 @@ int call_s5(struct s1 *s1, struct s5 *s5)
 {
   return s5->w1(s1);
 }
+
+enum signed_enum classify_integer(int x)
+{
+  return (x < 0) ? minus_one : plus_one;
+}
+
+enum signed_enum out_of_range(void)
+{
+  return (enum signed_enum)2;
+}
+
+enum fruit next_fruit(enum fruit f)
+{
+  switch (f)
+  {
+  case Orange: return Apple;
+  case Apple: return Banana;
+  case Banana: return Pear;
+  case Pear: return Orange;
+  default: assert(0);
+  }
+}

--- a/tests/clib/test_functions.h
+++ b/tests/clib/test_functions.h
@@ -204,6 +204,7 @@ int call_s5(struct s1 *, struct s5 *);
 enum letter { A, B, C = 10, D };
 
 enum fruit { Orange, Apple, Banana, Pear };
+enum bears { Edward, Winnie, Paddington };
 enum signed_enum { minus_one = -1, plus_one = 1 };
 
 enum fruit next_fruit(enum fruit);

--- a/tests/clib/test_functions.h
+++ b/tests/clib/test_functions.h
@@ -203,4 +203,11 @@ int call_s5(struct s1 *, struct s5 *);
 
 enum letter { A, B, C = 10, D };
 
+enum fruit { Orange, Apple, Banana, Pear };
+enum signed_enum { minus_one = -1, plus_one = 1 };
+
+enum fruit next_fruit(enum fruit);
+enum signed_enum classify_integer(int);
+enum signed_enum out_of_range(void);
+
 #endif /* TEST_FUNCTIONS_H */

--- a/tests/clib/test_functions.h
+++ b/tests/clib/test_functions.h
@@ -210,4 +210,9 @@ enum fruit next_fruit(enum fruit);
 enum signed_enum classify_integer(int);
 enum signed_enum out_of_range(void);
 
+struct fruit_cell {
+  enum fruit frt;
+  struct fruit_cell *next;
+};
+
 #endif /* TEST_FUNCTIONS_H */

--- a/tests/test-enums/struct-stub-generator/driver.ml
+++ b/tests/test-enums/struct-stub-generator/driver.ml
@@ -1,0 +1,12 @@
+(*
+ * Copyright (c) 2014 Jeremy Yallop.
+ *
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+(* Struct stub generation driver for the enum tests. *)
+
+let () = Tests_common.run Sys.argv
+   ~structs:(module Types.Struct_stubs)
+   (module functor (X: Cstubs.FOREIGN) -> struct end)

--- a/tests/test-enums/struct-stubs/types.ml
+++ b/tests/test-enums/struct-stubs/types.ml
@@ -37,4 +37,15 @@ struct
   let frt = field fruit_cell "frt" fruit
   let next = field fruit_cell "next" (ptr_opt fruit_cell)
   let () = seal fruit_cell
+
+
+  let edward     = constant "Edward"     int64_t
+  let winnie     = constant "Winnie"     int64_t
+  let paddington = constant "Paddington" int64_t
+
+  let bears : [`Edward|`Winnie|`Paddington] typ = enum "bears" [
+      `Edward     , edward     ;
+      `Winnie     , winnie     ;
+      `Paddington , paddington ;
+    ]
 end

--- a/tests/test-enums/struct-stubs/types.ml
+++ b/tests/test-enums/struct-stubs/types.ml
@@ -1,0 +1,37 @@
+(*
+ * Copyright (c) 2014 Jeremy Yallop.
+ *
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+open Ctypes
+
+type fruit = Orange | Apple | Banana | Pear
+
+module Struct_stubs(S : Cstubs.Types.TYPE) =
+struct
+  open S
+
+  let orange = constant "Orange" int64_t
+  let apple  = constant "Apple"  int64_t
+  let pear   = constant "Pear"   int64_t
+  let banana = constant "Banana" int64_t
+
+  let fruit = enum "fruit" [
+      Orange , orange ;
+      Apple  , apple  ;
+      Pear   , pear   ;
+      Banana , banana ;
+    ]
+
+  let minus_one = constant "minus_one"   int64_t
+  let plus_one  = constant "plus_one"    int64_t
+
+  let signed = enum "signed_enum" ~unexpected:(fun _ -> 0) [
+      -1, minus_one ;
+      1 , plus_one  ;
+    ]
+
+
+end

--- a/tests/test-enums/struct-stubs/types.ml
+++ b/tests/test-enums/struct-stubs/types.ml
@@ -33,5 +33,8 @@ struct
       1 , plus_one  ;
     ]
 
-
+  let fruit_cell : [`fruit_cell] structure typ = structure "fruit_cell"
+  let frt = field fruit_cell "frt" fruit
+  let next = field fruit_cell "next" (ptr_opt fruit_cell)
+  let () = seal fruit_cell
 end

--- a/tests/test-enums/stub-generator/driver.ml
+++ b/tests/test-enums/stub-generator/driver.ml
@@ -1,0 +1,10 @@
+(*
+ * Copyright (c) 2014 Jeremy Yallop.
+ *
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+(* Stub generation driver for the enum tests. *)
+
+let () = Tests_common.run Sys.argv (module Functions.Stubs)

--- a/tests/test-enums/stubs/functions.ml
+++ b/tests/test-enums/stubs/functions.ml
@@ -1,0 +1,27 @@
+(*
+ * Copyright (c) 2014 Jeremy Yallop.
+ *
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+(* Foreign function bindings for the enum tests. *)
+
+open Ctypes
+
+(* These functions can only be bound using stub generation, since Foreign
+   doesn't support passing enums. *)
+module Stubs(F : Cstubs.FOREIGN) =
+struct
+
+  module T = Types.Struct_stubs(Generated_struct_bindings)
+
+  let classify_integer = F.foreign "classify_integer"
+      (int @-> returning T.signed)
+
+  let out_of_range = F.foreign "out_of_range"
+      (void @-> returning T.signed)
+
+  let next_fruit = F.foreign "next_fruit"
+      (T.fruit @-> returning T.fruit)
+end

--- a/tests/test-enums/test_enums.ml
+++ b/tests/test-enums/test_enums.ml
@@ -17,6 +17,42 @@ struct
   module M = Types.Struct_stubs(S)
   open M
 
+  let test_enum_struct_members _ =
+    let reverse cell =
+      let rec loop prev cell =
+        match cell with
+          None -> prev
+        | Some c ->
+          let n = getf !@c next in
+          let () = setf !@c next prev in
+          loop cell n
+      in loop None cell
+    in
+    let as_list cell =
+      let rec loop l = function
+          None -> List.rev l
+        | Some c ->
+          loop (getf !@c frt :: l) (getf !@c next)
+      in loop [] cell
+    in
+    let rec of_list l =
+      match l with
+        [] -> None
+      | f :: fs ->
+        let c = make fruit_cell in
+        let n = of_list fs in
+        let () = setf c frt f in
+        let () = setf c next n in
+        Some (addr c)
+    in
+    begin
+      let open Types in
+      let l = of_list [Apple; Apple; Pear; Banana] in
+      assert_equal [Apple; Apple; Pear; Banana] (as_list l);
+      assert_equal [Banana; Pear; Apple; Apple] (as_list (reverse l));
+      assert_equal [] (as_list None);
+    end
+
   module Build_call_tests
       (F : Cstubs.FOREIGN with type 'a fn = 'a) =
   struct
@@ -62,6 +98,9 @@ let suite = "Enum tests" >:::
 
     "enums with default values"
     >:: Combined_stub_tests.test_default_enums;
+
+    "enums as struct members"
+    >:: Enum_stubs_tests.test_enum_struct_members;
   ]
 
 

--- a/tests/test-enums/test_enums.ml
+++ b/tests/test-enums/test_enums.ml
@@ -53,6 +53,18 @@ struct
       assert_equal [] (as_list None);
     end
 
+  let test_enum_arrays _ =
+    let module Array = CArray in
+    let a = Array.make bears 4 in
+    begin
+      a.(0) <- `Edward;
+      a.(1) <- `Winnie;
+      a.(2) <- `Paddington;
+      a.(3) <- `Edward;
+      assert_equal [`Edward; `Winnie; `Paddington; `Edward]
+        (Array.to_list a)
+    end
+
   module Build_call_tests
       (F : Cstubs.FOREIGN with type 'a fn = 'a) =
   struct
@@ -101,6 +113,9 @@ let suite = "Enum tests" >:::
 
     "enums as struct members"
     >:: Enum_stubs_tests.test_enum_struct_members;
+
+    "arrays of enums"
+    >:: Enum_stubs_tests.test_enum_arrays;
   ]
 
 

--- a/tests/test-enums/test_enums.ml
+++ b/tests/test-enums/test_enums.ml
@@ -1,0 +1,69 @@
+(*
+ * Copyright (c) 2013 Jeremy Yallop.
+ *
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+open OUnit2
+open Ctypes
+
+
+module Build_enum_stub_tests
+    (S : Cstubs.Types.TYPE
+          with type 'a typ = 'a Ctypes.typ
+           and type ('a, 's) field = ('a, 's) Ctypes.field) =
+struct
+  module M = Types.Struct_stubs(S)
+  open M
+
+  module Build_call_tests
+      (F : Cstubs.FOREIGN with type 'a fn = 'a) =
+  struct
+    module F = Functions.Stubs(F)
+    open F
+    open M
+
+    let test_passing_returning_enums _ =
+      let open Types in
+      begin
+        assert_equal Apple  (next_fruit Orange);
+        assert_equal Banana (next_fruit Apple);
+        assert_equal Pear   (next_fruit Banana);
+        assert_equal Orange (next_fruit Pear);
+      end
+
+    let test_signed_enums _ =
+      begin
+        assert_equal (-1)  (classify_integer (-3));
+        assert_equal 1     (classify_integer 4);
+      end
+
+    let test_default_enums _ =
+      begin
+        assert_equal 0 (out_of_range ())
+      end
+
+  end
+
+end
+
+module Enum_stubs_tests = Build_enum_stub_tests(Generated_struct_bindings)
+module Combined_stub_tests = Enum_stubs_tests.Build_call_tests(Generated_bindings)
+
+
+let suite = "Enum tests" >:::
+  [
+    "passing and returning enums"
+    >:: Combined_stub_tests.test_passing_returning_enums;
+
+    "enums with signed values"
+    >:: Combined_stub_tests.test_signed_enums;
+
+    "enums with default values"
+    >:: Combined_stub_tests.test_default_enums;
+  ]
+
+
+let _ =
+  run_test_tt_main suite


### PR DESCRIPTION
This pull request adds support for using enum types.

There's a new function

```ocaml
val enum : string -> ?unexpected:(int64 -> 'a) -> ('a * int64 const) list -> 'a typ
```

which builds a type representation for a named enum.  The size and alignment are retrieved from C so that the resulting type can be used everywhere an integer type can be used: as an array element or struct member, as an argument or return value, etc.

The last argument is an association list of OCaml values and values retrieved by the [constant] function.  For example, to expose the enum

```C
enum letters { A, B, C = 10, D }; 
```

you might first retrieve the values of the enumeration constants:

```ocaml
let a = constant "A" int64_t
and b = constant "B" int64_t
and c = constant "C" int64_t
and d = constant "D" int64_t
```

and then build the enumeration type

```ocaml
let letters = enum "letters" [
   `A, a;
   `B, b;
   `C, c;
   `D, d;
  ] ~unexpected:(fun i -> `Unexpected i)
```

The optional argument [?unexpected] specifies the value to return in the case that some unexpected value is encountered -- for example, if a function with the return type 'enum letters' actually returns the value [-1].

Note that it's straightforward to define a slightly more convenient (but less flexible) interface on top of the functionality provided here.  Instead of retrieving the constants and building the enum type in separate steps, you might like to define a function `enum_Of_names` which combines the two:

```OCaml
let letters = enum_of_names "letters" [
   `A, "a";
   `B, "b";
   `C, "c";
   `D, "d";
  ] ~unexpected:(fun i -> `Unexpected i)
]
```

Closes #234 and closes #29.
