### PR TITLE
Fix: inconsistent use of caml_stat_* functions

### DIFF
--- a/src/ctypes/managed_buffer_stubs.c
+++ b/src/ctypes/managed_buffer_stubs.c
@@ -18,7 +18,7 @@
 
 static void finalize_free(value v)
 {
-  free(*((void **)Data_custom_val(v)));
+  caml_stat_free(*((void **)Data_custom_val(v)));
 }
 
 static int compare_pointers(value l_, value r_)


### PR DESCRIPTION
Hello. I'm doing a large-scale study of C stub sources on OPAM.

Your library makes use of the undocumented `caml_stat_*` functions, which currently are thin wrappers around `malloc`, `realloc`, and `free` from the C standard library. In future, the implementation of these functions [may change](https://github.com/ocaml/ocaml/pull/71), making them incompatible with `malloc` and breaking the code that abused the old undocumented semantics.

Regardless of whether the change of semantics will happen or not, being consistent about such matters should be considered good style.