### PR TITLE
Support for registering OCaml values as roots

### DIFF
--- a/.depend
+++ b/.depend
@@ -1,183 +1,79 @@
-_build/src/ctypes/unsigned.cmi :
-_build/src/ctypes/ctypes.cmo : _build/src/ctypes/ctypes_value_printing.cmo \
-    _build/src/ctypes/ctypes_type_printing.cmi _build/src/ctypes/ctypes_structs_computed.cmi \
-    _build/src/ctypes/ctypes_std_views.cmo _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_memory.cmo \
-    _build/src/ctypes/ctypes_coerce.cmi _build/src/ctypes/ctypes.cmi
-_build/src/ctypes/ctypes.cmx : _build/src/ctypes/ctypes_value_printing.cmx \
-    _build/src/ctypes/ctypes_type_printing.cmx _build/src/ctypes/ctypes_structs_computed.cmx \
-    _build/src/ctypes/ctypes_std_views.cmx _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_memory.cmx \
-    _build/src/ctypes/ctypes_coerce.cmx _build/src/ctypes/ctypes.cmi
-_build/src/ctypes/ctypes_structs.cmo : _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_structs.cmi
-_build/src/ctypes/ctypes_structs.cmx : _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_structs.cmi
-_build/src/ctypes/posixTypes.cmi : _build/src/ctypes/unsigned.cmi _build/src/ctypes/ctypes.cmi
-_build/src/ctypes/ctypes_common.cmo :
-_build/src/ctypes/ctypes_common.cmx :
-_build/src/ctypes/ctypes_std_view_stubs.cmo : _build/src/ctypes/ctypes_static.cmi \
-    _build/src/ctypes/ctypes_memory_stubs.cmo _build/src/ctypes/ctypes_ptr.cmo
-_build/src/ctypes/ctypes_std_view_stubs.cmx : _build/src/ctypes/ctypes_static.cmx \
-    _build/src/ctypes/ctypes_memory_stubs.cmx _build/src/ctypes/ctypes_ptr.cmx
-_build/src/ctypes/ctypes_memory_stubs.cmo : _build/src/ctypes/ctypes_primitive_types.cmi \
-    _build/src/ctypes/ctypes_ptr.cmo
-_build/src/ctypes/ctypes_memory_stubs.cmx : _build/src/ctypes/ctypes_primitive_types.cmx \
-    _build/src/ctypes/ctypes_memory_stubs.cmx _build/src/ctypes/ctypes_ptr.cmx
-_build/src/ctypes/ctypes_memory_stubs.cmo : _build/src/ctypes/ctypes_primitive_types.cmi \
-    _build/src/ctypes/ctypes_ptr.cmo
-_build/src/ctypes/ctypes_memory_stubs.cmx : _build/src/ctypes/ctypes_primitive_types.cmx \
-    _build/src/ctypes/ctypes_ptr.cmx
-_build/src/ctypes/ctypes_std_views.cmo : _build/src/ctypes/ctypes_std_view_stubs.cmo \
-    _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_memory_stubs.cmo _build/src/ctypes/ctypes_memory.cmo \
-    _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_coerce.cmi
-_build/src/ctypes/ctypes_std_views.cmx : _build/src/ctypes/ctypes_std_view_stubs.cmx \
-    _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_memory_stubs.cmx _build/src/ctypes/ctypes_memory.cmx \
-    _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_coerce.cmx
-_build/src/ctypes/posixTypes.cmo : _build/src/ctypes/unsigned.cmi _build/src/ctypes/ctypes.cmi \
-    _build/src/ctypes/posixTypes.cmi
-_build/src/ctypes/posixTypes.cmx : _build/src/ctypes/unsigned.cmx _build/src/ctypes/ctypes.cmx \
-    _build/src/ctypes/posixTypes.cmi
-_build/src/ctypes/ctypes_structs_computed.cmo : _build/src/ctypes/ctypes_static.cmi \
-    _build/src/ctypes/ctypes_structs_computed.cmi
-_build/src/ctypes/ctypes_structs_computed.cmx : _build/src/ctypes/ctypes_static.cmx \
-    _build/src/ctypes/ctypes_structs_computed.cmi
-_build/src/ctypes/ctypes_ptr.cmo : _build/src/ctypes/signed.cmi
-_build/src/ctypes/ctypes_ptr.cmx : _build/src/ctypes/signed.cmx
-_build/src/ctypes/ctypes_bigarray_stubs.cmo : _build/src/ctypes/ctypes_ptr.cmo
-_build/src/ctypes/ctypes_bigarray_stubs.cmx : _build/src/ctypes/ctypes_ptr.cmx
-_build/src/ctypes/signed.cmi : _build/src/ctypes/unsigned.cmi
-_build/src/ctypes/ctypes_path.cmi :
-_build/src/ctypes/ctypes_value_printing_stubs.cmo : _build/src/ctypes/ctypes_primitive_types.cmi \
-    _build/src/ctypes/ctypes_ptr.cmo
-_build/src/ctypes/ctypes_value_printing_stubs.cmx : _build/src/ctypes/ctypes_primitive_types.cmx \
-    _build/src/ctypes/ctypes_ptr.cmx
-_build/src/ctypes/ctypes_type_printing.cmi : _build/src/ctypes/ctypes_static.cmi
-_build/src/ctypes/ctypes.cmi : _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_types.cmi
-_build/src/ctypes/ctypes_static.cmo : _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_ptr.cmo \
-    _build/src/ctypes/ctypes_primitive_types.cmo _build/src/ctypes/ctypes_bigarray.cmi \
-    _build/src/ctypes/ctypes_static.cmi
-_build/src/ctypes/ctypes_static.cmx : _build/src/ctypes/ctypes_primitive_types.cmx _build/src/ctypes/ctypes_ptr.cmx \
+_build/src/cstubs/cstubs_emit_c.cmo : _build/src/ctypes/ctypes_type_printing.cmi \
+    _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes.cmi \
+    _build/src/cstubs/cstubs_c_language.cmo
+_build/src/cstubs/cstubs_emit_c.cmx : _build/src/ctypes/ctypes_type_printing.cmx \
+    _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes.cmx \
+    _build/src/cstubs/cstubs_c_language.cmx
+_build/src/cstubs/cstubs.cmi : _build/src/ctypes/ctypes_types.cmi _build/src/ctypes/ctypes.cmi
+_build/src/cstubs/cstubs_analysis.cmo : _build/src/ctypes/unsigned.cmi \
+    _build/src/ctypes/signed.cmi _build/src/ctypes/ctypes_static.cmi \
+    _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_bigarray.cmi \
+    _build/src/cstubs/cstubs_analysis.cmi
+_build/src/cstubs/cstubs_analysis.cmx : _build/src/ctypes/unsigned.cmx \
+    _build/src/ctypes/signed.cmx _build/src/ctypes/ctypes_static.cmx \
     _build/src/ctypes/ctypes_primitive_types.cmx _build/src/ctypes/ctypes_bigarray.cmx \
