### PR TITLE
Custom inverted stubs

### DIFF
--- a/src/cstubs/cstubs_c_language.ml
+++ b/src/cstubs/cstubs_c_language.ml
@@ -40,7 +40,8 @@ type cexp = [ cconst
             | `Addr of cvar ]
 type clvalue = [ clocal | `Index of clvalue * cexp ]
 type camlop = [ `CAMLparam0
-              | `CAMLlocalN of cexp * cexp ]
+              | `CAMLlocalN of cexp * cexp
+              | `CAMLdrop ]
 type ceff = [ cexp
             | camlop
             | `Global of cglobal
@@ -77,7 +78,8 @@ struct
 
   let camlop : camlop -> ty = function
     | `CAMLparam0
-    | `CAMLlocalN _ -> Ty Void
+    | `CAMLlocalN _
+    | `CAMLdrop -> Ty Void
 
   let rec ceff : ceff -> ty = function
     | #cexp as e -> cexp e

--- a/src/cstubs/cstubs_c_language.ml
+++ b/src/cstubs/cstubs_c_language.ml
@@ -48,12 +48,15 @@ type ceff = [ cexp
             | `App of cfunction * cexp list
             | `Index of ceff * cexp
             | `Deref of cexp
-            | `Assign of clvalue * ceff ]
+            | `Assign of clvalue * ceff
+            | `Inline of string
+            ]
 type cbind = clocal * ceff
 type ccomp = [ ceff
              | `LetConst of clocal * cconst * ccomp
              | `CAMLreturnT of ty * cexp
-             | `Let of cbind * ccomp ]
+             | `Let of cbind * ccomp
+             ]
 type cfundec = [ `Fundec of string * (string * ty) list * ty ]
 type cfundef = [ `Function of cfundec * ccomp ]
 

--- a/src/cstubs/cstubs_emit_c.ml
+++ b/src/cstubs/cstubs_emit_c.ml
@@ -57,7 +57,7 @@ let camlop fmt : camlop -> unit = function
   | `CAMLlocalN (e, c) -> Format.fprintf fmt "CAMLlocalN(@[%a@],@ @[%a@])"
     cexp e cexp c
   | `CAMLdrop ->
-    Format.fprintf fmt "caml_local_roots = caml__frame;"
+    Format.fprintf fmt "caml_local_roots = caml__frame"
     (* Format.fprintf fmt "CAMLdrop()" *) (* 4.03+ only *)
 
 let rec ceff fmt : ceff -> unit = function

--- a/src/cstubs/cstubs_emit_c.ml
+++ b/src/cstubs/cstubs_emit_c.ml
@@ -56,6 +56,9 @@ let camlop fmt : camlop -> unit = function
   | `CAMLparam0 -> Format.fprintf fmt "CAMLparam0()"
   | `CAMLlocalN (e, c) -> Format.fprintf fmt "CAMLlocalN(@[%a@],@ @[%a@])"
     cexp e cexp c
+  | `CAMLdrop ->
+    Format.fprintf fmt "caml_local_roots = caml__frame;"
+    (* Format.fprintf fmt "CAMLdrop()" *) (* 4.03+ only *)
 
 let rec ceff fmt : ceff -> unit = function
   | #cexp as e -> cexp fmt e
@@ -125,5 +128,5 @@ let cfundec : Format.formatter -> cfundec -> unit =
       `nonarray fmt
 
 let cfundef fmt (`Function (dec, body) : cfundef) =
-  fprintf fmt "%a@\n{@[<v 2>@\n%a@]@\n}@\n" 
+  fprintf fmt "%a@\n{@[<v 2>@\n%a@]@\n}@\n"
     cfundec dec ccomp body

