### PR TITLE
Fix: inconsistent use of caml_stat_* functions

### DIFF
--- a/src/ctypes-foreign-base/ffi_call_stubs.c
+++ b/src/ctypes-foreign-base/ffi_call_stubs.c
@@ -136,8 +136,8 @@ static struct callspec {
 static void finalize_callspec(value v)
 {
   struct callspec *callspec = Data_custom_val(v);
-  free(callspec->args);
-  free(callspec->cif);
+  caml_stat_free(callspec->args);
+  caml_stat_free(callspec->cif);
 }
 
 


### PR DESCRIPTION
One more patch from the same series:

> Hello. I'm doing a large-scale study of C stub sources on OPAM.
>
> Your library makes use of the undocumented `caml_stat_*` functions, which currently are thin wrappers around `malloc`, `realloc`, and `free` from the C standard library. In future, the implementation of these functions [may change](https://github.com/ocaml/ocaml/pull/71), making them incompatible with `malloc` and breaking the code that abused the old undocumented semantics.
>
> Regardless of whether the change of semantics will happen or not, being consistent about such matters should be considered good style.