-    _build/src/ctypes/ctypes_static.cmi
-_build/src/ctypes/ctypes_memory.cmo : _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_memory_stubs.cmo \
-    _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_bigarray.cmi
-_build/src/ctypes/ctypes_memory.cmx : _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_memory_stubs.cmx \
-    _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_bigarray.cmx
-_build/src/ctypes/ctypes_bigarray.cmo : _build/src/ctypes/ctypes_primitive_types.cmi \
-    _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitive_types.cmo \
-    _build/src/ctypes/ctypes_path.cmi _build/src/ctypes/ctypes_bigarray_stubs.cmo \
-    _build/src/ctypes/ctypes_bigarray.cmi
-_build/src/ctypes/ctypes_bigarray.cmx : _build/src/ctypes/ctypes_primitive_types.cmx \
-    _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_primitive_types.cmx \
-    _build/src/ctypes/ctypes_path.cmx _build/src/ctypes/ctypes_bigarray_stubs.cmx \
-    _build/src/ctypes/ctypes_bigarray.cmi
-_build/src/ctypes/ctypes_structs_computed.cmi : _build/src/ctypes/ctypes_structs.cmi \
-    _build/src/ctypes/ctypes_static.cmi
-_build/src/ctypes/ctypes_primitive_types.cmo : _build/src/ctypes/ctypes_primitive_types.cmi
-_build/src/ctypes/ctypes_primitive_types.cmx : _build/src/ctypes/ctypes_primitive_types.cmx
-_build/src/ctypes/unsigned.cmo : _build/src/ctypes/unsigned.cmi
-_build/src/ctypes/unsigned.cmx : _build/src/ctypes/unsigned.cmi
-_build/src/ctypes/ctypes_value_printing.cmo : _build/src/ctypes/ctypes_value_printing_stubs.cmo \
-    _build/src/ctypes/ctypes_type_printing.cmi _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_memory.cmo \
-    _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_common.cmo
-_build/src/ctypes/ctypes_value_printing.cmx : _build/src/ctypes/ctypes_value_printing_stubs.cmx \
-    _build/src/ctypes/ctypes_type_printing.cmx _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_memory.cmx \
-    _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_common.cmx
-_build/src/ctypes/ctypes_static.cmi : _build/src/ctypes/unsigned.cmi _build/src/ctypes/signed.cmi \
-    _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_ptr.cmo \
-    _build/src/ctypes/ctypes_bigarray.cmi
-_build/src/ctypes/ctypes_coerce.cmo : _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_primitive_types.cmi \
-    _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_coerce.cmi
-_build/src/ctypes/ctypes_coerce.cmx : _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_primitive_types.cmx \
-    _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_coerce.cmi
-_build/src/ctypes/ctypes_bigarray.cmi : _build/src/ctypes/ctypes_primitive_types.cmi \
-    _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_path.cmi
-_build/src/ctypes/ctypes_primitive_types.cmi : _build/src/ctypes/unsigned.cmi _build/src/ctypes/signed.cmi
-_build/src/ctypes/ctypes_primitive_types.cmo : _build/src/ctypes/unsigned.cmi _build/src/ctypes/signed.cmi \
-    _build/src/ctypes/ctypes_primitive_types.cmi
-_build/src/ctypes/ctypes_primitive_types.cmx : _build/src/ctypes/unsigned.cmx _build/src/ctypes/signed.cmx \
-    _build/src/ctypes/ctypes_primitive_types.cmi
-_build/src/ctypes/signed.cmo : _build/src/ctypes/unsigned.cmi _build/src/ctypes/signed.cmi
-_build/src/ctypes/signed.cmx : _build/src/ctypes/unsigned.cmx _build/src/ctypes/signed.cmi
-_build/src/ctypes/ctypes_path.cmo : _build/src/ctypes/ctypes_path.cmi
-_build/src/ctypes/ctypes_path.cmx : _build/src/ctypes/ctypes_path.cmi
-_build/src/ctypes/ctypes_structs.cmi : _build/src/ctypes/ctypes_static.cmi
-_build/src/ctypes/ctypes_coerce.cmi : _build/src/ctypes/ctypes_static.cmi
-_build/src/ctypes/ctypes_type_printing.cmo : _build/src/ctypes/ctypes_static.cmi \
-    _build/src/ctypes/ctypes_primitive_types.cmo _build/src/ctypes/ctypes_bigarray.cmi \
-    _build/src/ctypes/ctypes_common.cmo _build/src/ctypes/ctypes_type_printing.cmi
-_build/src/ctypes/ctypes_type_printing.cmx : _build/src/ctypes/ctypes_static.cmx \
-    _build/src/ctypes/ctypes_primitive_types.cmx _build/src/ctypes/ctypes_bigarray.cmx \
-    _build/src/ctypes/ctypes_common.cmx _build/src/ctypes/ctypes_type_printing.cmi
-_build/src/ctypes-foreign-base/ctypes_weak_ref.cmi :
-_build/src/ctypes-foreign-base/ctypes_closure_properties.cmi :
-_build/src/ctypes-foreign-base/dl.cmo : _build/src/ctypes/ctypes_ptr.cmo \
-    _build/src/ctypes-foreign-base/dl.cmi
-_build/src/ctypes-foreign-base/dl.cmx : _build/src/ctypes/ctypes_ptr.cmx \
-    _build/src/ctypes-foreign-base/dl.cmi
-_build/src/ctypes-foreign-base/dl.cmi : _build/src/ctypes/ctypes_ptr.cmo
-_build/src/ctypes-foreign-base/libffi_abi.cmo : _build/src/ctypes/ctypes.cmi \
-    _build/src/ctypes-foreign-base/libffi_abi.cmi
-_build/src/ctypes-foreign-base/libffi_abi.cmx : _build/src/ctypes/ctypes.cmx \
-    _build/src/ctypes-foreign-base/libffi_abi.cmi
-_build/src/ctypes-foreign-base/ctypes_weak_ref.cmo : _build/src/ctypes-foreign-base/ctypes_weak_ref.cmi
-_build/src/ctypes-foreign-base/ctypes_weak_ref.cmx : _build/src/ctypes-foreign-base/ctypes_weak_ref.cmi
-_build/src/ctypes-foreign-base/libffi_abi.cmi :
-_build/src/ctypes-foreign-base/ctypes_ffi.cmo : _build/src/ctypes-foreign-base/ctypes_weak_ref.cmi \
-    _build/src/ctypes/ctypes_type_printing.cmi _build/src/ctypes/ctypes_static.cmi \
-    _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_memory.cmo \
-    _build/src/ctypes-foreign-base/libffi_abi.cmi \
-    _build/src/ctypes-foreign-base/ctypes_ffi_stubs.cmo _build/src/ctypes/ctypes_ptr.cmo \
-    _build/src/ctypes/ctypes_primitive_types.cmo _build/src/ctypes-foreign-base/ctypes_ffi.cmi
-_build/src/ctypes-foreign-base/ctypes_ffi.cmx : _build/src/ctypes-foreign-base/ctypes_weak_ref.cmx \
-    _build/src/ctypes/ctypes_type_printing.cmx _build/src/ctypes/ctypes_static.cmx \
-    _build/src/ctypes/ctypes_primitive_types.cmx _build/src/ctypes/ctypes_memory.cmx \
-    _build/src/ctypes-foreign-base/libffi_abi.cmx \
-    _build/src/ctypes-foreign-base/ctypes_ffi_stubs.cmx _build/src/ctypes/ctypes_ptr.cmx \
-    _build/src/ctypes/ctypes_primitive_types.cmx _build/src/ctypes-foreign-base/ctypes_ffi.cmi
-_build/src/ctypes-foreign-base/ctypes_foreign_basis.cmo : _build/src/ctypes/ctypes_type_printing.cmi \
-    _build/src/ctypes/ctypes_std_views.cmo _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_memory.cmo \
-    _build/src/ctypes-foreign-base/libffi_abi.cmi \
-    _build/src/ctypes-foreign-base/ctypes_ffi_stubs.cmo _build/src/ctypes-foreign-base/ctypes_ffi.cmi \
-    _build/src/ctypes-foreign-base/dl.cmi _build/src/ctypes/ctypes_ptr.cmo \
-    _build/src/ctypes/ctypes.cmi _build/src/ctypes/ctypes_coerce.cmi
-_build/src/ctypes-foreign-base/ctypes_foreign_basis.cmx : _build/src/ctypes/ctypes_type_printing.cmx \
-    _build/src/ctypes/ctypes_std_views.cmx _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_memory.cmx \
-    _build/src/ctypes-foreign-base/libffi_abi.cmx \
-    _build/src/ctypes-foreign-base/ctypes_ffi_stubs.cmx _build/src/ctypes-foreign-base/ctypes_ffi.cmx \
-    _build/src/ctypes-foreign-base/dl.cmx _build/src/ctypes/ctypes_ptr.cmx \
-    _build/src/ctypes/ctypes.cmx _build/src/ctypes/ctypes_coerce.cmx
-_build/src/ctypes-foreign-base/ctypes_ffi.cmi : _build/src/ctypes/ctypes_static.cmi \
-    _build/src/ctypes-foreign-base/libffi_abi.cmi
-_build/src/ctypes-foreign-base/ctypes_ffi_stubs.cmo : _build/src/ctypes/ctypes_static.cmi \
-    _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_ptr.cmo
-_build/src/ctypes-foreign-base/ctypes_ffi_stubs.cmx : _build/src/ctypes/ctypes_static.cmx \
-    _build/src/ctypes/ctypes_primitive_types.cmx _build/src/ctypes/ctypes_ptr.cmx
-_build/src/ctypes-foreign-base/ctypes_closure_properties.cmo : \
-    _build/src/ctypes-foreign-base/ctypes_closure_properties.cmi
-_build/src/ctypes-foreign-base/ctypes_closure_properties.cmx : \
-    _build/src/ctypes-foreign-base/ctypes_closure_properties.cmi
-_build/src/ctypes-foreign-threaded/foreign.cmo : \
-    _build/src/ctypes-foreign-base/ctypes_foreign_basis.cmo \
-    _build/src/ctypes-foreign-base/ctypes_closure_properties.cmi \
-    _build/src/ctypes-foreign-threaded/foreign.cmi
-_build/src/ctypes-foreign-threaded/foreign.cmx : \
-    _build/src/ctypes-foreign-base/ctypes_foreign_basis.cmx \
-    _build/src/ctypes-foreign-base/ctypes_closure_properties.cmx \
-    _build/src/ctypes-foreign-threaded/foreign.cmi
-_build/src/ctypes-foreign-threaded/foreign.cmi : \
-    _build/src/ctypes-foreign-base/libffi_abi.cmi _build/src/ctypes-foreign-base/dl.cmi \
+    _build/src/cstubs/cstubs_analysis.cmi
+_build/src/cstubs/cstubs_internals.cmo : _build/src/ctypes/unsigned.cmi \
+    _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_ptr.cmo \
+    _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_memory_stubs.cmo \
+    _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs_internals.cmi
+_build/src/cstubs/cstubs_internals.cmx : _build/src/ctypes/unsigned.cmx \
+    _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_ptr.cmx \
+    _build/src/ctypes/ctypes_primitive_types.cmx _build/src/ctypes/ctypes_memory_stubs.cmx \
+    _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs_internals.cmi
+_build/src/cstubs/cstubs_structs.cmo : _build/src/ctypes/ctypes_types.cmi \
+    _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_primitives.cmo \
+    _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_path.cmi \
+    _build/src/ctypes/ctypes_common.cmo _build/src/ctypes/ctypes.cmi \
+    _build/src/cstubs/cstubs_public_name.cmi _build/src/cstubs/cstubs_c_language.cmo \
+    _build/src/cstubs/cstubs_structs.cmi
+_build/src/cstubs/cstubs_structs.cmx : _build/src/ctypes/ctypes_types.cmi \
+    _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_primitives.cmx \
+    _build/src/ctypes/ctypes_primitive_types.cmx _build/src/ctypes/ctypes_path.cmx \
+    _build/src/ctypes/ctypes_common.cmx _build/src/ctypes/ctypes.cmx \
+    _build/src/cstubs/cstubs_public_name.cmx _build/src/cstubs/cstubs_c_language.cmx \
+    _build/src/cstubs/cstubs_structs.cmi
+_build/src/cstubs/cstubs_internals.cmi : _build/src/ctypes/unsigned.cmi \
+    _build/src/ctypes/signed.cmi _build/src/ctypes/ctypes_static.cmi \
+    _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitive_types.cmi \
+    _build/src/ctypes/ctypes_memory_stubs.cmo _build/src/ctypes/ctypes_bigarray.cmi \
     _build/src/ctypes/ctypes.cmi
