### PR TITLE
Remove the deprecated '*:*' and '+:+' functions.

### DIFF
--- a/src/ctypes/ctypes.ml
+++ b/src/ctypes/ctypes.ml
@@ -19,8 +19,4 @@ include Ctypes_value_printing
 
 include Ctypes_coerce
 
-let ( *:* ) s t = field s "<unknown>" t
-
-let ( +:+ ) s t = field s "<unknown>" t
-
 let lift_typ x = x

--- a/src/ctypes/ctypes.mli
+++ b/src/ctypes/ctypes.mli
@@ -116,12 +116,6 @@ include Ctypes_types.TYPE
 
 (** {3 Operations on types} *)
 
-val ( *:* ) : 't typ -> 'a typ -> ('a, (('s, [`Struct]) structured as 't)) field
-(** @deprecated Add an anonymous field to a structure.  Use {!field} instead. *)
-
-val ( +:+ ) : 't typ -> 'a typ -> ('a, (('s, [`Union]) structured as 't)) field
-(** @deprecated Add an anonymous field to a union.  Use {!field} instead. *)
-
 val sizeof : 'a typ -> int
 (** [sizeof t] computes the size in bytes of the type [t].  The exception
     {!IncompleteType} is raised if [t] is incomplete. *)


### PR DESCRIPTION
This pull request removes `*:*` and `+:+`, which have been deprecated since 510b7a8f6747a8422bccc15fe4050d034ea134c9 (August 2013), and since the 0.2.0 release.

Initially, structs were defined as follows in ctypes:

```ocaml
let s : s structure typ = structure "s"
let x = s *:* int 
let y = s *:* float 
let () = seal s
```
However, struct fields have names, and those names turn out to be useful when generating C code.  The [`field`](http://ocamllabs.github.io/ocaml-ctypes/Ctypes_types.TYPE.html#VALfield) function, which replaces `*:*` and `+:+`, takes an additional argument that specifies the name:

```ocaml
let s : s structure typ = structure "s"
let x = field s "x" int 
let y = field s "y" float 
let () = seal s
```

In [practice](https://github.com/dsheets/profuse/blob/009ffddce0c6d2353e4b99f79b083bc419b35aed/lib_gen/profuse_types_7_8.ml#L27), people often like to define an operator similar to `*:*` by partially applying `field` to a structure type representation, like this:

```ocaml
let s = structure "s"
let ( -:* ) s x = field t s x
let x = "x" -:* int 
let y = "y" -:* float 
let () = seal s
```

Names are useful in a variety of circumstances, not just in code generation.  For example, they're used when printing types: 

```ocaml
# s;;
- : s Ctypes.structure Ctypes.typ = struct s { int x; float y;  }
```

and when printing values:

```ocaml
# v;;
- : (s, [ `Struct ]) Ctypes.structured = { x = 10, y = 20  }
```
