### PR TITLE
Add top-level build targets for individual components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 _build
-setup.data
+libffi.config
+asneeded.config
 src/ctypes/ctypes_primitives.ml
 src/ctypes_config.h
 src/ctypes_config.ml

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ BASE_PROJECTS=configure libffi-abigen configured ctypes ctypes-top
 FOREIGN_PROJECTS=ctypes-foreign-base ctypes-foreign-threaded ctypes-foreign-unthreaded
 STUB_PROJECTS=cstubs
 PROJECTS=$(BASE_PROJECTS) $(FOREIGN_PROJECTS) $(STUB_PROJECTS)
-GENERATED=src/ctypes_config.h src/ctypes_config.ml setup.data src/ctypes/ctypes_primitives.ml src/ctypes-foreign-base/dl.ml src/ctypes-foreign-base/dl_stubs.c
+GENERATED=src/ctypes_config.h src/ctypes_config.ml libffi.config src/ctypes/ctypes_primitives.ml src/ctypes-foreign-base/dl.ml src/ctypes-foreign-base/dl_stubs.c
 OCAML_FFI_INCOPTS=$(libffi_opt)
 export CFLAGS DEBUG
 
@@ -25,7 +25,7 @@ OS_ALT_SUFFIX=.unix
 endif
 
 # public targets
-all: setup.data $(PROJECTS)
+all: libffi.config $(PROJECTS)
 
 ctypes-base: $(BASE_PROJECTS)
 ctypes-foreign: ctypes-base $(FOREIGN_PROJECTS)
@@ -144,9 +144,11 @@ src/ctypes/ctypes_primitives.ml: $(BUILDDIR)/configure.native
 src/ctypes-foreign-base/libffi_abi.ml: $(BUILDDIR)/libffi-abigen.native
 	$< > $@
 
-setup.data: src/discover/commands.mli src/discover/commands.ml src/discover/discover.ml
+libffi.config: src/discover/commands.mli src/discover/commands.ml src/discover/discover.ml
 	@ocamlfind ocamlc -o discover -package str,bytes -linkpkg $^ -I src/discover
 	./discover -ocamlc "$(OCAMLFIND) ocamlc" > $@ || (rm $@ && false)
+
+asneeded.config:
 	./src/discover/determine_as_needed_flags.sh >> $@
 
 # dependencies
@@ -176,5 +178,5 @@ uninstall:
 .PHONY: depend distclean clean configure all install $(PROJECTS)
 
 include .depend Makefile.rules Makefile.examples Makefile.tests
--include setup.data
-
+-include libffi.config
+-include asneeded.config