-_build/src/libffi-abigen/libffi_abigen.cmo :
-_build/src/libffi-abigen/libffi_abigen.cmx :
-_build/src/ctypes-top/ctypes_printers.cmo : _build/src/ctypes/unsigned.cmi \
-    _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/signed.cmi _build/src/ctypes/posixTypes.cmi \
-    _build/src/ctypes/ctypes.cmi _build/src/ctypes-top/ctypes_printers.cmi
-_build/src/ctypes-top/ctypes_printers.cmx : _build/src/ctypes/unsigned.cmx \
-    _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/signed.cmx _build/src/ctypes/posixTypes.cmx \
-    _build/src/ctypes/ctypes.cmx _build/src/ctypes-top/ctypes_printers.cmi
-_build/src/ctypes-top/install_ctypes_printers.cmo :
-_build/src/ctypes-top/install_ctypes_printers.cmx :
-_build/src/ctypes-top/ctypes_printers.cmi : _build/src/ctypes/unsigned.cmi \
-    _build/src/ctypes/signed.cmi _build/src/ctypes/posixTypes.cmi _build/src/ctypes/ctypes.cmi
+_build/src/cstubs/cstubs_generate_c.cmo : _build/src/ctypes/ctypes_static.cmi \
+    _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes.cmi \
+    _build/src/cstubs/cstubs_emit_c.cmo _build/src/cstubs/cstubs_c_language.cmo \
+    _build/src/cstubs/cstubs_generate_c.cmi
+_build/src/cstubs/cstubs_generate_c.cmx : _build/src/ctypes/ctypes_static.cmx \
+    _build/src/ctypes/ctypes_primitive_types.cmx _build/src/ctypes/ctypes.cmx \
+    _build/src/cstubs/cstubs_emit_c.cmx _build/src/cstubs/cstubs_c_language.cmx \
+    _build/src/cstubs/cstubs_generate_c.cmi
+_build/src/cstubs/cstubs_generate_c.cmi : _build/src/ctypes/ctypes.cmi
+_build/src/cstubs/cstubs_generate_ml.cmi : _build/src/ctypes/ctypes.cmi
+_build/src/cstubs/cstubs_errors.cmi :
+_build/src/cstubs/cstubs_c_language.cmo : _build/src/ctypes/ctypes_static.cmi \
+    _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs_errors.cmi
+_build/src/cstubs/cstubs_c_language.cmx : _build/src/ctypes/ctypes_static.cmx \
+    _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs_errors.cmx
 _build/src/cstubs/cstubs_inverted.cmi : _build/src/ctypes/ctypes.cmi
+_build/src/cstubs/cstubs.cmo : _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs_structs.cmi \
+    _build/src/cstubs/cstubs_generate_ml.cmi _build/src/cstubs/cstubs_generate_c.cmi \
+    _build/src/cstubs/cstubs.cmi
+_build/src/cstubs/cstubs.cmx : _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs_structs.cmx \
+    _build/src/cstubs/cstubs_generate_ml.cmx _build/src/cstubs/cstubs_generate_c.cmx \
+    _build/src/cstubs/cstubs.cmi
+_build/src/cstubs/cstubs_public_name.cmo : _build/src/ctypes/ctypes_static.cmi \
+    _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_path.cmi \
+    _build/src/cstubs/cstubs_public_name.cmi
+_build/src/cstubs/cstubs_public_name.cmx : _build/src/ctypes/ctypes_static.cmx \
+    _build/src/ctypes/ctypes_primitive_types.cmx _build/src/ctypes/ctypes_path.cmx \
+    _build/src/cstubs/cstubs_public_name.cmi
+_build/src/cstubs/cstubs_errors.cmo : _build/src/cstubs/cstubs_errors.cmi
+_build/src/cstubs/cstubs_errors.cmx : _build/src/cstubs/cstubs_errors.cmi
+_build/src/cstubs/cstubs_inverted.cmo : _build/src/ctypes/ctypes_type_printing.cmi \
+    _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs_generate_ml.cmi \
+    _build/src/cstubs/cstubs_generate_c.cmi _build/src/cstubs/cstubs_inverted.cmi
+_build/src/cstubs/cstubs_inverted.cmx : _build/src/ctypes/ctypes_type_printing.cmx \
+    _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs_generate_ml.cmx \
+    _build/src/cstubs/cstubs_generate_c.cmx _build/src/cstubs/cstubs_inverted.cmi
 _build/src/cstubs/cstubs_generate_ml.cmo : _build/src/ctypes/ctypes_static.cmi \
     _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_path.cmi \
     _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs_public_name.cmi \
@@ -188,76 +84,224 @@ _build/src/cstubs/cstubs_generate_ml.cmx : _build/src/ctypes/ctypes_static.cmx \
     _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs_public_name.cmx \
     _build/src/cstubs/cstubs_errors.cmx _build/src/cstubs/cstubs_analysis.cmx \
     _build/src/cstubs/cstubs_generate_ml.cmi
-_build/src/cstubs/cstubs_errors.cmi :
-_build/src/cstubs/cstubs_analysis.cmo : _build/src/ctypes/unsigned.cmi \
-    _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/signed.cmi _build/src/ctypes/ctypes_primitive_types.cmi \
-    _build/src/ctypes/ctypes_bigarray.cmi _build/src/cstubs/cstubs_analysis.cmi
-_build/src/cstubs/cstubs_analysis.cmx : _build/src/ctypes/unsigned.cmx \
-    _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/signed.cmx _build/src/ctypes/ctypes_primitive_types.cmx \
-    _build/src/ctypes/ctypes_bigarray.cmx _build/src/cstubs/cstubs_analysis.cmi
-_build/src/cstubs/cstubs_errors.cmo : _build/src/cstubs/cstubs_errors.cmi
-_build/src/cstubs/cstubs_errors.cmx : _build/src/cstubs/cstubs_errors.cmi
-_build/src/cstubs/cstubs.cmi : _build/src/ctypes/ctypes.cmi
+_build/src/cstubs/cstubs_analysis.cmi : _build/src/ctypes/ctypes_static.cmi
+_build/src/cstubs/cstubs_structs.cmi : _build/src/ctypes/ctypes_types.cmi
 _build/src/cstubs/cstubs_public_name.cmi : _build/src/ctypes/ctypes_primitive_types.cmi \
     _build/src/ctypes/ctypes_path.cmi
