### PR TITLE
Refactor discover.ml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,8 +139,9 @@ src/ctypes/ctypes_primitives.ml: $(BUILDDIR)/configure.native
 src/ctypes-foreign-base/libffi_abi.ml: $(BUILDDIR)/libffi-abigen.native
 	$< > $@
 
-setup.data: src/discover/discover.ml
-	ocaml $^ -ocamlc "$(OCAMLFIND) ocamlc"
+setup.data: src/discover/commands.mli src/discover/commands.ml src/discover/discover.ml
+	@ocamlfind ocamlc -o discover -package str,bytes -linkpkg $^ -I src/discover
+	./discover -ocamlc "$(OCAMLFIND) ocamlc"
 
 # dependencies
 depend: configure

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ src/ctypes-foreign-base/libffi_abi.ml: $(BUILDDIR)/libffi-abigen.native
 
 setup.data: src/discover/commands.mli src/discover/commands.ml src/discover/discover.ml
 	@ocamlfind ocamlc -o discover -package str,bytes -linkpkg $^ -I src/discover
-	./discover -ocamlc "$(OCAMLFIND) ocamlc"
+	./discover -ocamlc "$(OCAMLFIND) ocamlc" > $@ || (rm $@ && false)
 	./src/discover/determine_as_needed_flags.sh >> $@
 
 # dependencies

--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,7 @@ src/ctypes-foreign-base/libffi_abi.ml: $(BUILDDIR)/libffi-abigen.native
 setup.data: src/discover/commands.mli src/discover/commands.ml src/discover/discover.ml
 	@ocamlfind ocamlc -o discover -package str,bytes -linkpkg $^ -I src/discover
 	./discover -ocamlc "$(OCAMLFIND) ocamlc"
+	./src/discover/determine_as_needed_flags.sh >> $@
 
 # dependencies
 depend: configure

--- a/src/discover/commands.ml
+++ b/src/discover/commands.ml
@@ -39,15 +39,23 @@ type command_output = {
   stderr: string;
 }
 
+let temp_dir = "."
+
+(* The use of [unixify] below is not ideal: it's a workaround for the Windows
+   build, which uses a mixture of Windows- and Unix-style paths due to using MinGW
+   to compile OCaml and Bash for the shell.
+*)
+let unixify = Str.(global_replace (regexp "\\\\") "/")
+
 let shell_command_results command =
