### PR TITLE
Fix: a memory leak in ctypes_caml_roots_release

### DIFF
--- a/src/ctypes/ctypes_roots.c
+++ b/src/ctypes/ctypes_roots.c
@@ -31,5 +31,6 @@ value ctypes_caml_roots_release(value p_)
 {
   value *p = CTYPES_TO_PTR(p_);
   caml_remove_generational_global_root(p);
+  caml_stat_free(p);
   return Val_unit;
 }


### PR DESCRIPTION
Each invocation of `ctypes_caml_roots_create` seems to be leaking a "pointerful" of memory. Caught this as part of a large-scale audit of C stubs related to [this PR](https://github.com/ocaml/ocaml/pull/71).