-_build/src/cstubs/cstubs_structs.cmo : _build/src/ctypes/ctypes.cmi \
-    _build/src/cstubs/cstubs_structs.cmi
-_build/src/cstubs/cstubs_structs.cmx : _build/src/ctypes/ctypes.cmx \
-    _build/src/cstubs/cstubs_structs.cmi
-_build/src/cstubs/cstubs_c_language.cmo : _build/src/ctypes/ctypes_static.cmi \
-    _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs_errors.cmi
-_build/src/cstubs/cstubs_c_language.cmx : _build/src/ctypes/ctypes_static.cmx \
-    _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs_errors.cmx
-_build/src/cstubs/cstubs_structs.cmi : _build/src/ctypes/ctypes.cmi
-_build/src/cstubs/cstubs_internals.cmo : _build/src/ctypes/ctypes_static.cmi \
-    _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_memory_stubs.cmo \
-    _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes.cmi \
-    _build/src/cstubs/cstubs_internals.cmi
-_build/src/cstubs/cstubs_internals.cmx : _build/src/ctypes/ctypes_static.cmx \
-    _build/src/ctypes/ctypes_primitive_types.cmx _build/src/ctypes/ctypes_memory_stubs.cmx \
-    _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes.cmx \
-    _build/src/cstubs/cstubs_internals.cmi
-_build/src/cstubs/cstubs.cmo : _build/src/ctypes/ctypes.cmi \
-    _build/src/cstubs/cstubs_generate_ml.cmi _build/src/cstubs/cstubs_generate_c.cmi \
-    _build/src/cstubs/cstubs.cmi
-_build/src/cstubs/cstubs.cmx : _build/src/ctypes/ctypes.cmx \
-    _build/src/cstubs/cstubs_generate_ml.cmx _build/src/cstubs/cstubs_generate_c.cmx \
-    _build/src/cstubs/cstubs.cmi
-_build/src/cstubs/cstubs_public_name.cmo : _build/src/ctypes/ctypes_static.cmi \
-    _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_path.cmi \
-    _build/src/cstubs/cstubs_public_name.cmi
-_build/src/cstubs/cstubs_public_name.cmx : _build/src/ctypes/ctypes_static.cmx \
-    _build/src/ctypes/ctypes_primitive_types.cmx _build/src/ctypes/ctypes_path.cmx \
-    _build/src/cstubs/cstubs_public_name.cmi
-_build/src/cstubs/cstubs_generate_c.cmi : _build/src/ctypes/ctypes.cmi
-_build/src/cstubs/cstubs_emit_c.cmo : _build/src/ctypes/ctypes_type_printing.cmi \
+_build/src/libffi-abigen/libffi_abigen.cmo :
+_build/src/libffi-abigen/libffi_abigen.cmx :
+_build/src/discover/discover.cmo :
+_build/src/discover/discover.cmx :
+_build/src/discover/commands.cmo : _build/src/discover/commands.cmi
+_build/src/discover/commands.cmx : _build/src/discover/commands.cmi
+_build/src/discover/commands.cmi :
+_build/src/ctypes/ctypes_value_printing.cmo : \
+    _build/src/ctypes/ctypes_value_printing_stubs.cmo \
+    _build/src/ctypes/ctypes_type_printing.cmi _build/src/ctypes/ctypes_static.cmi \
+    _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_memory.cmo \
+    _build/src/ctypes/ctypes_common.cmo
+_build/src/ctypes/ctypes_value_printing.cmx : \
+    _build/src/ctypes/ctypes_value_printing_stubs.cmx \
+    _build/src/ctypes/ctypes_type_printing.cmx _build/src/ctypes/ctypes_static.cmx \
+    _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_memory.cmx \
+    _build/src/ctypes/ctypes_common.cmx
+_build/src/ctypes/ctypes_types.cmi : _build/src/ctypes/unsigned.cmi _build/src/ctypes/signed.cmi \
+    _build/src/ctypes/ctypes_static.cmi
+_build/src/ctypes/ctypes_std_view_stubs.cmo : _build/src/ctypes/ctypes_static.cmi \
+    _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_memory_stubs.cmo
+_build/src/ctypes/ctypes_std_view_stubs.cmx : _build/src/ctypes/ctypes_static.cmx \
+    _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_memory_stubs.cmx
+_build/src/ctypes/signed.cmo : _build/src/ctypes/unsigned.cmi _build/src/ctypes/signed.cmi
+_build/src/ctypes/signed.cmx : _build/src/ctypes/unsigned.cmx _build/src/ctypes/signed.cmi
+_build/src/ctypes/ctypes_path.cmi :
+_build/src/ctypes/ctypes_primitive_types.cmi : _build/src/ctypes/unsigned.cmi \
+    _build/src/ctypes/signed.cmi
+_build/src/ctypes/ctypes_coerce.cmo : _build/src/ctypes/ctypes_static.cmi \
+    _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitive_types.cmi
+_build/src/ctypes/ctypes_coerce.cmx : _build/src/ctypes/ctypes_static.cmx \
+    _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_primitive_types.cmx
+_build/src/ctypes/ctypes_ptr.cmo : _build/src/ctypes/signed.cmi
+_build/src/ctypes/ctypes_ptr.cmx : _build/src/ctypes/signed.cmx
+_build/src/ctypes/ctypes_primitives.cmo : _build/src/ctypes/ctypes_primitive_types.cmi
+_build/src/ctypes/ctypes_primitives.cmx : _build/src/ctypes/ctypes_primitive_types.cmx
+_build/src/ctypes/posixTypes.cmi : _build/src/ctypes/unsigned.cmi _build/src/ctypes/signed.cmi \
+    _build/src/ctypes/ctypes.cmi
+_build/src/ctypes/ctypes_structs.cmo : _build/src/ctypes/ctypes_static.cmi \
+    _build/src/ctypes/ctypes_structs.cmi
+_build/src/ctypes/ctypes_structs.cmx : _build/src/ctypes/ctypes_static.cmx \
+    _build/src/ctypes/ctypes_structs.cmi
+_build/src/ctypes/ctypes_static.cmi : _build/src/ctypes/unsigned.cmi _build/src/ctypes/signed.cmi \
+    _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitive_types.cmi \
+    _build/src/ctypes/ctypes_bigarray.cmi
+_build/src/ctypes/coerce.cmi : _build/src/ctypes/ctypes_static.cmi
+_build/src/ctypes/ctypes_primitive_types.cmo : _build/src/ctypes/unsigned.cmi \
+    _build/src/ctypes/signed.cmi _build/src/ctypes/ctypes_primitive_types.cmi
+_build/src/ctypes/ctypes_primitive_types.cmx : _build/src/ctypes/unsigned.cmx \
+    _build/src/ctypes/signed.cmx _build/src/ctypes/ctypes_primitive_types.cmi
+_build/src/ctypes/ctypes_static.cmo : _build/src/ctypes/ctypes_ptr.cmo \
+    _build/src/ctypes/ctypes_primitives.cmo _build/src/ctypes/ctypes_primitive_types.cmi \
+    _build/src/ctypes/ctypes_bigarray.cmi _build/src/ctypes/ctypes_static.cmi
+_build/src/ctypes/ctypes_static.cmx : _build/src/ctypes/ctypes_ptr.cmx \
+    _build/src/ctypes/ctypes_primitives.cmx _build/src/ctypes/ctypes_primitive_types.cmx \
+    _build/src/ctypes/ctypes_bigarray.cmx _build/src/ctypes/ctypes_static.cmi
+_build/src/ctypes/ctypes.cmi : _build/src/ctypes/ctypes_types.cmi \
+    _build/src/ctypes/ctypes_static.cmi
+_build/src/ctypes/ctypes_path.cmo : _build/src/ctypes/ctypes_path.cmi
+_build/src/ctypes/ctypes_path.cmx : _build/src/ctypes/ctypes_path.cmi
+_build/src/ctypes/ctypes_type_printing.cmi : _build/src/ctypes/ctypes_static.cmi
+_build/src/ctypes/unsigned.cmo : _build/src/ctypes/unsigned.cmi
+_build/src/ctypes/unsigned.cmx : _build/src/ctypes/unsigned.cmi
+_build/src/ctypes/ctypes_bigarray_stubs.cmo : _build/src/ctypes/ctypes_ptr.cmo
+_build/src/ctypes/ctypes_bigarray_stubs.cmx : _build/src/ctypes/ctypes_ptr.cmx
+_build/src/ctypes/ctypes_structs_computed.cmo : _build/src/ctypes/ctypes_static.cmi \
+    _build/src/ctypes/ctypes_structs_computed.cmi
+_build/src/ctypes/ctypes_structs_computed.cmx : _build/src/ctypes/ctypes_static.cmx \
+    _build/src/ctypes/ctypes_structs_computed.cmi
+_build/src/ctypes/ctypes_bigarray.cmo : _build/src/ctypes/ctypes_ptr.cmo \
+    _build/src/ctypes/ctypes_primitives.cmo _build/src/ctypes/ctypes_primitive_types.cmi \
+    _build/src/ctypes/ctypes_path.cmi _build/src/ctypes/ctypes_bigarray_stubs.cmo \
+    _build/src/ctypes/ctypes_bigarray.cmi
+_build/src/ctypes/ctypes_bigarray.cmx : _build/src/ctypes/ctypes_ptr.cmx \
+    _build/src/ctypes/ctypes_primitives.cmx _build/src/ctypes/ctypes_primitive_types.cmx \
+    _build/src/ctypes/ctypes_path.cmx _build/src/ctypes/ctypes_bigarray_stubs.cmx \
+    _build/src/ctypes/ctypes_bigarray.cmi
+_build/src/ctypes/unsigned.cmi :
+_build/src/ctypes/ctypes_memory_stubs.cmo : _build/src/ctypes/ctypes_ptr.cmo \
+    _build/src/ctypes/ctypes_primitive_types.cmi
+_build/src/ctypes/ctypes_memory_stubs.cmx : _build/src/ctypes/ctypes_ptr.cmx \
+    _build/src/ctypes/ctypes_primitive_types.cmx
+_build/src/ctypes/signed.cmi : _build/src/ctypes/unsigned.cmi
+_build/src/ctypes/ctypes_bigarray.cmi : _build/src/ctypes/ctypes_ptr.cmo \
+    _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_path.cmi
+_build/src/ctypes/posixTypes.cmo : _build/src/ctypes/unsigned.cmi \
+    _build/src/ctypes/ctypes_std_views.cmo _build/src/ctypes/ctypes_static.cmi \
+    _build/src/ctypes/ctypes.cmi _build/src/ctypes/posixTypes.cmi
+_build/src/ctypes/posixTypes.cmx : _build/src/ctypes/unsigned.cmx \
+    _build/src/ctypes/ctypes_std_views.cmx _build/src/ctypes/ctypes_static.cmx \
+    _build/src/ctypes/ctypes.cmx _build/src/ctypes/posixTypes.cmi
+_build/src/ctypes/ctypes_memory.cmo : _build/src/ctypes/ctypes_static.cmi \
+    _build/src/ctypes/ctypes_roots_stubs.cmo _build/src/ctypes/ctypes_ptr.cmo \
+    _build/src/ctypes/ctypes_memory_stubs.cmo _build/src/ctypes/ctypes_bigarray.cmi
+_build/src/ctypes/ctypes_memory.cmx : _build/src/ctypes/ctypes_static.cmx \
+    _build/src/ctypes/ctypes_roots_stubs.cmx _build/src/ctypes/ctypes_ptr.cmx \
+    _build/src/ctypes/ctypes_memory_stubs.cmx _build/src/ctypes/ctypes_bigarray.cmx
+_build/src/ctypes/ctypes.cmo : _build/src/ctypes/ctypes_value_printing.cmo \
+    _build/src/ctypes/ctypes_type_printing.cmi \
+    _build/src/ctypes/ctypes_structs_computed.cmi _build/src/ctypes/ctypes_std_views.cmo \
+    _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_memory.cmo \
+    _build/src/ctypes/ctypes_coerce.cmo _build/src/ctypes/ctypes.cmi
+_build/src/ctypes/ctypes.cmx : _build/src/ctypes/ctypes_value_printing.cmx \
+    _build/src/ctypes/ctypes_type_printing.cmx \
+    _build/src/ctypes/ctypes_structs_computed.cmx _build/src/ctypes/ctypes_std_views.cmx \
+    _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_memory.cmx \
+    _build/src/ctypes/ctypes_coerce.cmx _build/src/ctypes/ctypes.cmi
+_build/src/ctypes/ctypes_structs_computed.cmi : _build/src/ctypes/ctypes_structs.cmi \
+    _build/src/ctypes/ctypes_static.cmi
+_build/src/ctypes/ctypes_type_printing.cmo : _build/src/ctypes/ctypes_static.cmi \
+    _build/src/ctypes/ctypes_primitives.cmo _build/src/ctypes/ctypes_common.cmo \
+    _build/src/ctypes/ctypes_bigarray.cmi _build/src/ctypes/ctypes_type_printing.cmi
+_build/src/ctypes/ctypes_type_printing.cmx : _build/src/ctypes/ctypes_static.cmx \
+    _build/src/ctypes/ctypes_primitives.cmx _build/src/ctypes/ctypes_common.cmx \
+    _build/src/ctypes/ctypes_bigarray.cmx _build/src/ctypes/ctypes_type_printing.cmi
+_build/src/ctypes/ctypes_common.cmo :
+_build/src/ctypes/ctypes_common.cmx :
+_build/src/ctypes/ctypes_std_views.cmo : _build/src/ctypes/unsigned.cmi \
+    _build/src/ctypes/signed.cmi _build/src/ctypes/ctypes_std_view_stubs.cmo \
+    _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_ptr.cmo \
+    _build/src/ctypes/ctypes_memory_stubs.cmo _build/src/ctypes/ctypes_memory.cmo \
+    _build/src/ctypes/ctypes_coerce.cmo
+_build/src/ctypes/ctypes_std_views.cmx : _build/src/ctypes/unsigned.cmx \
+    _build/src/ctypes/signed.cmx _build/src/ctypes/ctypes_std_view_stubs.cmx \
+    _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_ptr.cmx \
+    _build/src/ctypes/ctypes_memory_stubs.cmx _build/src/ctypes/ctypes_memory.cmx \
+    _build/src/ctypes/ctypes_coerce.cmx
+_build/src/ctypes/ctypes_structs.cmi : _build/src/ctypes/ctypes_static.cmi
+_build/src/ctypes/ctypes_value_printing_stubs.cmo : _build/src/ctypes/ctypes_ptr.cmo \
+    _build/src/ctypes/ctypes_primitive_types.cmi
+_build/src/ctypes/ctypes_value_printing_stubs.cmx : _build/src/ctypes/ctypes_ptr.cmx \
+    _build/src/ctypes/ctypes_primitive_types.cmx
+_build/src/ctypes-top/install_ctypes_printers.cmo :
+_build/src/ctypes-top/install_ctypes_printers.cmx :
+_build/src/ctypes-top/ctypes_printers.cmi : _build/src/ctypes/unsigned.cmi \
+    _build/src/ctypes/signed.cmi _build/src/ctypes/posixTypes.cmi _build/src/ctypes/ctypes.cmi
+_build/src/ctypes-top/ctypes_printers.cmo : _build/src/ctypes/unsigned.cmi \
+    _build/src/ctypes/signed.cmi _build/src/ctypes/posixTypes.cmi \
     _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes.cmi \
