### PR TITLE
Extend the maximum duration of the cstdlib tests.

### DIFF
--- a/tests/test-cstdlib/test_cstdlib.ml
+++ b/tests/test-cstdlib/test_cstdlib.ml
@@ -297,8 +297,8 @@ let test_div _ =
 module Foreign_tests = Common_tests(Tests_common.Foreign_binder)
 module Stub_tests = Common_tests(Generated_bindings)
 
-
 let suite = "C standard library tests" >:::
+  let (>::) name f = name >: OUnitTest.TestCase (OUnitTest.Long, f) in
   ["test isX functions (foreign)"
     >:: Foreign_tests.test_isX_functions;
 

--- a/tests/test-pointers/test_pointers.ml
+++ b/tests/test-pointers/test_pointers.ml
@@ -578,6 +578,7 @@ module Foreign_tests = Common_tests(Tests_common.Foreign_binder)
 module Stub_tests = Common_tests(Generated_bindings)
 
 let suite = "Pointer tests" >:::
+  let (>::) name f = name >: OUnitTest.TestCase (OUnitTest.Long, f) in
   ["passing pointers (foreign)"
     >:: Foreign_tests.test_passing_pointers;
 

--- a/tests/test-structs/test_structs.ml
+++ b/tests/test-structs/test_structs.ml
@@ -594,6 +594,7 @@ module Combined_stub_tests =
 
 
 let suite = "Struct tests" >:::
+  let (>::) name f = name >: OUnitTest.TestCase (OUnitTest.Long, f) in
   ["passing struct (foreign)"
    >:: Foreign_tests.test_passing_struct;
 


### PR DESCRIPTION
When coverage is enabled the cstdlib tests often time out, causing the Travis build to fail.  This PR extends the maximum test duration to [`OUnitTest.Long`](http://ounit.forge.ocamlcore.org/api-ounit/OUnitTest.html#TYPEtest_length), i.e. 10 minutes.