### PR TITLE
Expose more information in the Uncoercible exception.

### DIFF
--- a/src/ctypes/ctypes.mli
+++ b/src/ctypes/ctypes.mli
@@ -458,5 +458,6 @@ exception IncompleteType
     cannot be used as argument or return types.
 *)
 
-exception Uncoercible
+type uncoercible_info
+exception Uncoercible of uncoercible_info
 (** An attempt was made to coerce between uncoercible types.  *)

--- a/tests/test-coercions/test_coercions.ml
+++ b/tests/test-coercions/test_coercions.ml
@@ -252,7 +252,10 @@ let test_unsupported_coercions _ =
     let () = 
       ListLabels.iter types ~f:(fun (T t1, ts) ->
       ListLabels.iter ts ~f:(fun (T t2) ->
-        assert_raises Uncoercible (fun () -> coerce t1 t2)))
+              try 
+                coerce t1 t2;
+                assert_failure "coercion unexpectedly succeeded"
+              with Uncoercible _ -> ()))
   end in ()
 
 


### PR DESCRIPTION
This PR partially addresses #338 by adding additional information to the `Uncoercible` exception, which was previously declared as follows:

```ocaml
exception Uncoercible
```

and is now declared as follows:

```ocaml
exception Uncoercible of uncoercible_info
```

where `uncoercible_info` is an abstract type.  Additionally, the PR registers a printer for `Uncoercible` that displays the source and target types of the failed coercion.  Here's an example program

```
$ cat uc.ml
let _ = Ctypes.(coerce int string) 3
$ ocamlfind c -o uc  -package ctypes -linkpkg uc.ml
```

which previously behaved like this:

```
$ ./uc
Fatal error: exception Ctypes_coerce.Uncoercible
```

and now behaves like this:

```
$ ./uc
Fatal error: exception Coercion failure: int is not coercible to char*
```