-    _build/src/cstubs/cstubs_c_language.cmo
-_build/src/cstubs/cstubs_emit_c.cmx : _build/src/ctypes/ctypes_type_printing.cmx \
+    _build/src/ctypes-top/ctypes_printers.cmi
+_build/src/ctypes-top/ctypes_printers.cmx : _build/src/ctypes/unsigned.cmx \
+    _build/src/ctypes/signed.cmx _build/src/ctypes/posixTypes.cmx \
     _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes.cmx \
-    _build/src/cstubs/cstubs_c_language.cmx
-_build/src/cstubs/cstubs_analysis.cmi : _build/src/ctypes/ctypes_static.cmi
-_build/src/cstubs/cstubs_generate_ml.cmi : _build/src/ctypes/ctypes.cmi
-_build/src/cstubs/cstubs_internals.cmi : _build/src/ctypes/unsigned.cmi \
-    _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/signed.cmi _build/src/ctypes/ctypes_primitive_types.cmi \
-    _build/src/ctypes/ctypes_memory_stubs.cmo _build/src/ctypes/ctypes_ptr.cmo \
-    _build/src/ctypes/ctypes_bigarray.cmi _build/src/ctypes/ctypes.cmi
-_build/src/cstubs/cstubs_inverted.cmo : _build/src/ctypes/ctypes.cmi \
-    _build/src/cstubs/cstubs_generate_ml.cmi _build/src/cstubs/cstubs_generate_c.cmi \
-    _build/src/cstubs/cstubs_inverted.cmi
-_build/src/cstubs/cstubs_inverted.cmx : _build/src/ctypes/ctypes.cmx \
-    _build/src/cstubs/cstubs_generate_ml.cmx _build/src/cstubs/cstubs_generate_c.cmx \
-    _build/src/cstubs/cstubs_inverted.cmi
-_build/src/cstubs/cstubs_generate_c.cmo : _build/src/ctypes/ctypes_static.cmi \
-    _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes.cmi \
-    _build/src/cstubs/cstubs_emit_c.cmo _build/src/cstubs/cstubs_c_language.cmo \
-    _build/src/cstubs/cstubs_generate_c.cmi
-_build/src/cstubs/cstubs_generate_c.cmx : _build/src/ctypes/ctypes_static.cmx \
-    _build/src/ctypes/ctypes_primitive_types.cmx _build/src/ctypes/ctypes.cmx \
-    _build/src/cstubs/cstubs_emit_c.cmx _build/src/cstubs/cstubs_c_language.cmx \
-    _build/src/cstubs/cstubs_generate_c.cmi
-_build/src/ctypes-foreign-unthreaded/ctypes_gc_mutex.cmo :
-_build/src/ctypes-foreign-unthreaded/ctypes_gc_mutex.cmx :
+    _build/src/ctypes-top/ctypes_printers.cmi
+_build/src/ctypes-foreign-threaded/foreign.cmi : \
+    _build/src/ctypes-foreign-base/libffi_abi.cmi _build/src/ctypes-foreign-base/dl.cmi \
+    _build/src/ctypes/ctypes.cmi
+_build/src/ctypes-foreign-threaded/foreign.cmo : \
+    _build/src/ctypes-foreign-base/ctypes_foreign_basis.cmo \
+    _build/src/ctypes-foreign-base/ctypes_closure_properties.cmi \
+    _build/src/ctypes-foreign-threaded/foreign.cmi
+_build/src/ctypes-foreign-threaded/foreign.cmx : \
+    _build/src/ctypes-foreign-base/ctypes_foreign_basis.cmx \
+    _build/src/ctypes-foreign-base/ctypes_closure_properties.cmx \
+    _build/src/ctypes-foreign-threaded/foreign.cmi
+_build/src/configure/make_primitive_details.cmo :
+_build/src/configure/make_primitive_details.cmx :
+_build/src/ctypes-foreign-base/ctypes_ffi_stubs.cmo : _build/src/ctypes/ctypes_static.cmi \
+    _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitive_types.cmi
+_build/src/ctypes-foreign-base/ctypes_ffi_stubs.cmx : _build/src/ctypes/ctypes_static.cmx \
+    _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_primitive_types.cmx
+_build/src/ctypes-foreign-base/dl.cmi : _build/src/ctypes/ctypes_ptr.cmo
+_build/src/ctypes-foreign-base/ctypes_weak_ref.cmo : \
+    _build/src/ctypes-foreign-base/ctypes_weak_ref.cmi
+_build/src/ctypes-foreign-base/ctypes_weak_ref.cmx : \
+    _build/src/ctypes-foreign-base/ctypes_weak_ref.cmi
+_build/src/ctypes-foreign-base/libffi_abi.cmo : _build/src/ctypes/ctypes.cmi \
+    _build/src/ctypes-foreign-base/libffi_abi.cmi
+_build/src/ctypes-foreign-base/libffi_abi.cmx : _build/src/ctypes/ctypes.cmx \
+    _build/src/ctypes-foreign-base/libffi_abi.cmi
+_build/src/ctypes-foreign-base/dl.cmo : _build/src/ctypes/ctypes_ptr.cmo \
+    _build/src/ctypes-foreign-base/dl.cmi
+_build/src/ctypes-foreign-base/dl.cmx : _build/src/ctypes/ctypes_ptr.cmx \
+    _build/src/ctypes-foreign-base/dl.cmi
+_build/src/ctypes-foreign-base/ctypes_foreign_basis.cmo : \
+    _build/src/ctypes-foreign-base/libffi_abi.cmi _build/src/ctypes-foreign-base/dl.cmi \
+    _build/src/ctypes/ctypes_std_views.cmo _build/src/ctypes/ctypes_static.cmi \
+    _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes-foreign-base/ctypes_ffi_stubs.cmo \
+    _build/src/ctypes-foreign-base/ctypes_ffi.cmi _build/src/ctypes/ctypes_coerce.cmo \
+    _build/src/ctypes/ctypes.cmi
+_build/src/ctypes-foreign-base/ctypes_foreign_basis.cmx : \
+    _build/src/ctypes-foreign-base/libffi_abi.cmx _build/src/ctypes-foreign-base/dl.cmx \
+    _build/src/ctypes/ctypes_std_views.cmx _build/src/ctypes/ctypes_static.cmx \
+    _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes-foreign-base/ctypes_ffi_stubs.cmx \
+    _build/src/ctypes-foreign-base/ctypes_ffi.cmx _build/src/ctypes/ctypes_coerce.cmx \
+    _build/src/ctypes/ctypes.cmx
+_build/src/ctypes-foreign-base/libffi_abi.cmi :
+_build/src/ctypes-foreign-base/ctypes_ffi.cmi : \
+    _build/src/ctypes-foreign-base/libffi_abi.cmi _build/src/ctypes/ctypes_static.cmi
+_build/src/ctypes-foreign-base/ctypes_weak_ref.cmi :
+_build/src/ctypes-foreign-base/ctypes_ffi.cmo : \
+    _build/src/ctypes-foreign-base/libffi_abi.cmi \
+    _build/src/ctypes-foreign-base/ctypes_weak_ref.cmi \
+    _build/src/ctypes/ctypes_type_printing.cmi _build/src/ctypes/ctypes_static.cmi \
+    _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitives.cmo \
+    _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_memory.cmo \
+    _build/src/ctypes-foreign-base/ctypes_ffi_stubs.cmo \
+    _build/src/ctypes-foreign-base/ctypes_ffi.cmi
+_build/src/ctypes-foreign-base/ctypes_ffi.cmx : \
+    _build/src/ctypes-foreign-base/libffi_abi.cmx \
+    _build/src/ctypes-foreign-base/ctypes_weak_ref.cmx \
+    _build/src/ctypes/ctypes_type_printing.cmx _build/src/ctypes/ctypes_static.cmx \
+    _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_primitives.cmx \
+    _build/src/ctypes/ctypes_primitive_types.cmx _build/src/ctypes/ctypes_memory.cmx \
+    _build/src/ctypes-foreign-base/ctypes_ffi_stubs.cmx \
+    _build/src/ctypes-foreign-base/ctypes_ffi.cmi
+_build/src/ctypes-foreign-base/ctypes_closure_properties.cmo : \
+    _build/src/ctypes-foreign-base/ctypes_closure_properties.cmi
+_build/src/ctypes-foreign-base/ctypes_closure_properties.cmx : \
+    _build/src/ctypes-foreign-base/ctypes_closure_properties.cmi
+_build/src/ctypes-foreign-base/ctypes_closure_properties.cmi :
+_build/src/ctypes-foreign-unthreaded/foreign.cmi : \
+    _build/src/ctypes-foreign-base/libffi_abi.cmi _build/src/ctypes-foreign-base/dl.cmi \
+    _build/src/ctypes/ctypes.cmi
 _build/src/ctypes-foreign-unthreaded/foreign.cmo : \
     _build/src/ctypes-foreign-unthreaded/ctypes_gc_mutex.cmo \
     _build/src/ctypes-foreign-base/ctypes_foreign_basis.cmo \