-  let stdout_filename = Filename.temp_file "ctypes_config" ".stdout" in
-  let stderr_filename = Filename.temp_file "ctypes_config" ".stderr" in
+  let stdout_filename = Filename.temp_file ~temp_dir "ctypes_config" ".stdout" in
+  let stderr_filename = Filename.temp_file ~temp_dir "ctypes_config" ".stderr" in
   unwind_protect
     (fun () ->
        let full_command =
          Printf.sprintf "(%s) > %s 2> %s" command 
-           (Filename.quote stdout_filename)
-           (Filename.quote stderr_filename)
+           (unixify stdout_filename)
+           (unixify stderr_filename)
        in
        let status = Sys.command full_command in
        let stdout = file_contents stdout_filename in

--- a/src/discover/commands.ml
+++ b/src/discover/commands.ml
@@ -1,0 +1,72 @@
+(*
+ * Copyright (c) 2014 Jeremy Yallop.
+ *
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+let unwind_protect ~cleanup f x =
+  let rv = try f x
+    with exn ->
+      begin
+        cleanup x;
+        raise exn
+      end
+  in
+  begin
+    cleanup x;
+    rv
+  end
+
+let with_open_output_file ~filename f =
+  unwind_protect ~cleanup:close_out f (open_out filename)
+
+let with_open_input_file ~filename f =
+  unwind_protect ~cleanup:close_in f (open_in filename)
+
+let file_contents ~filename : string =
+  with_open_input_file ~filename
+    (fun file ->
+       let () = set_binary_mode_in file true in
+       let size = in_channel_length file in
+       let buf = Bytes.create size in
+       let () = really_input file buf 0 size in
+       buf)
+
+type command_output = {
+  status: int;
+  stdout: string;
+  stderr: string;
+}
+
+let shell_command_results command =
+  let stdout_filename = Filename.temp_file "ctypes_config" ".stdout" in
+  let stderr_filename = Filename.temp_file "ctypes_config" ".stderr" in
+  unwind_protect
+    (fun () ->
+       let full_command =
+         Printf.sprintf "(%s) > %s 2> %s" command 
+           (Filename.quote stdout_filename)
+           (Filename.quote stderr_filename)
+       in
+       let status = Sys.command full_command in
+       let stdout = file_contents stdout_filename in
+       let stderr = file_contents stderr_filename in
+       { status; stdout; stderr }
+    ) ()
+    ~cleanup:begin fun () ->
+      Sys.remove stdout_filename;
+      Sys.remove stderr_filename;
+    end
+
+
+let command fmt =
+  Printf.ksprintf shell_command_results fmt
+
+let command_output' command =
+  (shell_command_results command).stdout
+
+let command_succeeds' command = (shell_command_results command).status = 0
+
+let command_succeeds fmt =
+  Printf.ksprintf command_succeeds' fmt

--- a/src/discover/commands.mli
+++ b/src/discover/commands.mli
@@ -1,0 +1,21 @@
+(*
+ * Copyright (c) 2014 Jeremy Yallop.
+ *
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+val unwind_protect : cleanup:('a -> 'c) -> ('a -> 'b) -> 'a -> 'b
+val with_open_output_file : filename:string -> (out_channel -> 'a) -> 'a
+
+val file_contents : filename:string -> string
+
+type command_output = {
+  status: int;
+  stdout: string;
+  stderr: string;
+}
+
+val command : ('a, unit, string, command_output) format4 -> 'a
+
+val command_succeeds : ('a, unit, string, bool) format4 -> 'a

--- a/src/discover/determine_as_needed_flags.sh
+++ b/src/discover/determine_as_needed_flags.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+touch as_needed_test.ml
+if ocamlopt -shared -cclib -Wl,--no-as-needed as_needed_test.ml -o as_needed_test.cmxs 2>/dev/null
+then
+    echo 'as_needed_flags=-Wl,--no-as-needed'
+else
+    echo 'as_needed_flags='
+fi
+rm as_needed_test.*

--- a/src/discover/discover.ml
+++ b/src/discover/discover.ml
@@ -249,12 +249,6 @@ let lib_flags env_var_prefix fallback =
    | Entry point                                                     |
    +-----------------------------------------------------------------+ *)
 
-let arg_bool r =
-  Arg.Symbol (["true"; "false"],
-              function
-                | "true" -> r := true
-                | "false" -> r := false
-                | _ -> assert false)
 let () =
   let args = [
     "-ocamlc", Arg.Set_string ocamlc, "<path> ocamlc";
@@ -352,28 +346,10 @@ export LIBFFI_LIBS=-L/opt/local/lib
     exit 1
   end;
 
-  (match is_win with
-   | true -> setup_data := ("as_needed_flags", []) :: !setup_data;
-   | false ->
-     if test_feature "no_as_needed" 
-       (fun () ->
-         ksprintf Sys.command "
-         touch as_needed_test.ml;
-         ocamlopt -shared -cclib -Wl,--no-as-needed as_needed_test.ml -o as_needed_test.cmxs > %s 2>&1;
-         EXIT=$?;
-         rm as_needed_test.*;
-         exit $EXIT"
-        !log_file = 0) then
-       setup_data := ("as_needed_flags", ["-Wl,--no-as-needed"]) :: !setup_data
-     else
-       setup_data := ("as_needed_flags", []) :: !setup_data;
-  );
-
   (* Our setup.data keys. *)
   let setup_data_keys = [
     "libffi_opt";
     "libffi_lib";
-    "as_needed_flags";
   ] in
 
   (* Load setup.data *)

--- a/src/discover/discover.ml
+++ b/src/discover/discover.ml
@@ -35,7 +35,7 @@ open Printf
    LIBRARY_PATH.
 *)
 
-let default_search_paths =
+let search_paths =
   List.map (fun dir -> (dir ^ "/include", dir ^ "/lib")) [
     "/usr";
     "/usr/local";
@@ -65,20 +65,6 @@ export LIBFFI_CFLAGS=-I/opt/local/include
 export LIBFFI_LIBS=-L/opt/local/lib
 
 "
-
-let search_paths =
-  let get var f =
-    try
-      List.map f (split_path (Sys.getenv var))
-    with Not_found ->
-      []
-  in
-  List.flatten [
-    get "C_INCLUDE_PATH" (fun dir -> (dir, dir // ".." // "lib"));
-    get "LIBRARY_PATH" (fun dir -> (dir // ".." // "include", dir));
-    default_search_paths;
-  ]
-
 (* +-----------------------------------------------------------------+
    | Test codes                                                      |
    +-----------------------------------------------------------------+ *)

--- a/src/discover/discover.ml
+++ b/src/discover/discover.ml
@@ -180,16 +180,8 @@ let pkg_config flags =
 
 let pkg_config_flags name =
   try
-    (* Get compile flags. *)
-    let opt = ksprintf pkg_config "--cflags %s" name in
-    (* Get linking flags. *)
-    let lib =
-      if !ccomp_type = "msvc" then
-        ksprintf pkg_config "--libs-only-L %s" name @ ksprintf pkg_config "--libs-only-l --msvc-syntax %s" name
-      else
-        ksprintf pkg_config "--libs %s" name
-    in
-    Some (opt, lib)
+    Some (ksprintf pkg_config "--cflags %s" name,
+          ksprintf pkg_config "--libs %s" name)
   with Exit ->
     None
 

--- a/src/discover/discover.ml
+++ b/src/discover/discover.ml
@@ -175,15 +175,14 @@ let pkg_config flags =
       Commands.command "pkg-config %s > %s 2>&1" flags !log_file
   in
   match output with
-    { Commands.status } when status <> 0 -> raise Exit
-  | { Commands.stdout } -> split stdout
+    { Commands.status } when status <> 0 -> None
+  | { Commands.stdout } -> Some (split (String.trim stdout))
 
 let pkg_config_flags name =
-  try
-    Some (ksprintf pkg_config "--cflags %s" name,
-          ksprintf pkg_config "--libs %s" name)
-  with Exit ->
-    None
+  match (ksprintf pkg_config "--cflags %s" name,
+         ksprintf pkg_config "--libs %s" name) with
+    Some opt, Some lib -> Some (opt, lib)
+  | _ -> None
 
 let get_homebrew_prefix log_file =
   match Commands.command "brew --prefix > %s" log_file with

--- a/src/discover/discover.ml
+++ b/src/discover/discover.ml
@@ -157,17 +157,13 @@ let test_feature name test =
 let split = Str.(split (regexp " +"))
 
 let brew_libffi_version flags =
-  if Commands.command_succeeds "brew ls libffi --versions | awk '{print $NF}' > %s 2>&1" !log_file then begin
-    let ic = open_in !log_file in
-    let line = input_line ic in
-    close_in ic;
-    if line = "" then begin
-      print_endline "You need to 'brew install libffi' to get a suitably up-to-date version";
-      exit 1
-    end;
-    line
-  end else
+  match Commands.command "brew ls libffi --versions | awk '{print $NF}' > %s 2>&1" !log_file with
+    { Commands.status } when status <> 0 ->
     raise Exit
+  | { Commands.stdout = "" } ->
+    failwith "You need to 'brew install libffi' to get a suitably up-to-date version"
+  | { Commands.stdout } ->
+    String.trim stdout
 
 let pkg_config flags =
   let output =

--- a/src/discover/discover.ml
+++ b/src/discover/discover.ml
@@ -329,12 +329,6 @@ export LIBFFI_LIBS=-L/opt/local/lib
     exit 1
   end;
 
-  (* Add flags to setup.data *)
-  let setup_data_lines =
-    List.fold_left
-      (fun lines (name, args) ->
-         sprintf "%s=%s" name (String.concat " " args) :: lines)
-      [] !setup_data
-  in
-  List.iter (Printf.printf "%s\n") setup_data_lines
-
+  ListLabels.iter !setup_data
+    ~f:(fun (name, args) ->
+        Printf.printf "%s=%s\n" name (String.concat " " args))

--- a/src/discover/discover.ml
+++ b/src/discover/discover.ml
@@ -178,25 +178,7 @@ let test_feature name test =
    | pkg-config                                                      |
    +-----------------------------------------------------------------+ *)
 
-let split str =
-  let rec skip_spaces i =
-    if i = String.length str then
-      []
-    else
-      if str.[i] = ' ' then
-        skip_spaces (i + 1)
-      else
-        extract i (i + 1)
-  and extract i j =
-    if j = String.length str then
-      [String.sub str i (j - i)]
-    else
-      if str.[j] = ' ' then
-        String.sub str i (j - i) :: skip_spaces (j + 1)
-      else
-        extract i (j + 1)
-  in
-  skip_spaces 0
+let split = Str.(split (regexp " +"))
 
 let brew_libffi_version flags =
   if ksprintf Sys.command "brew ls libffi --versions | awk '{print $NF}' > %s 2>&1" !log_file = 0 then begin

--- a/src/discover/discover.ml
+++ b/src/discover/discover.ml
@@ -346,46 +346,12 @@ export LIBFFI_LIBS=-L/opt/local/lib
     exit 1
   end;
 
-  (* Our setup.data keys. *)
-  let setup_data_keys = [
-    "libffi_opt";
-    "libffi_lib";
-  ] in
-
-  (* Load setup.data *)
-  let setup_data_lines =
-    match try Some (open_in "setup.data") with Sys_error _ -> None with
-      | Some ic ->
-          let rec aux acc =
-            match try Some (input_line ic) with End_of_file -> None with
-              | None ->
-                  close_in ic;
-                  acc
-              | Some line ->
-                  match try Some(String.index line '=') with Not_found -> None with
-                    | Some idx ->
-                        let key = String.sub line 0 idx in
-                        if List.mem key setup_data_keys then
-                          aux acc
-                        else
-                          aux (line :: acc)
-                    | None ->
-                        aux (line :: acc)
-          in
-          aux []
-      | None ->
-          []
-  in
-
   (* Add flags to setup.data *)
   let setup_data_lines =
     List.fold_left
       (fun lines (name, args) ->
          sprintf "%s=%s" name (String.concat " " args) :: lines)
-      setup_data_lines !setup_data
+      [] !setup_data
   in
-  let oc = open_out "setup.data" in
-  List.iter
-    (fun str -> output_string oc str; output_char oc '\n')
-    (List.rev setup_data_lines);
-  close_out oc;
+  List.iter (Printf.printf "%s\n") setup_data_lines
+

--- a/src/discover/discover.ml
+++ b/src/discover/discover.ml
@@ -51,18 +51,9 @@ let default_search_paths =
 
 let is_win = Sys.os_type = "Win32"
 
-let path_sep = if is_win then ';' else ':'
+let path_sep = if is_win then ";" else ":"
 
-let split_path str =
-  let len = String.length str in
-  let rec aux i =
-    if i >= len then
-      []
-    else
-      let j = try String.index_from str i path_sep with Not_found -> len in
-      String.sub str i (j - i) :: aux (j + 1)
-  in
-  aux 0
+let split_path = Str.(split (regexp (path_sep ^ "+")))
 
 let search_paths =
   let get var f =

--- a/src/discover/discover.ml
+++ b/src/discover/discover.ml
@@ -164,12 +164,12 @@ let test_code args stub_code =
 
 let test_feature name test =
   begin
-    printf "testing for %s:%!" name;
+    fprintf stderr "testing for %s:%!" name;
     if test () then begin
-      printf " %s available\n%!" (String.make (34 - String.length name) '.');
+      fprintf stderr " %s available\n%!" (String.make (34 - String.length name) '.');
       true
     end else begin
-      printf " %s unavailable\n%!" (String.make (34 - String.length name) '.');
+      fprintf stderr " %s unavailable\n%!" (String.make (34 - String.length name) '.');
       false
     end
   end
@@ -309,7 +309,7 @@ let () =
     )
   in
   if not have_pkg_config then
-    printf "Warning: the 'pkg-config' command is not available."
+    fprintf stderr "Warning: the 'pkg-config' command is not available."
   ;
 
   let test_libffi () =
@@ -331,7 +331,7 @@ let () =
   in
 
   if not (test_feature "libffi" test_libffi) then begin
-    printf "
+    fprintf stderr "
 The following required C libraries are missing: libffi.
 Please install them and retry. If they are installed in a non-standard location
 or need special flags, set the environment variables <LIB>_CFLAGS and <LIB>_LIBS


### PR DESCRIPTION
Various improvements
* Communicate via argument passing rather than globals
* A module to run commands and capture stdout/stderr/status
* Simplify input/output structure: write output to stdout and diagnostics to stderr
* Remove some hand-rolled functions that duplicate standard library functionality
* Simplified control flow (e.g. no passing of "fallback" functions)
* Split out the `-Wl,-no-as-needed` linker flag detection into a separate script
* Don't generate unnecessary/unused header files and modules 

This should leave behaviour more or less unchanged, but should make it easier to fix various configuration-related issues (e.g. #20)

Closes #172.