### PR TITLE
Support function pointers in the core type representation

### DIFF
--- a/src/cstubs/cstubs_analysis.ml
+++ b/src/cstubs/cstubs_analysis.ml
@@ -49,6 +49,7 @@ type _ alloc =
 | Alloc_float : float alloc
 | Alloc_complex : Complex.t alloc
 | Alloc_pointer : (_, _) pointer alloc
+| Alloc_funptr : _ static_funptr alloc
 | Alloc_structured : (_, _) structured alloc
 | Alloc_array : _ carray alloc
 | Alloc_bigarray : (_, 'a) Ctypes_bigarray.t -> 'a alloc
@@ -90,6 +91,7 @@ let rec allocation : type a. a typ -> a allocation = function
  | Void -> `Noalloc Noalloc_unit
  | Primitive p -> primitive_allocation p
  | Pointer _ -> `Alloc Alloc_pointer
+ | Funptr _ -> `Alloc Alloc_funptr
  | Struct _ -> `Alloc Alloc_structured
  | Union _ -> `Alloc Alloc_structured
  | Abstract _ -> `Alloc Alloc_structured

--- a/src/cstubs/cstubs_generate_c.ml
+++ b/src/cstubs/cstubs_generate_c.ml
@@ -182,6 +182,7 @@ struct
       let rt = return_type fn in
       Some (cast ~from:rt ~into:(Ty (Primitive p)) (`App (prj, [x])))
     | Pointer _ -> Some (of_fatptr x)
+    | Funptr _ -> Some (of_fatptr x)
     | Struct s ->
       Some ((of_fatptr x, ptr void) >>= fun y ->
             `Deref (`Cast (Ty (ptr orig), y)))
@@ -203,6 +204,7 @@ struct
     | Void -> val_unit
     | Primitive p -> `App (prim_inj p, [`Cast (Ty (Primitive p), (x :> cexp))])
     | Pointer _ -> from_ptr (x:> cexp)
+    | Funptr _ -> from_ptr (x:> cexp)
     | Struct s -> `App (copy_bytes, [`Addr (x :> cvar); `Int (sizeof ty)])
     | Union u -> `App (copy_bytes, [`Addr (x :> cvar); `Int (sizeof ty)])
     | Abstract _ -> report_unpassable "values of abstract type"

--- a/src/cstubs/cstubs_internals.ml
+++ b/src/cstubs/cstubs_internals.ml
@@ -11,6 +11,7 @@
 type voidp = Ctypes_ptr.voidp
 type managed_buffer = Ctypes_memory_stubs.managed_buffer
 type 'a fatptr = 'a Ctypes.typ Ctypes_ptr.Fat.t
+type 'a fatfunptr = 'a Ctypes.fn Ctypes_ptr.Fat.t
 
 let make_structured reftyp buf =
   let open Ctypes_static in
@@ -22,8 +23,10 @@ include Ctypes_static
 include Ctypes_primitive_types
 
 let make_ptr reftyp raw_ptr = CPointer (Ctypes_ptr.Fat.make ~reftyp raw_ptr)
+let make_fun_ptr reftyp raw_ptr = Static_funptr (Ctypes_ptr.Fat.make ~reftyp raw_ptr)
 
 let cptr (CPointer p) = p
+let fptr (Static_funptr p) = p
 
 let mkView :
   type a b. string -> a typ -> unexpected:(a -> b) -> (b * a) list -> b typ =

--- a/src/cstubs/cstubs_internals.mli
+++ b/src/cstubs/cstubs_internals.mli
@@ -32,6 +32,7 @@ type 'a typ = 'a Ctypes_static.typ =
     Void            :                              unit typ
   | Primitive       : 'a Ctypes_primitive_types.prim        -> 'a typ
   | Pointer         : 'a typ                    -> 'a ptr typ
+  | Funptr          : 'a fn                     -> 'a static_funptr typ
   | Struct          : 'a Ctypes_static.structure_type  -> 'a Ctypes_static.structure typ
   | Union           : 'a Ctypes_static.union_type      -> 'a Ctypes_static.union typ
   | Abstract        : Ctypes_static.abstract_type      -> 'a Ctypes_static.abstract typ
@@ -44,6 +45,8 @@ and ('a, 'b) pointer = ('a, 'b) Ctypes_static.pointer =
 | OCamlRef : int * 'a * 'a ocaml_type -> ('a, [`OCaml]) pointer
 and 'a ptr = ('a, [`C]) pointer
 and 'a ocaml = ('a, [`OCaml]) pointer
+and 'a static_funptr = 'a Ctypes_static.static_funptr =
+  Static_funptr of 'a fn Ctypes_ptr.Fat.t
 and ('a, 'b) view = ('a, 'b) Ctypes_static.view = {
   read : 'b -> 'a;
   write : 'a -> 'b;

--- a/src/cstubs/cstubs_internals.mli
+++ b/src/cstubs/cstubs_internals.mli
@@ -15,13 +15,16 @@ open Unsigned
 type voidp = Ctypes_ptr.voidp
 type managed_buffer = Ctypes_memory_stubs.managed_buffer
 type 'a fatptr = 'a typ Ctypes_ptr.Fat.t
+type 'a fatfunptr = 'a fn Ctypes_ptr.Fat.t
 
 val make_structured :
   ('a, 's) structured typ -> managed_buffer -> ('a, 's) structured
 
 val make_ptr : 'a typ -> voidp -> 'a ptr
+val make_fun_ptr : 'a fn -> voidp -> 'a Ctypes_static.static_funptr
 
 val cptr : 'a ptr -> 'a typ Ctypes_ptr.Fat.t
+val fptr : 'a Ctypes_static.static_funptr -> 'a fn Ctypes_ptr.Fat.t
 
 type 'a ocaml_type = 'a Ctypes_static.ocaml_type =
   String     : string ocaml_type

--- a/src/ctypes-foreign-base/ctypes_ffi.ml
+++ b/src/ctypes-foreign-base/ctypes_ffi.ml
@@ -52,6 +52,7 @@ struct
                                                (Ctypes_type_printing.string_of_typ prim)
                                              else ArgType ffitype
     | Pointer _                           -> ArgType (Ctypes_ffi_stubs.pointer_ffitype ())
+    | Funptr _                            -> ArgType (Ctypes_ffi_stubs.pointer_ffitype ())
     | OCaml _                             -> ArgType (Ctypes_ffi_stubs.pointer_ffitype ())
     | Union _                             -> report_unpassable "unions"
     | Struct ({ spec = Complete _ } as s) -> struct_arg_type s

--- a/src/ctypes-foreign-base/ctypes_ffi.mli
+++ b/src/ctypes-foreign-base/ctypes_ffi.mli
@@ -25,12 +25,13 @@ sig
   (** Dynamic function calls based on libffi *)
 
   val function_of_pointer : ?name:string -> abi:abi -> check_errno:bool ->
-    release_runtime_lock:bool -> ('a -> 'b) fn -> unit ptr -> ('a -> 'b)
+    release_runtime_lock:bool -> ('a -> 'b) fn -> ('a -> 'b) static_funptr ->
+    ('a -> 'b)
   (** Build an OCaml function from a type specification and a pointer to a C
       function. *)
 
   val pointer_of_function : abi:abi -> acquire_runtime_lock:bool -> ('a -> 'b) fn ->
-    ('a -> 'b) -> unit ptr
+    ('a -> 'b) -> ('a -> 'b) static_funptr
   (** Build an C function from a type specification and an OCaml function.
 
       The C function pointer returned is callable as long as the OCaml function

--- a/src/ctypes-foreign-base/ctypes_ffi_stubs.ml
+++ b/src/ctypes-foreign-base/ctypes_ffi_stubs.ml
@@ -55,7 +55,7 @@ external prep_callspec : callspec -> int -> _ ffitype -> unit
 (* Call the function specified by `callspec' at the given address.
    The callback functions write the arguments to the buffer and read
    the return value. *)
-external call : string -> unit Ctypes_static.typ Fat.t -> callspec ->
+external call : string -> _ Ctypes_static.fn Fat.t -> callspec ->
   (voidp -> (Obj.t * int) array -> unit) -> (voidp -> 'a) -> 'a
   = "ctypes_call"
 

--- a/src/ctypes-foreign-base/ctypes_foreign_basis.ml
+++ b/src/ctypes-foreign-base/ctypes_foreign_basis.ml
@@ -33,6 +33,9 @@ struct
     Ctypes_std_views.nullable_view ~format_typ
       (funptr ?abi ?name ?check_errno ?runtime_lock fn) void
 
+  let funptr_of_raw_ptr p = 
+    Ctypes.funptr_of_raw_address (Ctypes_ptr.Raw.to_nativeint p)
+
   let ptr_of_raw_ptr p = 
     Ctypes.ptr_of_raw_address (Ctypes_ptr.Raw.to_nativeint p)
 
@@ -42,9 +45,9 @@ struct
   let foreign ?(abi=Libffi_abi.default_abi) ?from ?(stub=false)
       ?(check_errno=false) ?(release_runtime_lock=false) symbol typ =
     try
-      let coerce = Ctypes_coerce.coerce (ptr void)
+      let coerce = Ctypes_coerce.coerce (static_funptr (void @-> returning void))
         (funptr ~abi ~name:symbol ~check_errno ~runtime_lock:release_runtime_lock typ) in
-      coerce (ptr_of_raw_ptr (dlsym ?handle:from ~symbol))
-    with 
+      coerce (funptr_of_raw_ptr (dlsym ?handle:from ~symbol))
+    with
     | exn -> if stub then fun _ -> raise exn else raise exn
 end

--- a/src/ctypes-foreign-base/ctypes_foreign_basis.ml
+++ b/src/ctypes-foreign-base/ctypes_foreign_basis.ml
@@ -30,8 +30,8 @@ struct
 
   let funptr_opt ?abi ?name ?check_errno ?runtime_lock fn =
     let format_typ = format_function_pointer fn in
-    Ctypes_std_views.nullable_view ~format_typ
-      (funptr ?abi ?name ?check_errno ?runtime_lock fn) void
+    Ctypes_std_views.nullable_funptr_view ~format_typ
+      (funptr ?abi ?name ?check_errno ?runtime_lock fn) fn
 
   let funptr_of_raw_ptr p = 
     Ctypes.funptr_of_raw_address (Ctypes_ptr.Raw.to_nativeint p)

--- a/src/ctypes-foreign-base/ctypes_foreign_basis.ml
+++ b/src/ctypes-foreign-base/ctypes_foreign_basis.ml
@@ -26,7 +26,7 @@ struct
     and write = pointer_of_function
       ~abi ~acquire_runtime_lock:runtime_lock fn
     and format_typ = format_function_pointer fn in
-    Ctypes_static.(view ~format_typ ~read ~write (ptr void))
+    Ctypes_static.(view ~format_typ ~read ~write (static_funptr fn))
 
   let funptr_opt ?abi ?name ?check_errno ?runtime_lock fn =
     let format_typ = format_function_pointer fn in

--- a/src/ctypes-foreign-base/ctypes_foreign_basis.ml
+++ b/src/ctypes-foreign-base/ctypes_foreign_basis.ml
@@ -14,23 +14,17 @@ struct
 
   exception CallToExpiredClosure = Ctypes_ffi_stubs.CallToExpiredClosure
 
-  let format_function_pointer fn k fmt =
-    Ctypes_type_printing.format_fn' fn
-      (fun fmt -> Format.fprintf fmt "(*%t)" k) fmt
-
   let funptr ?(abi=Libffi_abi.default_abi) ?name ?(check_errno=false)
       ?(runtime_lock=false) fn =
     let open Ffi in
     let read = function_of_pointer
       ~abi ~check_errno ~release_runtime_lock:runtime_lock ?name fn
     and write = pointer_of_function
-      ~abi ~acquire_runtime_lock:runtime_lock fn
-    and format_typ = format_function_pointer fn in
-    Ctypes_static.(view ~format_typ ~read ~write (static_funptr fn))
+      ~abi ~acquire_runtime_lock:runtime_lock fn in
+    Ctypes_static.(view ~read ~write (static_funptr fn))
 
   let funptr_opt ?abi ?name ?check_errno ?runtime_lock fn =
-    let format_typ = format_function_pointer fn in
-    Ctypes_std_views.nullable_funptr_view ~format_typ
+    Ctypes_std_views.nullable_funptr_view
       (funptr ?abi ?name ?check_errno ?runtime_lock fn) fn
 
   let funptr_of_raw_ptr p = 

--- a/src/ctypes-foreign-base/ffi_call_stubs.c
+++ b/src/ctypes-foreign-base/ffi_call_stubs.c
@@ -288,7 +288,7 @@ value ctypes_prep_callspec(value callspec_, value abi_, value rtype)
 
 /* Call the function specified by `callspec', passing arguments and return
    values in `buffer' */
-/* call : string -> raw_pointer -> callspec ->
+/* call : string -> _ fn Fat.t -> callspec ->
           (raw_pointer -> Obj.t array -> unit) -> (raw_pointer -> 'a) -> 'a */
 value ctypes_call(value fnname, value function, value callspec_,
                   value argwriter, value rvreader)

--- a/src/ctypes/ctypes.mli
+++ b/src/ctypes/ctypes.mli
@@ -206,6 +206,9 @@ val reference_type : 'a ptr -> 'a typ
 val ptr_of_raw_address : nativeint -> unit ptr
 (** Convert the numeric representation of an address to a pointer *)
 
+val funptr_of_raw_address : nativeint -> (unit -> unit) Ctypes_static.static_funptr
+(** Convert the numeric representation of an address to a function pointer *)
+
 val raw_address_of_ptr : unit ptr -> nativeint
 (** [raw_address_of_ptr p] returns the numeric representation of p.
 

--- a/src/ctypes/ctypes.mli
+++ b/src/ctypes/ctypes.mli
@@ -113,7 +113,6 @@ type 'a abstract = 'a Ctypes_static.abstract
 include Ctypes_types.TYPE
  with type 'a typ = 'a Ctypes_static.typ
   and type ('a, 's) field := ('a, 's) field
-include Ctypes_types.FUNCTION
 
 (** {3 Operations on types} *)
 

--- a/src/ctypes/ctypes.mli
+++ b/src/ctypes/ctypes.mli
@@ -383,7 +383,7 @@ val coerce : 'a typ -> 'b typ -> 'a -> 'b
 
     The following coercions are currently supported:
 
-     - All pointer types are intercoercible.
+     - All function and object pointer types are intercoercible.
      - Any type may be coerced to {!void}
      - There is a coercion between a {!view} and another type [t] (in either
        direction) if there is a coercion between the representation type

--- a/src/ctypes/ctypes_coerce.ml
+++ b/src/ctypes/ctypes_coerce.ml
@@ -69,6 +69,10 @@ let rec coercion : type a b. a typ -> b typ -> (a, b) coercion =
       with Uncoercible ->
         Coercion (fun (CPointer p) -> CPointer (Ctypes_ptr.Fat.coerce p b))
     end
+  | Pointer a, Funptr b ->
+    Coercion (fun (CPointer p) -> Static_funptr (Ctypes_ptr.Fat.coerce p b))
+  | Funptr a, Pointer b ->
+    Coercion (fun (Static_funptr p) -> CPointer (Ctypes_ptr.Fat.coerce p b))
   | Funptr a, Funptr b ->
     begin
       try

--- a/src/ctypes/ctypes_coerce.ml
+++ b/src/ctypes/ctypes_coerce.ml
@@ -69,9 +69,20 @@ let rec coercion : type a b. a typ -> b typ -> (a, b) coercion =
       with Uncoercible ->
         Coercion (fun (CPointer p) -> CPointer (Ctypes_ptr.Fat.coerce p b))
     end
+  | Funptr a, Funptr b ->
+    begin
+      try
+        begin match fn_coercion a b with
+        | Id -> Id
+        | Coercion _ ->
+          Coercion (fun (Static_funptr p) -> Static_funptr (Ctypes_ptr.Fat.coerce p b))
+        end
+      with Uncoercible ->
+        Coercion (fun (Static_funptr p) -> Static_funptr (Ctypes_ptr.Fat.coerce p b))
+    end
   | _ -> raise Uncoercible
 
-let rec fn_coercion : type a b. a fn -> b fn -> (a, b) coercion =
+and fn_coercion : type a b. a fn -> b fn -> (a, b) coercion =
   fun afn bfn -> match afn, bfn with
   | Function (af, at), Function (bf, bt) ->
     begin match coercion bf af, fn_coercion at bt with

--- a/src/ctypes/ctypes_memory.ml
+++ b/src/ctypes/ctypes_memory.ml
@@ -29,6 +29,8 @@ let rec build : type a b. a typ -> b typ Fat.t -> a
         { structured = CPointer dst})
     | Pointer reftyp ->
       (fun buf -> CPointer (Fat.make ~reftyp (Stubs.Pointer.read buf)))
+    | Funptr fn ->
+      (fun buf -> Static_funptr (Fat.make ~reftyp:fn (Stubs.Pointer.read buf)))
     | View { read; ty } ->
       let buildty = build ty in
       (fun buf -> read (buildty buf))
@@ -49,6 +51,8 @@ let rec write : type a b. a typ -> a -> b Fat.t -> unit
     | Primitive p -> Stubs.write p
     | Pointer _ ->
       (fun (CPointer p) dst -> Stubs.Pointer.write p dst)
+    | Funptr _ ->
+      (fun (Static_funptr p) dst -> Stubs.Pointer.write p dst)
     | Struct { spec = Incomplete _ } -> raise IncompleteType
     | Struct { spec = Complete _ } as s -> write_aggregate (sizeof s)
     | Union { uspec = None } -> raise IncompleteType

--- a/src/ctypes/ctypes_memory.ml
+++ b/src/ctypes/ctypes_memory.ml
@@ -150,6 +150,9 @@ let reference_type (CPointer p) = Fat.reftype p
 let ptr_of_raw_address addr =
   CPointer (Fat.make ~reftyp:Void (Raw.of_nativeint addr))
 
+let funptr_of_raw_address addr =
+  Static_funptr (Fat.make ~reftyp:(void @-> returning void) (Raw.of_nativeint addr))
+
 let raw_address_of_ptr (CPointer p) =
   (* This is unsafe by definition: if the object to which [p] refers
      is collected at this point then the returned address is invalid.

--- a/src/ctypes/ctypes_ptr.ml
+++ b/src/ctypes/ctypes_ptr.ml
@@ -54,6 +54,8 @@ sig
       address is stored in [raw_ptr]. *)
   val make : ?managed:_ -> reftyp:'typ -> voidp -> 'typ t
 
+  val is_null : _ t -> bool
+
   val reftype : 'typ t -> 'typ
 
   val managed : _ t -> Obj.t option
@@ -80,6 +82,8 @@ struct
   let make ?managed ~reftyp raw = match managed with
     | None   -> { reftyp; raw; managed = None }
     | Some v -> { reftyp; raw; managed = Some (Obj.repr v) }
+
+  let is_null { raw } = Raw.(compare zero) raw = 0
 
   let reftype { reftyp } = reftyp
 

--- a/src/ctypes/ctypes_static.ml
+++ b/src/ctypes/ctypes_static.ml
@@ -226,6 +226,7 @@ let returning v =
     raise (Unsupported "Unsupported return type")
   else
     Returns v
+let static_funptr fn = Funptr fn
 
 let structure tag =
   Struct { spec = Incomplete { isize = 0 }; tag; fields = [] }

--- a/src/ctypes/ctypes_static.ml
+++ b/src/ctypes/ctypes_static.ml
@@ -36,6 +36,7 @@ type _ typ =
     Void            :                       unit typ
   | Primitive       : 'a Ctypes_primitive_types.prim -> 'a typ
   | Pointer         : 'a typ             -> 'a ptr typ
+  | Funptr          : 'a fn              -> 'a static_funptr typ
   | Struct          : 'a structure_type  -> 'a structure typ
   | Union           : 'a union_type      -> 'a union typ
   | Abstract        : abstract_type      -> 'a abstract typ
@@ -54,6 +55,7 @@ and (_, _) pointer =
 | OCamlRef : int * 'a * 'a ocaml_type -> ('a, [`OCaml]) pointer
 and 'a ptr = ('a, [`C]) pointer
 and 'a ocaml = ('a, [`OCaml]) pointer
+and 'a static_funptr = Static_funptr of 'a fn Ctypes_ptr.Fat.t
 and ('a, 'b) view = {
   read : 'b -> 'a;
   write : 'a -> 'b;
@@ -79,6 +81,9 @@ and 'a union_type = {
   mutable ufields : 'a union boxed_field list;
 }
 and 's boxed_field = BoxedField : ('a, 's) field -> 's boxed_field
+and _ fn =
+  | Returns  : 'a typ   -> 'a fn
+  | Function : 'a typ * 'b fn  -> ('a -> 'b) fn
 
 type _ bigarray_class =
   Genarray :
@@ -106,10 +111,6 @@ type _ bigarray_class =
     bigarray: ('a, 'b, Bigarray.c_layout) Bigarray.Array3.t;
     carray: 'a carray carray carray > bigarray_class
 
-type _ fn =
-  | Returns  : 'a typ   -> 'a fn
-  | Function : 'a typ * 'b fn  -> ('a -> 'b) fn
-
 type boxed_typ = BoxedType : 'a typ -> boxed_typ
 
 let rec sizeof : type a. a typ -> int = function
@@ -125,6 +126,7 @@ let rec sizeof : type a. a typ -> int = function
   | Bigarray ba                    -> Ctypes_bigarray.sizeof ba
   | Abstract { asize }             -> asize
   | Pointer _                      -> Ctypes_primitives.pointer_size
+  | Funptr _                       -> Ctypes_primitives.pointer_size
   | OCaml _                        -> raise IncompleteType
   | View { ty }                    -> sizeof ty
 
@@ -140,6 +142,7 @@ let rec alignment : type a. a typ -> int = function
   | Bigarray ba                      -> Ctypes_bigarray.alignment ba
   | Abstract { aalignment }          -> aalignment
   | Pointer _                        -> Ctypes_primitives.pointer_alignment
+  | Funptr _                         -> Ctypes_primitives.pointer_alignment
   | OCaml _                          -> raise IncompleteType
   | View { ty }                      -> alignment ty
 
@@ -153,6 +156,7 @@ let rec passable : type a. a typ -> bool = function
   | Array _                        -> false
   | Bigarray _                     -> false
   | Pointer _                      -> true
+  | Funptr _                       -> true
   | Abstract _                     -> false
   | OCaml _                        -> true
   | View { ty }                    -> passable ty

--- a/src/ctypes/ctypes_static.mli
+++ b/src/ctypes/ctypes_static.mli
@@ -30,6 +30,7 @@ type _ typ =
     Void            :                       unit typ
   | Primitive       : 'a Ctypes_primitive_types.prim -> 'a typ
   | Pointer         : 'a typ             -> 'a ptr typ
+  | Funptr          : 'a fn              -> 'a static_funptr typ
   | Struct          : 'a structure_type  -> 'a structure typ
   | Union           : 'a union_type      -> 'a union typ
   | Abstract        : abstract_type      -> 'a abstract typ
@@ -48,6 +49,7 @@ and (_, _) pointer =
 | OCamlRef : int * 'a * 'a ocaml_type -> ('a, [`OCaml]) pointer
 and 'a ptr = ('a, [`C]) pointer
 and 'a ocaml = ('a, [`OCaml]) pointer
+and 'a static_funptr = Static_funptr of 'a fn Ctypes_ptr.Fat.t
 and ('a, 'b) view = {
   read : 'b -> 'a;
   write : 'a -> 'b;
@@ -71,6 +73,9 @@ and 'a union_type = {
   mutable ufields : 'a union boxed_field list;
 }
 and 's boxed_field = BoxedField : ('a, 's) field -> 's boxed_field
+and _ fn =
+  | Returns  : 'a typ   -> 'a fn
+  | Function : 'a typ * 'b fn  -> ('a -> 'b) fn
 
 type _ bigarray_class =
   Genarray :
@@ -97,10 +102,6 @@ type _ bigarray_class =
     ba_repr: 'b;
     bigarray: ('a, 'b, Bigarray.c_layout) Bigarray.Array3.t;
     carray: 'a carray carray carray > bigarray_class
-
-type _ fn =
-  | Returns  : 'a typ   -> 'a fn
-  | Function : 'a typ * 'b fn  -> ('a -> 'b) fn
 
 type boxed_typ = BoxedType : 'a typ -> boxed_typ
 

--- a/src/ctypes/ctypes_static.mli
+++ b/src/ctypes/ctypes_static.mli
@@ -156,6 +156,7 @@ val bigarray : < ba_repr : 'c;
                  element : 'a > bigarray_class ->
                'b -> ('a, 'c) Bigarray.kind -> 'd typ
 val returning : 'a typ -> 'a fn
+val static_funptr : 'a fn -> 'a static_funptr typ
 val structure : string -> 'a structure typ
 val union : string -> 'a union typ
 val offsetof : ('a, 'b) field -> int

--- a/src/ctypes/ctypes_std_views.ml
+++ b/src/ctypes/ctypes_std_views.ml
@@ -29,6 +29,24 @@ let nullable_view ?format_typ ?format t reftyp =
   and write = write_nullable t reftyp
   in Ctypes_static.(view ~read ~write ?format_typ ?format (ptr reftyp))
 
+let read_nullable_funptr t reftyp =
+  let coerce = Ctypes_coerce.coerce (Ctypes_static.static_funptr reftyp) t in
+  fun (Ctypes_static.Static_funptr p as ptr) ->
+    if Ctypes_ptr.Fat.is_null p
+    then None
+    else Some (coerce ptr)
+
+let write_nullable_funptr t reftyp =
+  let coerce = Ctypes_coerce.coerce t Ctypes_static.(static_funptr reftyp) in
+  function None -> Ctypes_static.Static_funptr
+                     (Ctypes_ptr.Fat.make ~reftyp Ctypes_ptr.Raw.null)
+         | Some f -> coerce f
+
+let nullable_funptr_view ?format_typ ?format t reftyp =
+  let read = read_nullable_funptr t reftyp
+  and write = write_nullable_funptr t reftyp
+  in Ctypes_static.(view ~read ~write ?format_typ ?format (static_funptr reftyp))
+
 let ptr_opt t = nullable_view (Ctypes_static.ptr t) t
 
 let string_opt = nullable_view string Ctypes_static.char

--- a/src/ctypes/ctypes_type_printing.ml
+++ b/src/ctypes/ctypes_type_printing.ml
@@ -53,6 +53,9 @@ let rec format_typ' : type a. a typ ->
             | `array -> fprintf fmt "(*%t)" (k `nonarray)
             | _      -> fprintf fmt "*%t" (k `nonarray))
         `nonarray fmt
+    | Funptr fn ->
+      format_fn' fn
+        (fun fmt -> Format.fprintf fmt "(*%t)" (k `nonarray)) fmt
     | Array (ty, n) ->
       format_typ' ty (fun _ fmt -> fprintf fmt "%t[%d]" (k `array) n) `nonarray
         fmt

--- a/src/ctypes/ctypes_types.mli
+++ b/src/ctypes/ctypes_types.mli
@@ -304,14 +304,9 @@ sig
       [sizeof].  The [lift_typ] function makes it possible to use concrete
       type representations wherever such abstract type representations are
       needed. *)
-end
-
-(** Abstract interface to C function type descriptions *)
-module type FUNCTION =
-sig
-  open Ctypes_static
 
   (** {3 Function types} *)
+  (** Abstract interface to C function type descriptions *)
 
   type 'a fn = 'a Ctypes_static.fn
   (** The type of values representing C function types.  A value of type [t fn]

--- a/src/ctypes/ctypes_types.mli
+++ b/src/ctypes/ctypes_types.mli
@@ -306,7 +306,6 @@ sig
       needed. *)
 end
 
-
 (** Abstract interface to C function type descriptions *)
 module type FUNCTION =
 sig

--- a/src/ctypes/ctypes_types.mli
+++ b/src/ctypes/ctypes_types.mli
@@ -328,4 +328,12 @@ sig
   (** Give the return type of a C function.  Note that [returning] is intended
       to be used together with {!(@->)}; see the documentation for {!(@->)} for an
       example. *)
+
+  (** {3 Function pointer types} *)
+  type 'a static_funptr = 'a Ctypes_static.static_funptr
+  (** The type of values representing C function pointer types. *)
+
+  val static_funptr : 'a fn -> 'a Ctypes_static.static_funptr typ
+  (** Construct a function pointer type from an existing function type
+      (called the {i reference type}).  *)
 end

--- a/src/ctypes/ctypes_value_printing.ml
+++ b/src/ctypes/ctypes_value_printing.ml
@@ -14,6 +14,7 @@ let rec format : type a. a typ -> Format.formatter -> a -> unit
   | Primitive p ->
     Format.pp_print_string fmt (Ctypes_value_printing_stubs.string_of_prim p v)
   | Pointer _ -> format_ptr fmt v
+  | Funptr _ -> format_funptr fmt v
   | Struct _ -> format_structured fmt v
   | Union _ -> format_structured fmt v
   | Array (a, n) -> format_array fmt v
@@ -81,6 +82,9 @@ and format_fields : type a b. string -> (a, b) structured boxed_field list ->
       fields
 and format_ptr : type a. Format.formatter -> a ptr -> unit
   = fun fmt (CPointer p) ->
+    Format.fprintf fmt "%s" (Ctypes_value_printing_stubs.string_of_pointer p)
+and format_funptr  : type a. Format.formatter -> a static_funptr -> unit
+  = fun fmt (Static_funptr p) ->
     Format.fprintf fmt "%s" (Ctypes_value_printing_stubs.string_of_pointer p)
 
 let string_of typ v = Ctypes_common.string_of (format typ) v

--- a/tests/test-higher_order/stubs/functions.ml
+++ b/tests/test-higher_order/stubs/functions.ml
@@ -16,6 +16,9 @@ struct
   let higher_order_1 = foreign "higher_order_1"
     (funptr (int @-> int @-> returning int) @-> int @-> int @-> returning int)
 
+  let higher_order_1_static = foreign "higher_order_1"
+    (static_funptr (int @-> int @-> returning int) @-> int @-> int @-> returning int)
+
   let higher_order_3 = foreign "higher_order_3"
     (funptr (funptr (int @-> int @-> returning int) @->
              int @-> int @-> returning int) @->
@@ -24,6 +27,9 @@ struct
 
   let returning_funptr = foreign "returning_funptr"
     (int @-> returning (funptr (int @-> int @-> returning int)))
+
+  let returning_funptr_static = foreign "returning_funptr"
+    (int @-> returning (static_funptr (int @-> int @-> returning int)))
 
   let callback_returns_funptr = foreign "callback_returns_funptr"
     (funptr (int @-> returning (funptr (int @-> returning int))) @->

--- a/tests/test-higher_order/test_higher_order.ml
+++ b/tests/test-higher_order/test_higher_order.ml
@@ -107,6 +107,20 @@ struct
       call_registered_callback 3 !counter;
       assert_equal !counter 8;
     end
+
+
+  (*
+    Retrieve a function pointer from C and pass it back to C using
+    static_funptr.
+  *)
+  let test_static_funptr _ =
+    let add = returning_funptr_static 0
+    and mul = returning_funptr_static 1 in
+
+    begin
+      assert_equal 1 (higher_order_1_static add 2 3);
+      assert_equal 0 (higher_order_1_static mul 2 3);
+    end
 end
 
 
@@ -144,6 +158,12 @@ let suite = "Higher-order tests" >:::
 
    "test_zero_argument_callbacks (stubs)"
    >:: Stub_tests.test_zero_argument_callbacks;
+
+   "test_static_funptr (foreign)"
+   >:: Foreign_tests.test_static_funptr;
+
+   "test_static_funptr (stubs)"
+   >:: Stub_tests.test_static_funptr;
   ]
 
 

--- a/tests/test-raw/test_raw.ml
+++ b/tests/test-raw/test_raw.ml
@@ -30,8 +30,9 @@ let test_fabs _ =
       double_ffitype in
     
     let dlfabs = Dl.dlsym "fabs" in
-    let dlfabs_fat = Ctypes_ptr.Fat.make ~reftyp:Ctypes_static.Void dlfabs in
-    
+    let dlfabs_fat = Ctypes_ptr.Fat.make dlfabs
+        ~reftyp:Ctypes.(double @-> returning double) in
+
     let fabs x =
       call "fabs" dlfabs_fat callspec
         (fun p _values ->
@@ -63,8 +64,9 @@ let test_pow _ =
       double_ffitype in
     
     let dlpow = Dl.dlsym "pow" in
-    let dlpow_fat = Ctypes_ptr.Fat.make ~reftyp:Ctypes_static.Void dlpow in
-    
+    let dlpow_fat = Ctypes_ptr.Fat.make dlpow
+        ~reftyp:Ctypes.(double @-> double @-> returning double) in
+
     let pow x y =
       call "pow" dlpow_fat callspec
         (fun buffer _values ->


### PR DESCRIPTION
In standard C, object pointers (such as `void *`) and function pointers (such as `void(*)(void)`) are not compatible.  This pull request reflects that incompatibility by distinguishing them in ctypes' core language (i.e. Ctypes_static.typ).  This is mostly an internal change, but there are a couple of externally-visible additions:

* A new type `static_funptr` and and accompanying type representation constructor of the same name.  This is less flexible than `Foreign.funptr`, but doesn't rely on `libffi`.  You can use `static_funptr` to store function pointers returned from C, and to pass those function pointers back to C:

   ```ocaml
   let qsort = foreign "qsort"
     (ptr void @-> size_t @-> size_t @->
      static_funptr (ptr void @-> ptr void @-> returning int) @->
      returning void)
   ```

  However, `static_funptr` doesn't support passing OCaml functions to C, or calling C functions directly from OCaml.  `Foreign.funptr` is now a view over `static_funptr`, and adds those latter facilities.

* A new function `funptr_of_raw_address` for building function pointers from numeric addresses.

Following C, all function pointers are intercoercible using `Ctypes.coerce`.  For backwards compatibility, object and function pointers are also intercoercible.

This request also lays the basis for #278.