@@ -268,15 +312,76 @@ _build/src/ctypes-foreign-unthreaded/foreign.cmx : \
     _build/src/ctypes-foreign-base/ctypes_foreign_basis.cmx \
     _build/src/ctypes-foreign-base/ctypes_closure_properties.cmx \
     _build/src/ctypes-foreign-unthreaded/foreign.cmi
-_build/src/ctypes-foreign-unthreaded/foreign.cmi : \
-    _build/src/ctypes-foreign-base/libffi_abi.cmi _build/src/ctypes-foreign-base/dl.cmi \
+_build/src/ctypes-foreign-unthreaded/ctypes_gc_mutex.cmo :
+_build/src/ctypes-foreign-unthreaded/ctypes_gc_mutex.cmx :
+_build/examples/date/stub-generation/date_cmd.cmo : _build/src/ctypes/posixTypes.cmi \
     _build/src/ctypes/ctypes.cmi
-_build/src/configure/make_primitive_details.cmo :
-_build/src/configure/make_primitive_details.cmx :
-_build/src/discover/discover.cmo :
-_build/src/discover/discover.cmx :
-_build/src/ctypes_config.cmo :
-_build/src/ctypes_config.cmx :
+_build/examples/date/stub-generation/date_cmd.cmx : _build/src/ctypes/posixTypes.cmx \
+    _build/src/ctypes/ctypes.cmx
+_build/examples/date/stub-generation/bindings/date_stubs.cmo : \
+    _build/src/ctypes/posixTypes.cmi _build/src/ctypes/ctypes.cmi
+_build/examples/date/stub-generation/bindings/date_stubs.cmx : \
+    _build/src/ctypes/posixTypes.cmx _build/src/ctypes/ctypes.cmx
+_build/examples/date/stub-generation/stub-generator/date_stub_generator.cmo : \
+    _build/src/cstubs/cstubs.cmi
+_build/examples/date/stub-generation/stub-generator/date_stub_generator.cmx : \
+    _build/src/cstubs/cstubs.cmx
+_build/examples/date/foreign/date.cmi : _build/src/ctypes/posixTypes.cmi \
+    _build/src/ctypes/ctypes.cmi
+_build/examples/date/foreign/date.cmo : _build/src/ctypes/posixTypes.cmi \
+    _build/src/ctypes-foreign-threaded/foreign.cmi _build/src/ctypes/ctypes.cmi \
+    _build/examples/date/foreign/date.cmi
+_build/examples/date/foreign/date.cmx : _build/src/ctypes/posixTypes.cmx \
+    _build/src/ctypes-foreign-threaded/foreign.cmx _build/src/ctypes/ctypes.cmx \
+    _build/examples/date/foreign/date.cmi
+_build/examples/fts/stub-generation/bindings/fts_types.cmo : \
+    _build/src/ctypes/unsigned.cmi _build/src/ctypes/posixTypes.cmi \
+    _build/src/ctypes-foreign-threaded/foreign.cmi _build/src/ctypes/ctypes_coerce.cmo \
+    _build/src/ctypes/ctypes.cmi
+_build/examples/fts/stub-generation/bindings/fts_types.cmx : \
+    _build/src/ctypes/unsigned.cmx _build/src/ctypes/posixTypes.cmx \
+    _build/src/ctypes-foreign-threaded/foreign.cmx _build/src/ctypes/ctypes_coerce.cmx \
+    _build/src/ctypes/ctypes.cmx
+_build/examples/fts/stub-generation/bindings/fts_bindings.cmo : \
+    _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs.cmi
+_build/examples/fts/stub-generation/bindings/fts_bindings.cmx : \
+    _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs.cmx
+_build/examples/fts/stub-generation/bindings/fts.cmi : _build/src/ctypes/ctypes.cmi
+_build/examples/fts/stub-generation/fts_if.cmo : _build/src/ctypes/ctypes.cmi
+_build/examples/fts/stub-generation/fts_if.cmx : _build/src/ctypes/ctypes.cmx
+_build/examples/fts/stub-generation/fts_cmd.cmo : _build/src/ctypes/ctypes.cmi
+_build/examples/fts/stub-generation/fts_cmd.cmx : _build/src/ctypes/ctypes.cmx
+_build/examples/fts/stub-generation/stub-generator/fts_stub_generator.cmo : \
+    _build/src/cstubs/cstubs.cmi
+_build/examples/fts/stub-generation/stub-generator/fts_stub_generator.cmx : \
+    _build/src/cstubs/cstubs.cmx
+_build/examples/fts/foreign/fts.cmo : _build/src/ctypes/unsigned.cmi \
+    _build/src/ctypes/posixTypes.cmi _build/src/ctypes-foreign-threaded/foreign.cmi \
+    _build/src/ctypes/ctypes_coerce.cmo _build/src/ctypes/ctypes.cmi \
+    _build/examples/fts/foreign/fts.cmi
+_build/examples/fts/foreign/fts.cmx : _build/src/ctypes/unsigned.cmx \
+    _build/src/ctypes/posixTypes.cmx _build/src/ctypes-foreign-threaded/foreign.cmx \
+    _build/src/ctypes/ctypes_coerce.cmx _build/src/ctypes/ctypes.cmx \
+    _build/examples/fts/foreign/fts.cmi
+_build/examples/fts/foreign/fts.cmi : _build/src/ctypes/posixTypes.cmi \
+    _build/src/ctypes/ctypes.cmi
+_build/examples/fts/foreign/fts_cmd.cmo : _build/src/ctypes/ctypes.cmi
+_build/examples/fts/foreign/fts_cmd.cmx : _build/src/ctypes/ctypes.cmx
+_build/examples/ncurses/stub-generation/bindings/ncurses_bindings.cmo : \
+    _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs.cmi
+_build/examples/ncurses/stub-generation/bindings/ncurses_bindings.cmx : \
+    _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs.cmx
+_build/examples/ncurses/stub-generation/ncurses_stub_cmd.cmo :
+_build/examples/ncurses/stub-generation/ncurses_stub_cmd.cmx :
+_build/examples/ncurses/foreign/ncurses_cmd.cmo :
+_build/examples/ncurses/foreign/ncurses_cmd.cmx :
+_build/examples/ncurses/foreign/ncurses.cmo : \
+    _build/src/ctypes-foreign-threaded/foreign.cmi _build/src/ctypes/ctypes.cmi \
+    _build/examples/ncurses/foreign/ncurses.cmi
+_build/examples/ncurses/foreign/ncurses.cmx : \
+    _build/src/ctypes-foreign-threaded/foreign.cmx _build/src/ctypes/ctypes.cmx \
+    _build/examples/ncurses/foreign/ncurses.cmi
+_build/examples/ncurses/foreign/ncurses.cmi :
 _build/examples/sigset/sigset.cmi : _build/src/ctypes/posixTypes.cmi _build/src/ctypes/ctypes.cmi
 _build/examples/sigset/sigset.cmo : _build/src/ctypes/posixTypes.cmi \
     _build/src/ctypes-foreign-threaded/foreign.cmi _build/src/ctypes/ctypes.cmi \
@@ -284,110 +389,3 @@ _build/examples/sigset/sigset.cmo : _build/src/ctypes/posixTypes.cmi \
 _build/examples/sigset/sigset.cmx : _build/src/ctypes/posixTypes.cmx \
     _build/src/ctypes-foreign-threaded/foreign.cmx _build/src/ctypes/ctypes.cmx \
     _build/examples/sigset/sigset.cmi
