### PR TITLE
Allocate zeros

### DIFF
--- a/src/ctypes-foreign-base/ffi_type_stubs.c
+++ b/src/ctypes-foreign-base/ffi_type_stubs.c
@@ -121,7 +121,7 @@ value ctypes_allocate_struct_ffitype(value nargs_)
   /* Space for the struct ffi_type plus a null-terminated array of arguments */
   int size = sizeof (ffi_type) + (1 + nargs) * sizeof (ffi_type *);
   CAMLlocal1(block);
-  block = ctypes_allocate(Val_int(size));
+  block = ctypes_allocate(Val_int(1), Val_int(size));
   ffi_type *struct_type = Struct_ffitype_val(block);
   struct_type->size = 0;
   struct_type->alignment = 0;

--- a/src/ctypes/ctypes.mli
+++ b/src/ctypes/ctypes.mli
@@ -185,14 +185,16 @@ val to_voidp : _ ptr -> unit ptr
 (** Conversion to [void *]. *)
 
 val allocate : ?finalise:('a ptr -> unit) -> 'a typ -> 'a -> 'a ptr
-(** [allocate t v] allocates a fresh value of type [t], initialises it with
-    [v] and returns its address.  The argument [?finalise], if present, will be
-    called just before the memory is freed.  *)
+(** [allocate t v] allocates a fresh value of type [t], initialises it
+    with [v] and returns its address.  The argument [?finalise], if
+    present, will be called just before the memory is freed.  *)
 
 val allocate_n : ?finalise:('a ptr -> unit) -> 'a typ -> count:int -> 'a ptr
-(** [allocate_n t ~count:n] allocates a fresh array with element type [t] and
-    length [n], and returns its address.  The argument [?finalise], if present,
-    will be called just before the memory is freed.  *)
+(** [allocate_n t ~count:n] allocates a fresh array with element type
+    [t] and length [n], and returns its address.  The argument
+    [?finalise], if present, will be called just before the memory is
+    freed.  The memory is allocated with libc's [calloc] and is
+    guaranteed to be zero-filled.  *)
 
 val ptr_compare : 'a ptr -> 'a ptr -> int
 (** If [p] and [q] are pointers to elements [i] and [j] of the same array then

--- a/src/ctypes/ctypes_managed_buffer_stubs.h
+++ b/src/ctypes/ctypes_managed_buffer_stubs.h
@@ -13,8 +13,8 @@
 /* copy_bytes : void * -> size_t -> managed_buffer */
 extern value ctypes_copy_bytes(void *, size_t);
 
-/* allocate : int -> managed_buffer */
-extern value ctypes_allocate(value size);
+/* allocate : int -> int -> managed_buffer */
+extern value ctypes_allocate(value count, value size);
 
 /* block_address : managed_buffer -> immediate_pointer */
 extern value ctypes_block_address(value managed_buffer);

--- a/src/ctypes/ctypes_memory.ml
+++ b/src/ctypes/ctypes_memory.ml
@@ -23,7 +23,7 @@ let rec build : type a b. a typ -> b typ Fat.t -> a
       raise IncompleteType
     | Struct { spec = Complete { size } } as reftyp ->
       (fun buf ->
-        let managed = Stubs.allocate size in
+        let managed = Stubs.allocate 1 size in
         let dst = Fat.make ~managed ~reftyp (Stubs.block_address managed) in
         let () = Stubs.memcpy ~size ~dst ~src:buf in
         { structured = CPointer dst})
@@ -122,7 +122,8 @@ let (<-@) : type a. a ptr -> a -> unit
 let from_voidp = castp
 let to_voidp p = castp Void p
 
-let allocate_n : type a. ?finalise:(a ptr -> unit) -> a typ -> count:int -> a ptr
+let allocate_n
+  : type a. ?finalise:(a ptr -> unit) -> a typ -> count:int -> a ptr
   = fun ?finalise reftyp ~count ->
     let package p =
       CPointer (Fat.make ~managed:p ~reftyp (Stubs.block_address p))
@@ -131,7 +132,7 @@ let allocate_n : type a. ?finalise:(a ptr -> unit) -> a typ -> count:int -> a pt
       | Some f -> Gc.finalise (fun p -> f (package p))
       | None -> ignore
     in
-    let p = Stubs.allocate (count * sizeof reftyp) in begin
+    let p = Stubs.allocate count (sizeof reftyp) in begin
       finalise p;
       package p
     end

--- a/src/ctypes/ctypes_memory_stubs.ml
+++ b/src/ctypes/ctypes_memory_stubs.ml
@@ -13,8 +13,8 @@ open Ctypes_ptr
    C heap. *)
 type managed_buffer
 
-(* Allocate a region of stable memory managed by a custom block. *)
-external allocate : int -> managed_buffer
+(* Allocate a region of stable, zeroed memory managed by a custom block. *)
+external allocate : int -> int -> managed_buffer
   = "ctypes_allocate"
 
 (* Obtain the address of the managed block. *)

--- a/src/ctypes/raw_pointer_stubs.c
+++ b/src/ctypes/raw_pointer_stubs.c
@@ -50,7 +50,7 @@ value ctypes_cstring_of_string(value s)
   CAMLparam1(s);
   CAMLlocal1(buffer);
   int len = caml_string_length(s);
-  buffer = ctypes_allocate(Val_int(len + 1));
+  buffer = ctypes_allocate(Val_int(1), Val_int(len + 1));
   char *dst = CTYPES_TO_PTR(ctypes_block_address(buffer));
   char *ss = String_val(s);
   memcpy(dst, ss, len);


### PR DESCRIPTION
This uses `calloc` under the hood to give the OS a chance to optimize if it tags pages as zeroed.

Please review and let me know how you'd like this expressed/integrated and if you see any issues.

Thanks!