### PR TITLE
Support adding fields to structs identified by typedefs

### DIFF
--- a/tests/clib/test_functions.c
+++ b/tests/clib/test_functions.c
@@ -565,6 +565,10 @@ size_t sizeof_s4(void) { return sizeof(struct s4); }
 size_t alignmentof_s4(void) { return offsetof(struct { char c; struct s4 x; }, x); }
 size_t offsetof_z3(void) { return offsetof(struct s4, z3); }
 size_t offsetof_z4(void) { return offsetof(struct s4, z4); }
+size_t sizeof_s6(void) { return sizeof(s6); }
+size_t alignmentof_s6(void) { return offsetof(struct { char c; s6 x; }, x); }
+size_t offsetof_v1(void) { return offsetof(s6, v1); }
+size_t offsetof_v2(void) { return offsetof(s6, v2); }
 
 size_t sizeof_u1(void) { return sizeof(union u1); }
 size_t alignmentof_u1(void) { return offsetof (struct { char c; union u1 x; }, x); }

--- a/tests/clib/test_functions.c
+++ b/tests/clib/test_functions.c
@@ -572,6 +572,8 @@ size_t offsetof_v2(void) { return offsetof(s6, v2); }
 
 size_t sizeof_u1(void) { return sizeof(union u1); }
 size_t alignmentof_u1(void) { return offsetof (struct { char c; union u1 x; }, x); }