-_build/examples/fts/stub-generation/fts_cmd.cmo : \
-    _build/examples/fts/stub-generation/bindings/fts_types.cmo \
-    _build/examples/fts/stub-generation/fts_if.cmo _build/src/ctypes/ctypes.cmi
-_build/examples/fts/stub-generation/fts_cmd.cmx : \
-    _build/examples/fts/stub-generation/bindings/fts_types.cmx \
-    _build/examples/fts/stub-generation/fts_if.cmx _build/src/ctypes/ctypes.cmx
-_build/examples/fts/stub-generation/fts_generated.cmo : _build/src/ctypes/ctypes.cmi \
-    _build/src/cstubs/cstubs_internals.cmi
-_build/examples/fts/stub-generation/fts_generated.cmx : _build/src/ctypes/ctypes.cmx \
-    _build/src/cstubs/cstubs_internals.cmx
-_build/examples/fts/stub-generation/fts_if.cmo : \
-    _build/examples/fts/stub-generation/bindings/fts_types.cmo \
-    _build/examples/fts/stub-generation/fts_generated.cmo \
-    _build/examples/fts/stub-generation/bindings/fts_bindings.cmo \
-    _build/src/ctypes/ctypes.cmi
-_build/examples/fts/stub-generation/fts_if.cmx : \
-    _build/examples/fts/stub-generation/bindings/fts_types.cmx \
-    _build/examples/fts/stub-generation/fts_generated.cmx \
-    _build/examples/fts/stub-generation/bindings/fts_bindings.cmx \
-    _build/src/ctypes/ctypes.cmx
-_build/examples/fts/stub-generation/stub-generator/fts_stub_generator.cmo : \
-    _build/examples/fts/stub-generation/bindings/fts_bindings.cmo \
-    _build/src/cstubs/cstubs.cmi
-_build/examples/fts/stub-generation/stub-generator/fts_stub_generator.cmx : \
-    _build/examples/fts/stub-generation/bindings/fts_bindings.cmx \
-    _build/src/cstubs/cstubs.cmx
-_build/examples/fts/stub-generation/bindings/fts.cmi : \
-    _build/examples/fts/stub-generation/bindings/fts_types.cmo _build/src/ctypes/ctypes.cmi
-_build/examples/fts/stub-generation/bindings/fts_bindings.cmo : \
-    _build/examples/fts/stub-generation/bindings/fts_types.cmo _build/src/ctypes/ctypes.cmi \
-    _build/src/cstubs/cstubs.cmi
-_build/examples/fts/stub-generation/bindings/fts_bindings.cmx : \
-    _build/examples/fts/stub-generation/bindings/fts_types.cmx _build/src/ctypes/ctypes.cmx \
-    _build/src/cstubs/cstubs.cmx
-_build/examples/fts/stub-generation/bindings/fts_types.cmo : \
-    _build/src/ctypes/unsigned.cmi _build/src/ctypes/posixTypes.cmi \
-    _build/src/ctypes-foreign-threaded/foreign.cmi _build/src/ctypes/ctypes.cmi \
-    _build/src/ctypes/ctypes_coerce.cmi
-_build/examples/fts/stub-generation/bindings/fts_types.cmx : \
-    _build/src/ctypes/unsigned.cmx _build/src/ctypes/posixTypes.cmx \
-    _build/src/ctypes-foreign-threaded/foreign.cmx _build/src/ctypes/ctypes.cmx \
-    _build/src/ctypes/ctypes_coerce.cmx
-_build/examples/fts/foreign/fts_cmd.cmo : _build/examples/fts/foreign/fts.cmi \
-    _build/src/ctypes/ctypes.cmi
-_build/examples/fts/foreign/fts_cmd.cmx : _build/examples/fts/foreign/fts.cmx \
-    _build/src/ctypes/ctypes.cmx
-_build/examples/fts/foreign/fts.cmi : _build/src/ctypes/posixTypes.cmi \
-    _build/src/ctypes/ctypes.cmi
-_build/examples/fts/foreign/fts.cmo : _build/src/ctypes/unsigned.cmi \
-    _build/src/ctypes/posixTypes.cmi _build/src/ctypes-foreign-threaded/foreign.cmi \
-    _build/src/ctypes/ctypes.cmi _build/src/ctypes/ctypes_coerce.cmi _build/examples/fts/foreign/fts.cmi
-_build/examples/fts/foreign/fts.cmx : _build/src/ctypes/unsigned.cmx \
-    _build/src/ctypes/posixTypes.cmx _build/src/ctypes-foreign-threaded/foreign.cmx \
-    _build/src/ctypes/ctypes.cmx _build/src/ctypes/ctypes_coerce.cmx _build/examples/fts/foreign/fts.cmi
-_build/examples/date/stub-generation/date_generated.cmo : _build/src/ctypes/ctypes.cmi \
-    _build/src/cstubs/cstubs_internals.cmi
-_build/examples/date/stub-generation/date_generated.cmx : _build/src/ctypes/ctypes.cmx \
-    _build/src/cstubs/cstubs_internals.cmx
-_build/examples/date/stub-generation/date_cmd.cmo : _build/src/ctypes/posixTypes.cmi \
-    _build/examples/date/stub-generation/bindings/date_stubs.cmo \
-    _build/examples/date/stub-generation/date_generated.cmo _build/src/ctypes/ctypes.cmi
-_build/examples/date/stub-generation/date_cmd.cmx : _build/src/ctypes/posixTypes.cmx \
-    _build/examples/date/stub-generation/bindings/date_stubs.cmx \
-    _build/examples/date/stub-generation/date_generated.cmx _build/src/ctypes/ctypes.cmx
-_build/examples/date/stub-generation/stub-generator/date_stub_generator.cmo : \
-    _build/examples/date/stub-generation/bindings/date_stubs.cmo \
-    _build/src/cstubs/cstubs.cmi
-_build/examples/date/stub-generation/stub-generator/date_stub_generator.cmx : \
-    _build/examples/date/stub-generation/bindings/date_stubs.cmx \
-    _build/src/cstubs/cstubs.cmx
-_build/examples/date/stub-generation/bindings/date_stubs.cmo : \
-    _build/src/ctypes/posixTypes.cmi _build/src/ctypes/ctypes.cmi
-_build/examples/date/stub-generation/bindings/date_stubs.cmx : \
-    _build/src/ctypes/posixTypes.cmx _build/src/ctypes/ctypes.cmx
-_build/examples/date/foreign/date.cmo : _build/src/ctypes/posixTypes.cmi \
-    _build/src/ctypes-foreign-threaded/foreign.cmi _build/src/ctypes/ctypes.cmi \
-    _build/examples/date/foreign/date.cmi
-_build/examples/date/foreign/date.cmx : _build/src/ctypes/posixTypes.cmx \
-    _build/src/ctypes-foreign-threaded/foreign.cmx _build/src/ctypes/ctypes.cmx \
-    _build/examples/date/foreign/date.cmi
-_build/examples/date/foreign/date.cmi : _build/src/ctypes/posixTypes.cmi \
-    _build/src/ctypes/ctypes.cmi
-_build/examples/ncurses/stub-generation/ncurses_stub_cmd.cmo : \
-    _build/examples/ncurses/stub-generation/ncurses_generated.cmo \
-    _build/examples/ncurses/stub-generation/bindings/ncurses_bindings.cmo
-_build/examples/ncurses/stub-generation/ncurses_stub_cmd.cmx : \
-    _build/examples/ncurses/stub-generation/ncurses_generated.cmx \
-    _build/examples/ncurses/stub-generation/bindings/ncurses_bindings.cmx
-_build/examples/ncurses/stub-generation/ncurses_generated.cmo : \
-    _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs_internals.cmi
-_build/examples/ncurses/stub-generation/ncurses_generated.cmx : \
-    _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs_internals.cmx
-_build/examples/ncurses/stub-generation/bindings/ncurses_bindings.cmo : \
-    _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs.cmi
-_build/examples/ncurses/stub-generation/bindings/ncurses_bindings.cmx : \
-    _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs.cmx
-_build/examples/ncurses/foreign/ncurses.cmi :
-_build/examples/ncurses/foreign/ncurses_cmd.cmo : \
-    _build/examples/ncurses/foreign/ncurses.cmi
-_build/examples/ncurses/foreign/ncurses_cmd.cmx : \
-    _build/examples/ncurses/foreign/ncurses.cmx
-_build/examples/ncurses/foreign/ncurses.cmo : \
-    _build/src/ctypes-foreign-threaded/foreign.cmi _build/src/ctypes/ctypes.cmi \
-    _build/examples/ncurses/foreign/ncurses.cmi
-_build/examples/ncurses/foreign/ncurses.cmx : \
-    _build/src/ctypes-foreign-threaded/foreign.cmx _build/src/ctypes/ctypes.cmx \
-    _build/examples/ncurses/foreign/ncurses.cmi

--- a/Makefile.tests
+++ b/Makefile.tests
@@ -792,6 +792,15 @@ tests/test-coercions/generated_stubs.c: $(BUILDDIR)/test-coercions-stub-generato
 tests/test-coercions/generated_bindings.ml: $(BUILDDIR)/test-coercions-stub-generator.native
 	$< --ml-file $@
 
+test-roots.dir = tests/test-roots
+test-roots.threads = yes
+test-roots.deps = str bigarray oUnit bytes
+test-roots.subproject_deps = ctypes ctypes-foreign-base \
+   ctypes-foreign-unthreaded cstubs tests-common
+test-roots.link_flags = -L$(BUILDDIR)/clib -ltest_functions
+test-roots: PROJECT=test-roots
+test-roots: $$(NATIVE_TARGET)
+
 test-passing-ocaml-values-stubs.dir  = tests/test-passing-ocaml-values/stubs
 test-passing-ocaml-values-stubs.threads = yes
 test-passing-ocaml-values-stubs.subproject_deps = ctypes cstubs \
