### PR TITLE
Use an external name for managed_buffer in generated code.

### DIFF
--- a/src/cstubs/cstubs_generate_ml.ml
+++ b/src/cstubs/cstubs_generate_ml.ml
@@ -191,7 +191,7 @@ let attributes : type a. a fn -> attributes =
    let open Cstubs_analysis in
    fun fn -> { float = float fn; noalloc = not (may_allocate fn) }
 
-let managed_buffer = `Ident (path_of_string "Memory_stubs.managed_buffer")
+let managed_buffer = `Ident (path_of_string "CI.managed_buffer")
 let voidp = `Ident (path_of_string "CI.voidp")
 let fatptr = `Appl (path_of_string "CI.fatptr", [`Ident (path_of_string "_")])
 let string = `Ident (path_of_string "string")


### PR DESCRIPTION
Fixes #252.