+size_t sizeof_u2(void) { return sizeof(u2); }
+size_t alignmentof_u2(void) { return offsetof (struct { char c; u2 x; }, x); }
 
 bool bool_and(bool l, bool r)
 {

--- a/tests/clib/test_functions.h
+++ b/tests/clib/test_functions.h
@@ -200,9 +200,13 @@ size_t offsetof_v1(void);
 size_t offsetof_v2(void);
 
 union u1 { char x1; float x2; double x3; char x4[13]; };
+typedef union { int t1; float t2; } u2;
 
 size_t sizeof_u1(void);
 size_t alignmentof_u1(void);
+
+size_t sizeof_u2(void);
+size_t alignmentof_u2(void);
 
 bool bool_and(bool, bool);
 int call_s5(struct s1 *, struct s5 *);

--- a/tests/clib/test_functions.h
+++ b/tests/clib/test_functions.h
@@ -169,6 +169,7 @@ struct s2 { int y1, y2, y3, y4; };
 struct s3 { int z1; struct s3 *z2; };
 struct s4 { struct s3 z3; struct s3 *z4; };
 struct s5 { int (*w1)(struct s1 *); };
+typedef struct { int v1; float v2; } s6;
 
 size_t sizeof_s1(void);
 size_t alignmentof_s1(void);
@@ -192,6 +193,11 @@ size_t sizeof_s4(void);
 size_t alignmentof_s4(void);
 size_t offsetof_z3(void);
 size_t offsetof_z4(void);
+
+size_t sizeof_s6(void);
+size_t alignmentof_s6(void);
+size_t offsetof_v1(void);
+size_t offsetof_v2(void);
 
 union u1 { char x1; float x2; double x3; char x4[13]; };
 

--- a/tests/test-structs/stubs/types.ml
+++ b/tests/test-structs/stubs/types.ml
@@ -42,4 +42,11 @@ struct
   let s5 : [`s5] structure typ = structure "s5"
   let w1 = field s5 "w1" (lift_typ (Foreign.funptr Ctypes.(ptr s1_fwd @-> returning int)))
   let () = seal s5
+
+  (* adding fields through views (typedefs) *)
+  let struct_s6 : [`s6] structure typ = structure ""
+  let s6 = typedef struct_s6 "s6"
+  let v1 = field s6 "v1" int
+  let v2 = field s6 "v2" float
+  let () = seal s6
 end

--- a/tests/test-structs/test_structs.ml
+++ b/tests/test-structs/test_structs.ml
@@ -98,6 +98,19 @@ let test_incomplete_struct_members _ =
 
 
 (*
+  Test that fields can be added to views over structs.
+*)
+let test_adding_fields_through_views _ =
+  let module M = struct
+    let struct_s = structure "struct_s"
+    let s = typedef struct_s "s"
+    let i = field s "i" int
+    let j = field s "j" float
+    let () = seal s
+  end in ()
+
+
+(*
   Test that OCaml types cannot be used as struct or union fields.
 *)
 let test_ocaml_types_rejected_as_fields _ =
@@ -578,6 +591,9 @@ let suite = "Struct tests" >:::
 
    "incomplete struct members rejected"
    >:: test_incomplete_struct_members;
+
+   "fields can be added to views over structs"
+   >:: test_adding_fields_through_views;
 
    "ocaml_string cannot be used as a structure field"
    >:: test_ocaml_types_rejected_as_fields;

--- a/tests/test-structs/test_structs.ml
+++ b/tests/test-structs/test_structs.ml
@@ -455,7 +455,6 @@ struct
   let offsetof_y2 = retrieve_size "offsetof_y2"
   let offsetof_y3 = retrieve_size "offsetof_y3"
   let offsetof_y4 = retrieve_size "offsetof_y4"
-
   let sizeof_s3 = retrieve_size "sizeof_s3"
   let alignmentof_s3 = retrieve_size "alignmentof_s3"
   let offsetof_z1 = retrieve_size "offsetof_z1"
@@ -464,6 +463,10 @@ struct
   let alignmentof_s4 = retrieve_size "alignmentof_s4"
   let offsetof_z3 = retrieve_size "offsetof_z3"
   let offsetof_z4 = retrieve_size "offsetof_z4"
+  let sizeof_s6 = retrieve_size "sizeof_s6"
+  let alignmentof_s6 = retrieve_size "alignmentof_s6"
+  let offsetof_v1 = retrieve_size "offsetof_v1"
+  let offsetof_v2 = retrieve_size "offsetof_v2"
 
   (*
     Test that struct layout retrieved from C correctly accounts for missing
@@ -530,6 +533,26 @@ struct
 
       assert_equal offsetof_z4
         (offsetof M.z4);
+    end
+
+
+  (* Test that we can retrieve information for structs without tags that are
+     identified through typedefs, e.g.
+         typedef struct { int x; float y; } t;
+   *)
+  let test_tagless_structs _ =
+    begin
+      assert_equal sizeof_s6
+        (sizeof M.s6);
+
+      assert_equal alignmentof_s6
+        (alignment M.s6);
+
+      assert_equal offsetof_v1
+        (offsetof M.v1);
+
+      assert_equal offsetof_v2
+        (offsetof M.v2);
     end
 
 
@@ -633,6 +656,9 @@ let suite = "Struct tests" >:::
 
    "test retrieving information about structs with dependencies"
    >:: Struct_stubs_tests.test_struct_dependencies;
+
+   "test adding fields to tagless structs"
+   >:: Struct_stubs_tests.test_tagless_structs;
   ]
 
 

--- a/tests/test-unions/stubs/types.ml
+++ b/tests/test-unions/stubs/types.ml
@@ -15,4 +15,11 @@ struct
   let u1 : [`u1] union typ = union "u1"
   let x1 = field u1 "x1" char
   let () = seal u1
+
+  (* adding fields through views (typedefs) *)
+  let union_u2 : [`s7] union typ = union ""
+  let u2 = typedef union_u2 "u2"
+  let t1 = field u2 "t1" int
+  let t2 = field u2 "t2" float
+  let () = seal u2
 end

--- a/tests/test-unions/test_unions.ml
+++ b/tests/test-unions/test_unions.ml
@@ -162,6 +162,9 @@ struct
   let sizeof_u1 = retrieve_size "sizeof_u1"
   let alignmentof_u1 = retrieve_size "alignmentof_u1"
 
+  let sizeof_u2 = retrieve_size "sizeof_u2"
+  let alignmentof_u2 = retrieve_size "alignmentof_u2"
+
   (*
     Test that union layout retrieved from C correctly accounts for missing
     fields.
@@ -173,6 +176,20 @@ struct
 
       assert_equal alignmentof_u1
         (alignment M.u1);
+    end
+
+
+  (* Test that we can retrieve information for unions without tags that are
+     identified through typedefs, e.g.
+         typedef union { int x; float y; } u;
+   *)
+  let test_tagless_unions _ =
+    begin
+      assert_equal sizeof_u2
+        (sizeof M.u2);
+
+      assert_equal alignmentof_u2
+        (alignment M.u2);
     end
 end
 
@@ -277,6 +294,9 @@ let suite = "Union tests" >:::
 
    "sealing empty union"
     >:: test_sealing_empty_union;
+
+   "test adding fields to tagless unions"
+   >:: Struct_stubs_tests.test_tagless_unions;
 
    (* "test layout of unions with missing fields" *)
    (* >:: Struct_stubs_tests.test_missing_fields; *)

--- a/tests/test-unions/test_unions.ml
+++ b/tests/test-unions/test_unions.ml
@@ -221,6 +221,19 @@ let test_updating_sealed_union _ =
 
 
 (*
+  Test that fields can be added to views over unions.
+*)
+let test_adding_fields_through_views _ =
+  let module M = struct
+    let union_u = union "union_u"
+    let u = typedef union_u "u"
+    let x = field u "x" int
+    let y = field u "y" float
+    let () = seal u
+  end in ()
+
+
+(*
   Test that attempting to seal an empty union is treated as an error.
 *)
 let test_sealing_empty_union _ =
@@ -255,6 +268,12 @@ let suite = "Union tests" >:::
 
    "updating sealed union"
     >:: test_updating_sealed_union;
+
+   "sealing empty union"
+    >:: test_sealing_empty_union;
+
+   "fields can be added to views over unions"
+   >:: test_adding_fields_through_views;
 
    "sealing empty union"
     >:: test_sealing_empty_union;


### PR DESCRIPTION
It's common style in C code to omit struct tags, relying on typedefs to identify types instead:

```C
typedef struct {
  int x;
  float y;
} t;
```

Here is the corresponding ctypes code:

```ocaml
let struct_t = structure ""
let t = typedef struct_t "t"
let x = field t "x" int
let y = field t "y" float
let () = seal t
```

Unfortunately, this code doesn't currently work, since ctypes relies on struct tags in generated code and rejects typedefs and other views when computing layout.  This pull request addresses that problem, so that both struct tags and typedef names can be used to retrieve layout information (fcbb5a7), and so that the code for computing struct layout treats views transparently (d286f5d).