@@ -871,6 +880,7 @@ TESTS += test-callback_lifetime-stubs test-callback_lifetime-stub-generator test
 TESTS += test-stubs
 TESTS += test-bigarrays-stubs test-bigarrays-stub-generator test-bigarrays-generated test-bigarrays
 TESTS += test-coercions-stubs test-coercions-stub-generator test-coercions-generated test-coercions
+TESTS += test-roots
 TESTS += test-passing-ocaml-values-stubs test-passing-ocaml-values-stub-generator test-passing-ocaml-values-generated test-passing-ocaml-values
 TESTS += test-threads-stubs test-threads
 

--- a/src/ctypes/ctypes.mli
+++ b/src/ctypes/ctypes.mli
@@ -414,6 +414,23 @@ val coerce_fn : 'a fn -> 'b fn -> 'a -> 'b
     ctypes may both add new types of coercion and restrict the existing
     coercions. *)
 
+(** {2:roots Registration of OCaml values as roots} *)
+module Root :
+sig
+  val create : 'a -> unit ptr
+  (** [create v] allocates storage for the address of the OCaml value [v],
+      registers the storage as a root, and returns its address. *)
+
+  val get : unit ptr -> 'a
+  (** [get p] retrieves the OCaml value whose address is stored at [p]. *)
+
+  val set : unit ptr -> 'a -> unit
+  (** [set p v] updates the OCaml value stored as a root at [p]. *)
+
+  val release : unit ptr -> unit
+  (** [release p] unregsiters the root [p]. *)
+end
+
 (** {2 Exceptions} *)
 
 exception Unsupported of string

--- a/src/ctypes/ctypes_memory.ml
+++ b/src/ctypes/ctypes_memory.ml
@@ -337,3 +337,24 @@ let ocaml_bytes_start str =
 
 let ocaml_float_array_start arr =
   OCamlRef (0, arr, FloatArray)
+
+module Root =
+struct
+  module Stubs = Ctypes_roots_stubs
+
+  (* Roots are not managed values so it's safe to call unsafe_raw_addr. *)
+  let raw_addr : unit ptr -> Raw.t =
+    fun (CPointer p) -> Fat.unsafe_raw_addr p
+
+  let create : 'a. 'a -> unit ptr =
+    fun v -> CPointer (Fat.make ~reftyp:void (Stubs.root v))
+
+  let get : 'a. unit ptr -> 'a =
+    fun p -> Stubs.get (raw_addr p)
+
+  let set : 'a. unit ptr -> 'a -> unit =
+    fun p v -> Stubs.set (raw_addr p) v
+  
+  let release : 'a. unit ptr -> unit =
+    fun p -> Stubs.release (raw_addr p)
+end

--- a/src/ctypes/ctypes_roots.c
+++ b/src/ctypes/ctypes_roots.c
@@ -1,0 +1,35 @@
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+#include "ctypes_raw_pointer.h"
+
+/* 'a -> voidp */
+value ctypes_caml_roots_create(value v)
+{
+  value *p = caml_stat_alloc(sizeof *p);
+  *p = v;
+  caml_register_generational_global_root(p);
+  return CTYPES_FROM_PTR(p);
+}
+
+/* voidp -> 'a -> unit */
+value ctypes_caml_roots_set(value p_, value v)
+{
+  value *p = CTYPES_TO_PTR(p_);
+  caml_modify_generational_global_root(p, v);
+  return Val_unit;
+}
+
+/* voidp -> 'a */
+value ctypes_caml_roots_get(value p_)
+{
+  value *p = CTYPES_TO_PTR(p_);
+  return *p;
+}
+
+/* voidp -> unit */
+value ctypes_caml_roots_release(value p_)
+{
+  value *p = CTYPES_TO_PTR(p_);
+  caml_remove_generational_global_root(p);
+  return Val_unit;
+}

--- a/src/ctypes/ctypes_roots_stubs.ml
+++ b/src/ctypes/ctypes_roots_stubs.ml
@@ -1,0 +1,18 @@
+(*
+ * Copyright (c) 2015 Jeremy Yallop.
+ *
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+external root : 'a -> Ctypes_ptr.voidp =
+  "ctypes_caml_roots_create"
+
+external set : Ctypes_ptr.voidp -> 'a -> unit =
+  "ctypes_caml_roots_set"
+
+external get : Ctypes_ptr.voidp -> 'a =
+  "ctypes_caml_roots_get"
+
+external release : Ctypes_ptr.voidp -> unit =
+  "ctypes_caml_roots_release"

--- a/tests/clib/test_functions.c
+++ b/tests/clib/test_functions.c
@@ -606,3 +606,14 @@ enum fruit next_fruit(enum fruit f)
   default: assert(0);
   }
 }
+
+void *global_ocaml_value = NULL;
+
+void save_ocaml_value(void *p)
+{
+  global_ocaml_value = p;
+}
+void *retrieve_ocaml_value(void)
+{
+  return global_ocaml_value;
+}

--- a/tests/clib/test_functions.h
+++ b/tests/clib/test_functions.h
@@ -226,4 +226,6 @@ struct fruit_cell {
   struct fruit_cell *next;
 };
 
+void save_ocaml_value(void *);
+void *retrieve_ocaml_value(void);
 #endif /* TEST_FUNCTIONS_H */

--- a/tests/test-roots/test_roots.ml
+++ b/tests/test-roots/test_roots.ml
@@ -67,9 +67,34 @@ let test_root_lifetime _ =
   ()
 
 
+(*
+  Test passing roots to C functions.
+*)
+let test_passing_roots _ =
+  let save =
+    foreign ~from:testlib "save_ocaml_value"
+      (ptr void @-> returning void)
+  and retrieve =
+    foreign ~from:testlib "retrieve_ocaml_value"
+      (void @-> returning (ptr void)) in
+  
+  let r = Root.create [| ( + ) 1; ( * ) 2 |] in
+
+  begin
+    save r;
+    Gc.compact ();
+    let fs : (int -> int) array = Root.get (retrieve ()) in
+    assert_equal 11 (fs.(0) 10);
+    assert_equal 20 (fs.(1) 10)
+  end
+
+
 let suite = "Root tests" >:::
   ["root lifetime"
     >:: test_root_lifetime;
+
+   "passing roots"
+    >:: test_passing_roots;
   ]
 
 

--- a/tests/test-roots/test_roots.ml
+++ b/tests/test-roots/test_roots.ml
@@ -1,0 +1,77 @@
+(*
+ * Copyright (c) 2013 Jeremy Yallop.
+ *
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+open OUnit2
+open Ctypes
+open Foreign
+
+
+let testlib = Dl.(dlopen ~filename:"clib/libtest_functions.so" ~flags:[RTLD_NOW])
+
+
+(*
+  Test root lifetime.
+*)
+let test_root_lifetime _ =
+  (* Check that values not registered as roots are collected. *)
+  let alive = ref true in
+  let v = [| 1; 2; 3 |] in
+  Gc.finalise (fun _ -> alive := false) v;
+  Gc.compact ();
+  assert_equal false !alive
+    ~msg:"values not registered as roots are collected";
+
+  (* Check that values registered as roots are not collected. *)
+  let alive = ref true in
+  let v = [| 1; 2; 3 |] in
+  Gc.finalise (fun _ -> alive := false) v;
+  let _r = Root.create v in
+  Gc.compact ();
+  assert_equal true !alive
+    ~msg:"registered roots are not collected";
+
+  (* Check that values unregistered as roots are collected. *)
+  let alive = ref true in
+  let v = [| 1; 2; 3 |] in
+  Gc.finalise (fun _ -> alive := false) v;
+  let r = Root.create v in
+  Root.release r;
+  Gc.compact ();
+  assert_equal false !alive
+    ~msg:"released roots are collected";
+
+  (* Check that values assigned to roots are not collected. *)
+  let alive = ref true in
+  let v = [| 1; 2; 3 |] in
+  Gc.finalise (fun _ -> alive := false) v;
+  let r = Root.create () in
+  Root.set r v;
+  Gc.compact ();
+  assert_equal true !alive
+    ~msg:"values assigned to roots are not collected";
+
+  (* Check that values registered as roots and then overwritten are collected. *)
+  let alive = ref true in
+  let v = [| 1; 2; 3 |] in
+  Gc.finalise (fun _ -> alive := false) v;
+  let r = Root.create v in
+  Root.set r ();
+  Gc.compact ();
+  assert_equal false !alive
+    ~msg:"overwritten roots are collected";
+
+  ()
+
+
+let suite = "Root tests" >:::
+  ["root lifetime"
+    >:: test_root_lifetime;
+  ]
+
+
+let _ =
+  run_test_tt_main suite


### PR DESCRIPTION
When exposing OCaml libraries to C (e.g. via [Cstubs_inverted](https://github.com/ocamllabs/ocaml-ctypes/blob/master/src/cstubs/cstubs_inverted.mli)) it's useful to give C code references to OCaml values and control over their lifetimes.  The `Ctypes.Root` module provides functions for creating, reading, updating and releasing OCaml roots that can be passed to C as `void*` values:

```ocaml
module Root :
sig
  val create : 'a -> unit ptr
  (** [create v] allocates storage for the address of the OCaml value [v],
      registers the storage as a root, and returns its address. *)

  val get : unit ptr -> 'a
  (** [get p] retrieves the OCaml value whose address is stored at [p]. *)

  val set : unit ptr -> 'a -> unit
  (** [set p v] updates the OCaml value stored as a root at [p]. *)

  val release : unit ptr -> unit
  (** [release p] unregsiters the root [p]. *)
end
```