--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ META-install:
 install-%: PROJECT=$*
 install-%:
 	$(if $(filter yes,$($(PROJECT).install)),\
-		$(OCAMLFIND) install -add ctypes $^ \
+		$(OCAMLFIND) install -add ctypes -optional $^ \
                    $(LIB_TARGETS) $(LIB_TARGET_EXTRAS) \
                    $(INSTALL_MLIS) $(INSTALL_CMIS) \
                    $(INSTALL_HEADERS) \

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,10 @@ OCAMLDEP=$(OCAMLFIND) ocamldep
 OCAMLMKLIB=$(OCAMLFIND) ocamlmklib
 VPATH=src examples
 BUILDDIR=_build
-PROJECTS=configure libffi-abigen configured ctypes cstubs ctypes-foreign-base ctypes-foreign-threaded ctypes-foreign-unthreaded ctypes-top
+BASE_PROJECTS=configure libffi-abigen configured ctypes ctypes-top
+FOREIGN_PROJECTS=ctypes-foreign-base ctypes-foreign-threaded ctypes-foreign-unthreaded
+STUB_PROJECTS=cstubs
+PROJECTS=$(BASE_PROJECTS) $(FOREIGN_PROJECTS) $(STUB_PROJECTS)
 GENERATED=src/ctypes_config.h src/ctypes_config.ml setup.data src/ctypes/ctypes_primitives.ml src/ctypes-foreign-base/dl.ml src/ctypes-foreign-base/dl_stubs.c
 OCAML_FFI_INCOPTS=$(libffi_opt)
 export CFLAGS DEBUG
@@ -22,9 +25,11 @@ OS_ALT_SUFFIX=.unix
 endif
 
 # public targets
-all: setup.data build
+all: setup.data $(PROJECTS)
 
-build: $(PROJECTS)
+ctypes-base: $(BASE_PROJECTS)
+ctypes-foreign: ctypes-base $(FOREIGN_PROJECTS)
+ctypes-stubs: ctypes-base $(STUB_PROJECTS)
 
 clean:
 	rm -fr _build
@@ -168,7 +173,7 @@ install: META-install $(PROJECTS:%=install-%)
 uninstall:
 	$(OCAMLFIND) remove ctypes
 
-.PHONY: depend distclean clean build configure all install $(PROJECTS)
+.PHONY: depend distclean clean configure all install $(PROJECTS)
 
 include .depend Makefile.rules Makefile.examples Makefile.tests
 -include setup.data

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,15 @@ OCAMLMKLIB=$(OCAMLFIND) ocamlmklib
 VPATH=src examples
 BUILDDIR=_build
 BASE_PROJECTS=configure libffi-abigen configured ctypes ctypes-top
-FOREIGN_PROJECTS=ctypes-foreign-base ctypes-foreign-threaded ctypes-foreign-unthreaded
+FOREIGN_PROJECTS=test-libffi ctypes-foreign-base ctypes-foreign-threaded ctypes-foreign-unthreaded
 STUB_PROJECTS=cstubs
 PROJECTS=$(BASE_PROJECTS) $(FOREIGN_PROJECTS) $(STUB_PROJECTS)
-GENERATED=src/ctypes_config.h src/ctypes_config.ml libffi.config src/ctypes/ctypes_primitives.ml src/ctypes-foreign-base/dl.ml src/ctypes-foreign-base/dl_stubs.c
+GENERATED=src/ctypes/ctypes_primitives.ml	\
+          src/ctypes-foreign-base/libffi_abi.ml \
+          src/ctypes-foreign-base/dl.ml		\
+          src/ctypes-foreign-base/dl_stubs.c	\
+          libffi.config				\
+          asneeded.config 
 OCAML_FFI_INCOPTS=$(libffi_opt)
 export CFLAGS DEBUG
 
@@ -33,8 +38,6 @@ ctypes-stubs: ctypes-base $(STUB_PROJECTS)
 
 clean:
 	rm -fr _build
-
-distclean: clean
 	rm -f $(GENERATED)
 
 # ctypes subproject
@@ -175,8 +178,24 @@ install: META-install $(PROJECTS:%=install-%)
 uninstall:
 	$(OCAMLFIND) remove ctypes
 
-.PHONY: depend distclean clean configure all install $(PROJECTS)
+.PHONY: depend clean configure all install $(PROJECTS)
 
 include .depend Makefile.rules Makefile.examples Makefile.tests
 -include libffi.config
 -include asneeded.config
+
+ifeq ($(libffi_available),false)
+test-libffi:
+	@echo "The following required C libraries are missing: libffi."
+	@echo "Please install them and retry. If they are installed in a non-standard location"
+	@echo "or need special flags, set the environment variables <LIB>_CFLAGS and <LIB>_LIBS"
+	@echo "accordingly and retry."
+	@echo
+	@echo " For example, if libffi is installed in /opt/local, you can type:"
+	@echo
+	@echo "   export LIBFFI_CFLAGS=-I/opt/local/include"
+	@echo "   export LIBFFI_LIBS=-L/opt/local/lib"
+	@exit 1
+else:
+test-libffi:
+endif

--- a/appveyor/build.sh
+++ b/appveyor/build.sh
@@ -71,9 +71,9 @@ else
     export PKG_CONFIG_LIBDIR=${godi_dir}/lib/pkgconfig
 fi
 
-touch setup.data
+touch libffi.config
 make distclean || true
-rm -f setup.data
+rm -f libffi.config
 make all
 make date date-stubs date-stub-generator date-cmd-build date-cmd
 ./_build/date-cmd.native


### PR DESCRIPTION
Split up the base, foreign and stubs sub-projects so that the latter two are optional.

1. There are new top-level build targets, so that you can run

   ```
   make ctypes-base
   make ctypes-foreign
   make ctypes-stubs
   ```
    
   and just build the components you need.  This supersedes #91.

2. `libffi` is no longer required if you're not using the `foreign` subpackage.  Closes #195.

3. If you try to build the `foreign` subpackage when `libffi` is not available the build process exits with a helpful error message:

   ```
   The following required C libraries are missing: libffi.
   Please install them and retry. If they are installed in a non-standard location
   or need special flags, set the environment variables <LIB>_CFLAGS and <LIB>_LIBS
   accordingly and retry.

    For example, if libffi is installed in /opt/local, you can type:

      export LIBFFI_CFLAGS=-I/opt/local/include
      export LIBFFI_LIBS=-L/opt/local/lib
   ```

   Closes #20.

4. `make install` will only install the findlib packages that have been built.  In practice this means that running `make ctypes-base install` (for example) will install the findlib packages `ctypes` and `ctypes.top` and won't complain about the missing `foreign` and stubs components.  For the moment the interface (`.mli`) files for the missing components are still installed, so there's room for improvement.
