### PR TITLE
Expose time_t as an unsigned value

### DIFF
--- a/src/ctypes/posixTypes.ml
+++ b/src/ctypes/posixTypes.ml
@@ -84,13 +84,13 @@ module Mode = (val mkArithmetic "mode_t" (typeof_mode_t ()))
 module Nlink = (val mkArithmetic "nlink_t" (typeof_nlink_t ()))
 module Off = (val mkSigned "off_t" (typeof_off_t ()))
 module Pid = (val mkSigned "pid_t" (typeof_pid_t ()))
-module Size = 
+module Size =
 struct
   type t = Unsigned.size_t
   let t = Ctypes.size_t
 end
 module Ssize = (val mkSigned "ssize_t" (typeof_ssize_t ()))
-module Time = (val mkArithmetic_abstract (typeof_time_t ()) : Abstract)
+module Time = (val mkArithmetic "time_t" (typeof_time_t ()))
 module Useconds = (val mkArithmetic_abstract (typeof_useconds_t ()) : Abstract)
 
 type clock_t = Clock.t

--- a/src/ctypes/posixTypes.mli
+++ b/src/ctypes/posixTypes.mli
@@ -19,6 +19,7 @@ module Nlink : Unsigned.S
 module Off : Signed.S
 module Pid : Signed.S
 module Ssize : Signed.S
+module Time : Unsigned.S
 
 type clock_t
 type dev_t = Dev.t
@@ -29,7 +30,7 @@ type off_t = Off.t
 type pid_t = Pid.t
 type size_t = Unsigned.size_t
 type ssize_t = Ssize.t
-type time_t
+type time_t = Time.t
 type useconds_t
 
 (** {3 Values representing POSIX arithmetic types} *)


### PR DESCRIPTION
I'm not actually sure this is correct, but I need a time_t exposed in such a way that I can convert an integer to it, is there a more correct way to do this?