### PR TITLE
Add support for ptrdiff_t as a typedef for a signed integer type.

### DIFF
--- a/src/ctypes/ctypes_std_view_stubs.ml
+++ b/src/ctypes/ctypes_std_view_stubs.ml
@@ -20,3 +20,6 @@ external uintptr_t_size : unit -> int = "ctypes_uintptr_t_size"
 
 (* Size information for uintptr_t *)
 external intptr_t_size : unit -> int = "ctypes_intptr_t_size"
+
+(* Size information for ptrdiff_t *)
+external ptrdiff_t_size : unit -> int = "ctypes_ptrdiff_t_size"

--- a/src/ctypes/ctypes_std_views.ml
+++ b/src/ctypes/ctypes_std_views.ml
@@ -85,3 +85,7 @@ module Uintptr = (val unsigned_typedef "uintptr_t"
                     ~size:(Ctypes_std_view_stubs.uintptr_t_size ()))
 let intptr_t = Intptr.t
 let uintptr_t = Uintptr.t
+
+module Ptrdiff = (val signed_typedef "ptrdiff_t"
+                     ~size:(Ctypes_std_view_stubs.ptrdiff_t_size ()))
+let ptrdiff_t = Ptrdiff.t

--- a/src/ctypes/ctypes_types.mli
+++ b/src/ctypes/ctypes_types.mli
@@ -96,6 +96,10 @@ sig
   val intptr_t : Intptr.t typ
   (** Value representing the C type [intptr_t]. *)
 
+  module Ptrdiff : Signed.S
+  val ptrdiff_t : Ptrdiff.t typ
+  (** Value representing the C type [ptrdiff_t]. *)
+
   val camlint : int typ
   (** Value representing an integer type with the same storage requirements as
       an OCaml [int]. *)

--- a/src/ctypes/unsigned_stubs.c
+++ b/src/ctypes/unsigned_stubs.c
@@ -173,3 +173,4 @@ value ctypes_uint64_of_int64 (value i) { return ctypes_copy_uint64(Int64_val(i))
 value ctypes_int64_of_uint64 (value u) { return caml_copy_int64(Uint_custom_val(uint64_t, u)); }
 value ctypes_uintptr_t_size (value _) { return Val_int(sizeof (uintptr_t)); }
 value ctypes_intptr_t_size (value _) { return Val_int(sizeof (intptr_t)); }
+value ctypes_ptrdiff_t_size (value _) { return Val_int(sizeof (ptrdiff_t)); }


### PR DESCRIPTION
Closes #117.