### PR TITLE
 Expose arithmetic operations for POSIX arithmetic types

### DIFF
--- a/src/ctypes/ctypes_std_views.ml
+++ b/src/ctypes/ctypes_std_views.ml
@@ -77,7 +77,11 @@ let signed_typedef name ~size : (module Signed_type) =
 
 let unsigned_typedef name ~size : (module Unsigned_type) =
   match size with
-    4 -> (module struct include Unsigned.UInt32
+  | 1 -> (module struct include Unsigned.UInt8
+           let t = Ctypes_static.(typedef uint8_t name) end)
+  | 2 -> (module struct include Unsigned.UInt16
+           let t = Ctypes_static.(typedef uint16_t name) end)
+  | 4 -> (module struct include Unsigned.UInt32
            let t = Ctypes_static.(typedef uint32_t name) end)
   | 8 -> (module struct include Unsigned.UInt64
            let t = Ctypes_static.(typedef uint64_t name) end)

--- a/src/ctypes/posixTypes.mli
+++ b/src/ctypes/posixTypes.mli
@@ -12,15 +12,22 @@ open Ctypes
 (* arithmetic types from <sys/types.h> *)
 (** {2 POSIX arithmetic types} *)
 
-type clock_t
-type dev_t
-type ino_t
-type mode_t
-type nlink_t
-type off_t
-type pid_t
-type size_t = Unsigned.size_t
+module Dev : Unsigned.S
+module Ino : Unsigned.S
+module Mode : Unsigned.S
+module Nlink : Unsigned.S
+module Off : Signed.S
+module Pid : Signed.S
 module Ssize : Signed.S
+
+type clock_t
+type dev_t = Dev.t
+type ino_t = Ino.t
+type mode_t = Mode.t
+type nlink_t = Nlink.t
+type off_t = Off.t
+type pid_t = Pid.t
+type size_t = Unsigned.size_t
 type ssize_t = Ssize.t
 type time_t
 type useconds_t


### PR DESCRIPTION
A number of the POSIX types, such as `dev_t` and `ino_t`, are [specified to be integers](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_types.h.html), not just arithmetic types, which means that we can expose arithmetic operations for them.

In cases such as `pid_t` where the type is known to be signed, this PR exposes a module of type [`Signed.S`](http://ocamllabs.github.io/ocaml-ctypes/Signed.S.html) for the type.  In cases such as `mode_t` where the signedness is not specified, the exposed module has type [`Unsigned.S`](http://ocamllabs.github.io/ocaml-ctypes/Unsigned.S.html), which is a subtype of `Signed.S`.

Fixes #87.