### PR TITLE
Use the new #include path for ctypes_cstubs_internals.h.

### DIFF
--- a/src/cstubs/cstubs_inverted.ml
+++ b/src/cstubs/cstubs_inverted.ml
@@ -52,7 +52,7 @@ let format_enum_values fmt infos =
 let c_prologue fmt register infos =
   Format.fprintf fmt "#include <caml/memory.h>@\n";
   Format.fprintf fmt "#include <caml/callback.h>@\n";
-  Format.fprintf fmt "#include \"ctypes/cstubs_internals.h\"@\n@\n";
+  Format.fprintf fmt "#include \"ctypes_cstubs_internals.h\"@\n@\n";
   Format.fprintf fmt "enum functions@\n{@[<v 2>@ %afn_count@]@\n};"
     format_enum_values infos;
   Format.fprintf fmt "@\n


### PR DESCRIPTION
Closes #273.