--- a/src/cstubs/cstubs_emit_c.ml
+++ b/src/cstubs/cstubs_emit_c.ml
@@ -78,6 +78,9 @@ let rec ceff fmt : ceff -> unit = function
   | `Deref e -> fprintf fmt "@[*@[%a@]@]" cexp e
   | `Assign (lv, e) ->
     fprintf fmt "@[@[%a@]@;=@;@[%a@]@]" clvalue lv ceff e
+  | `Inline i ->
+    fprintf fmt "@[%s@]" i
+
 
 let rec ccomp fmt : ccomp -> unit = function
   | #cexp as e -> fprintf fmt "@[<2>return@;@[%a@]@];" cexp e

--- a/src/cstubs/cstubs_generate_c.mli
+++ b/src/cstubs/cstubs_generate_c.mli
@@ -7,14 +7,14 @@
 
 (* C stub generation *)
 
-val fn : cname:string -> stub_name:string -> Format.formatter ->
-         'a Ctypes.fn -> unit
+val fn : cname:string -> stub_name:string ->
+         Format.formatter -> 'a Ctypes.fn -> unit
 
 val value : cname:string -> stub_name:string -> Format.formatter ->
          'a Ctypes.typ -> unit
 
-val inverse_fn : stub_name:string -> Format.formatter ->
-         'a Ctypes.fn -> unit
+val inverse_fn : stub_name:string -> runtime_lock:bool ->
+         Format.formatter -> 'a Ctypes.fn -> unit
 
 val inverse_fn_decl : stub_name:string -> Format.formatter ->
          'a Ctypes.fn -> unit

--- a/src/cstubs/cstubs_generate_c.mli
+++ b/src/cstubs/cstubs_generate_c.mli
@@ -5,6 +5,19 @@
  * See the file LICENSE for details.
  *)
 
+(* C stub customization options. These options are documented in
+   [Cstubs_inverted]. *)
+type inverted_stubs_options =
+  {
+    (* will wrap [caml_release_runtime_system] and
+       [caml_acquire_runtime_system] around callbacks.*)
+    runtime_lock: bool;
+
+    (* will wrap each function call with [caml_c_thread_register] and
+       [caml_c_thread_unregister]. *)
+    c_thread_register: bool;
+  }
+
 (* C stub generation *)
 
 val fn : cname:string -> stub_name:string ->
@@ -13,8 +26,8 @@ val fn : cname:string -> stub_name:string ->
 val value : cname:string -> stub_name:string -> Format.formatter ->
          'a Ctypes.typ -> unit
 
-val inverse_fn : stub_name:string -> runtime_lock:bool ->
-         Format.formatter -> 'a Ctypes.fn -> unit
+val inverse_fn : stub_name:string -> options:inverted_stubs_options ->
+  Format.formatter -> 'a Ctypes.fn -> unit
 
 val inverse_fn_decl : stub_name:string -> Format.formatter ->
          'a Ctypes.fn -> unit

--- a/src/cstubs/cstubs_generate_c.mli
+++ b/src/cstubs/cstubs_generate_c.mli
@@ -5,8 +5,7 @@
  * See the file LICENSE for details.
  *)
 
-(* C stub customization options. These options are documented in
-   [Cstubs_inverted]. *)
+(* C stub customization options. *)
 type inverted_stubs_options =
   {
     (* will wrap [caml_release_runtime_system] and
@@ -16,6 +15,12 @@ type inverted_stubs_options =
     (* will wrap each function call with [caml_c_thread_register] and
        [caml_c_thread_unregister]. *)
     c_thread_register: bool;
+
+    (* Arbitrary C code to be inserted before/after the
+       function. Typically, can be used to insert mutex
+       acquire/release. *)
+    prelude: string option;
+    epilogue: string option;
   }
 
 (* C stub generation *)

--- a/src/cstubs/cstubs_inverted.ml
+++ b/src/cstubs/cstubs_inverted.ml
@@ -14,12 +14,16 @@ sig
   val union : _ Ctypes.union Ctypes.typ -> unit
   val typedef : _ Ctypes.typ -> string -> unit
 
-  val internal : string -> ('a -> 'b) Ctypes.fn -> ('a -> 'b) -> unit
+  val internal : ?runtime_lock:bool -> string -> ('a -> 'b) Ctypes.fn -> ('a -> 'b) -> unit
 end
 
 module type BINDINGS = functor (F : INTERNAL) -> sig end
 
-type fn_info = Fn : string * (_ -> _) Ctypes.fn -> fn_info
+type fn_meta = {
+  fn_runtime_lock : bool;
+  fn_name         : string;
+}
+type fn_info = Fn : fn_meta * (_ -> _) Ctypes.fn -> fn_info
 type ty = Ty : _ Ctypes.typ -> ty
 type typedef = Typedef : _ Ctypes.typ * string -> typedef
 type enum = Enum : (string * int64) list * _ Ctypes.typ -> enum
@@ -42,12 +46,14 @@ let collector () : (module INTERNAL) * (unit -> decl list) =
       let structure typ = push (Decl_ty (Ty typ))
       let union typ = push (Decl_ty (Ty typ))
       let typedef typ name = push (Decl_typedef (Typedef (typ, name)))
-      let internal name fn _ = push (Decl_fn ((Fn (name, fn))))
+      let internal ?(runtime_lock=false) name fn _ =
+        let meta = { fn_runtime_lock = runtime_lock; fn_name = name } in
+        push (Decl_fn ((Fn (meta, fn))))
     end),
    (fun () -> List.rev !decls))
 
 let format_enum_values fmt infos =
-  List.iter (fun (Fn (n, _)) -> Format.fprintf fmt "@[fn_%s,@]@ " n) infos
+  List.iter (fun (Fn ({fn_name}, _)) -> Format.fprintf fmt "@[fn_%s,@]@ " fn_name) infos
 
 let c_prologue fmt register infos =
   Format.fprintf fmt "#include <caml/memory.h>@\n";
@@ -68,8 +74,8 @@ value %s(value i, value v)
   CAMLreturn (Val_unit);
 }@\n" register
 
-let c_function fmt (Fn (stub_name, fn)) : unit =
-  Cstubs_generate_c.inverse_fn ~stub_name fmt fn
+let c_function fmt (Fn ({fn_name; fn_runtime_lock}, fn)) : unit =
+  Cstubs_generate_c.inverse_fn ~stub_name:fn_name ~runtime_lock:fn_runtime_lock fmt fn
 
 let gen_c fmt register infos =
   begin
@@ -77,8 +83,8 @@ let gen_c fmt register infos =
     List.iter (c_function fmt) infos
   end
 
-let c_declaration fmt (Fn (stub_name, fn)) : unit =
-  Cstubs_generate_c.inverse_fn_decl ~stub_name fmt fn
+let c_declaration fmt (Fn ({fn_name; fn_runtime_lock}, fn)) : unit =
+  Cstubs_generate_c.inverse_fn_decl ~stub_name:fn_name fmt fn
 
 let write_structure_declaration fmt (Ty ty) =
   Format.fprintf fmt "@[%a@];@\n@\n" (fun ty -> Ctypes.format_typ ty) ty
@@ -87,7 +93,7 @@ let write_enum_declaration fmt (Enum (constants, ty)) =
   Format.fprintf fmt "@[%a@ {@\n@[<v 2>@\n" (fun ty -> Ctypes.format_typ ty) ty;
   let last = List.length constants - 1 in
   List.iteri
-    (fun i (name, value) -> 
+    (fun i (name, value) ->
        (* Trailing commas are not allowed. *)
        if i < last
        then Format.fprintf fmt "@[%s@ =@ %Ld,@]@\n" name value
@@ -121,15 +127,15 @@ let write_c_header fmt ~prefix (module B : BINDINGS) : unit =
   Format.fprintf fmt "@."
 
 let gen_ml fmt register (infos : fn_info list) : unit =
-  Format.fprintf fmt 
+  Format.fprintf fmt
     "type 'a fn = 'a@\n@\n";
   Format.fprintf fmt
     "module CI = Cstubs_internals@\n@\n";
-  Format.fprintf fmt 
+  Format.fprintf fmt
     "type 'a name = @\n";
   ListLabels.iter infos
-    ~f:(fun (Fn (n, fn)) ->
-      Cstubs_generate_ml.constructor_decl (Printf.sprintf "Fn_%s" n) fn fmt);
+    ~f:(fun (Fn ({fn_name}, fn)) ->
+      Cstubs_generate_ml.constructor_decl (Printf.sprintf "Fn_%s" fn_name) fn fmt);
   Format.fprintf fmt
     "@\n";
   Format.fprintf fmt
@@ -138,13 +144,13 @@ let gen_ml fmt register (infos : fn_info list) : unit =
   Format.fprintf fmt
     "@[<h>let internal : ";
   Format.fprintf fmt
-    "@[type a b.@ @[string -> (a -> b) Ctypes.fn -> (a -> b) -> unit@]@]@ =@\n";
+    "@[type a b.@ @[?runtime_lock:bool -> string -> (a -> b) Ctypes.fn -> (a -> b) -> unit@]@]@ =@\n";
   Format.fprintf fmt
-    "fun name fn f -> match name, fn with@\n@[";
+    "fun ?runtime_lock name fn f -> match name, fn with@\n@[";
   ListLabels.iter infos
-    ~f:(fun (Fn (n, fn)) ->
+    ~f:(fun (Fn ({fn_name}, fn)) ->
       Cstubs_generate_ml.inverse_case ~register_name:"register_value"
-        ~constructor:(Printf.sprintf "Fn_%s" n) n fmt fn);
+        ~constructor:(Printf.sprintf "Fn_%s" fn_name) fn_name fmt fn);
   Format.fprintf fmt
     "| _ -> failwith (\"Linking mismatch on name: \" ^ name)@]@]@]@\n@\n";
   Format.fprintf fmt

--- a/src/cstubs/cstubs_inverted.ml
+++ b/src/cstubs/cstubs_inverted.ml
@@ -85,7 +85,9 @@ value %s(value i, value v)
 }@\n" register
 
 let c_function fmt (Fn (meta, fn)) : unit =
-  let options = Cstubs_generate_c.{
+  let options =
+    let open Cstubs_generate_c in
+    {
       runtime_lock = meta.fn_runtime_lock;
       c_thread_register = meta.fn_c_thread_register;
       prelude = meta.fn_prelude;

--- a/src/cstubs/cstubs_inverted.ml
+++ b/src/cstubs/cstubs_inverted.ml
@@ -162,9 +162,13 @@ let gen_ml fmt register (infos : fn_info list) : unit =
   Format.fprintf fmt
     "@[<h>let internal : ";
   Format.fprintf fmt
-    "@[type a b.@ @[?runtime_lock:bool -> string -> (a -> b) Ctypes.fn -> (a -> b) -> unit@]@]@ =@\n";
+    "@[type a b.@ @[?runtime_lock:bool ->@ \
+     ?c_thread_register:bool ->@ \
+     ?prelude:string ->@ \
+     ?epilogue:string ->@ \
+     string ->@ (a -> b) Ctypes.fn ->@ (a -> b)@ ->@ unit@]@]@ =@\n";
   Format.fprintf fmt
-    "fun ?runtime_lock name fn f -> match name, fn with@\n@[";
+    "fun ?runtime_lock ?c_thread_register ?prelude ?epilogue name fn f ->@\nmatch name, fn with@\n@[";
   ListLabels.iter infos
     ~f:(fun (Fn ({fn_name}, fn)) ->
       Cstubs_generate_ml.inverse_case ~register_name:"register_value"

--- a/src/cstubs/cstubs_inverted.mli
+++ b/src/cstubs/cstubs_inverted.mli
@@ -17,7 +17,10 @@ sig
   val union : _ Ctypes.union Ctypes.typ -> unit
   val typedef : _ Ctypes.typ -> string -> unit
 
-  val internal : ?runtime_lock:bool -> ?c_thread_register:bool -> string -> ('a -> 'b) Ctypes.fn -> ('a -> 'b) -> unit
+  val internal :
+    ?runtime_lock:bool ->
+    ?c_thread_register:bool ->
+    ?prelude:string -> ?epilogue:string -> string -> ('a -> 'b) Ctypes.fn -> ('a -> 'b) -> unit
 end
 
 module type BINDINGS = functor (F : INTERNAL) -> sig end

--- a/src/cstubs/cstubs_inverted.mli
+++ b/src/cstubs/cstubs_inverted.mli
@@ -17,7 +17,7 @@ sig
   val union : _ Ctypes.union Ctypes.typ -> unit
   val typedef : _ Ctypes.typ -> string -> unit
 
-  val internal : string -> ('a -> 'b) Ctypes.fn -> ('a -> 'b) -> unit
+  val internal : ?runtime_lock:bool -> string -> ('a -> 'b) Ctypes.fn -> ('a -> 'b) -> unit
 end
 
 module type BINDINGS = functor (F : INTERNAL) -> sig end

--- a/src/cstubs/cstubs_inverted.mli
+++ b/src/cstubs/cstubs_inverted.mli
@@ -17,7 +17,7 @@ sig
   val union : _ Ctypes.union Ctypes.typ -> unit
   val typedef : _ Ctypes.typ -> string -> unit
 
-  val internal : ?runtime_lock:bool -> string -> ('a -> 'b) Ctypes.fn -> ('a -> 'b) -> unit
+  val internal : ?runtime_lock:bool -> ?c_thread_register:bool -> string -> ('a -> 'b) Ctypes.fn -> ('a -> 'b) -> unit
 end
 
 module type BINDINGS = functor (F : INTERNAL) -> sig end

--- a/src/ctypes/ctypes_cstubs_internals.h
+++ b/src/ctypes/ctypes_cstubs_internals.h
@@ -14,6 +14,7 @@
 #include "ctypes_complex_stubs.h"
 #include "ctypes_raw_pointer.h"
 #include "ctypes_managed_buffer_stubs.h"
+#include <caml/threads.h>
 #define CTYPES_PTR_OF_OCAML_STRING(s) \
   (String_val(Field(s, 1)) + Int_val(Field(s, 0)))
 


### PR DESCRIPTION
This pull request makes it possible to use inverted stubs in a multi threaded context. There are quite a few issues that need to be ironed out (some of them are discussed in here http://caml.inria.fr/mantis/view.php?id=6764) :

- The runtime must be properly initialized. The shared library initializer must make the following calls at initialization time: 
```
caml_startup(caml_argv);
caml_release_runtime_system();
```
- The OCaml code of the library must be compiled with the -threads options, and must link the code from the `Thread` module. 

A few questions:
- it happens that some function might require a slightly different treatment from others (e.g., one particular function should not take the lock, or whatever)
- I have not yet settled on how to deal with attributes and pragmas.
- This might also be the opportunity to deal with these pesky shared objects visibility issues. The way I currently deal with it in the build system is not that satisfying. One could automatically tag the stubs using the proper `_declspec(dllexport)` for Windows and `__attribute__ ((visibility ("default")))` for Unix systems (provided that the latter is used with the correct `-fvisibility` flags at compile time). The issue with this kind of things is that they might complicate the build system for end users.
- One issue with the current state is that it is not possible to write a `#pragma GCC visibility push(default)` before the generated headers 
```
#include <caml/memory.h>
#include <caml/callback.h>
#include "ctypes/cstubs_internals.h"
```
