### PR TITLE
Extra care with optimizer/GC interactions

### DIFF
--- a/src/ctypes-foreign-base/ctypes_ffi.ml
+++ b/src/ctypes-foreign-base/ctypes_ffi.ml
@@ -136,7 +136,7 @@ struct
               raise Ctypes_ffi_stubs.CallToExpiredClosure
           in
           let v = box (Ctypes_weak_ref.make f') in
-          let () = Gc.finalise (fun _ -> ignore (f'); ()) v in
+          let () = Gc.finalise (fun _ -> Ctypes_memory_stubs.use_value f') v in
           v)
 
   let write_arg : type a. a typ -> offset:int -> idx:int -> a ->

--- a/src/ctypes/ctypes_bigarray.ml
+++ b/src/ctypes/ctypes_bigarray.ml
@@ -145,4 +145,4 @@ let view : type a b. (a, b) t -> _ Ctypes_ptr.Fat.t -> b =
   | Dims3 (d1, d2, d3) -> view3 kind [| d1; d2; d3 |] ptr in
   match Ctypes_ptr.Fat.managed ptr with
   | None -> ba
-  | Some src -> Gc.finalise (fun _ -> ignore src; ()) ba; ba
+  | Some src -> Gc.finalise (fun _ -> Ctypes_memory_stubs.use_value src) ba; ba

--- a/src/ctypes/ctypes_memory_stubs.ml
+++ b/src/ctypes/ctypes_memory_stubs.ml
@@ -45,3 +45,7 @@ external memcpy : dst:_ Fat.t -> src:_ Fat.t -> size:int -> unit
 (* Read a fixed length OCaml string from memory *)
 external string_of_array : _ Fat.t -> len:int -> string
   = "ctypes_string_of_array"
+
+(* Do nothing, concealing from the optimizer that nothing is being done. *)
+external use_value : 'a -> unit
+  = "ctypes_use"

--- a/src/ctypes/ctypes_roots.c
+++ b/src/ctypes/ctypes_roots.c
@@ -34,3 +34,9 @@ value ctypes_caml_roots_release(value p_)
   caml_stat_free(p);
   return Val_unit;
 }
+
+/* 'a -> unit */
+value ctypes_use(value v)
+{
+  return v;
+}

--- a/tests/test-bigarrays/test_bigarrays.ml
+++ b/tests/test-bigarrays/test_bigarrays.ml
@@ -404,8 +404,8 @@ let test_bigarray_lifetime_with_ctypes_reference _ =
     (* The bigarray is out of scope, but the ctypes object is still live, so
        the memory shouldn't be reclaimed. *)
     begin
-      Gc.major ();
-      Gc.major ();
+      Gc.full_major ();
+      Gc.full_major ();
       assert_equal !state `Not_safe_to_collect;
       assert_equal 1 !@pointer;
     end
@@ -414,8 +414,8 @@ let test_bigarray_lifetime_with_ctypes_reference _ =
      should (or, at least, could) run. *)
   begin
     state := `Safe_to_collect;
-    Gc.major ();
-    Gc.major ();
+    Gc.full_major ();
+    Gc.full_major ();
     assert_equal !state `Collected
   end
 
@@ -446,8 +446,8 @@ let test_ctypes_memory_lifetime_with_bigarray_reference _ =
     (* The ctypes object is out of scope, but the bigarray is still live, so
        the memory shouldn't be reclaimed. *)
     begin
-      Gc.major ();
-      Gc.major ();
+      Gc.full_major ();
+      Gc.full_major ();
       assert_equal !state `Not_safe_to_collect;
       assert_equal ba.{0} 1L;
       assert_equal ba.{3} 4L;
@@ -457,8 +457,8 @@ let test_ctypes_memory_lifetime_with_bigarray_reference _ =
      should (or, at least, could) run. *)
   begin
     state := `Safe_to_collect;
-    Gc.major ();
-    Gc.major ();
+    Gc.full_major ();
+    Gc.full_major ();
     assert_equal !state `Collected
   end
 

--- a/tests/test-callback_lifetime/test_callback_lifetime.ml
+++ b/tests/test-callback_lifetime/test_callback_lifetime.ml
@@ -25,7 +25,7 @@ struct
 
     begin
       store_callback double;
-      Gc.major ();
+      Gc.full_major ();
       assert_equal 10 (invoke_stored_callback 5)
     end
 
@@ -46,8 +46,8 @@ struct
       store_callback (closure 2);
       (* The first GC collects the closure itself, which frees the associated object
          to be collected on the next GC. *)
-      Gc.major ();
-      Gc.major (); 
+      Gc.full_major ();
+      Gc.full_major (); 
       assert_raises CallToExpiredClosure
         (fun () -> invoke_stored_callback 5)
     end

--- a/tests/test-callback_lifetime/test_callback_lifetime.ml
+++ b/tests/test-callback_lifetime/test_callback_lifetime.ml
@@ -43,7 +43,7 @@ struct
 
     begin
       (* The closure should be collected in the next GC *)
-      store_callback (closure 2);
+      store_callback (closure (int_of_string "2"));
       (* The first GC collects the closure itself, which frees the associated object
          to be collected on the next GC. *)
       Gc.full_major ();
@@ -106,27 +106,27 @@ struct
 
     (* First, the naive implementation.  This should fail, because arg is
        collected before ret is called. *)
-    let ret = Naive.make ~arg:(closure 3) in
+    let ret = Naive.make ~arg:(closure (int_of_string "3")) in
     Gc.full_major ();
     assert_raises CallToExpiredClosure
       (fun () -> Naive.get ret 5);
 
     (* Now a more careful implementation.  This succeeds, because we keep a
        reference to arg around with the reference to ret *)
-    let ret = Better.make ~arg:(closure 3) in
+    let ret = Better.make ~arg:(closure (int_of_string "3")) in
     Gc.full_major ();
     assert_equal 15 (Better.get ret 5);
 
     (* However, even with the careful implementation things can go wrong if we
        keep a reference to ret beyond the lifetime of the pair. *)
-    let ret = Better.get (Better.make ~arg:(closure 3)) in
+    let ret = Better.get (Better.make ~arg:(closure (int_of_string "3"))) in
     Gc.full_major ();
     assert_raises CallToExpiredClosure
       (fun () -> ret 5);
 
     (* The most careful implementation calls ret rather than returning it,
        so arg cannot be collected prematurely. *)
-    let ret = Careful.get (Careful.make ~arg:(closure 3)) in
+    let ret = Careful.get (Careful.make ~arg:(closure (int_of_string "3"))) in
     Gc.full_major ();
     assert_equal 15 (ret 5)
 end

--- a/tests/test-finalisers/test_finalisers.ml
+++ b/tests/test-finalisers/test_finalisers.ml
@@ -29,13 +29,13 @@ let test_array_finaliser _ =
         Array.start a
       end in
     begin
-      Gc.major ();
+      Gc.full_major ();
       assert_equal ~msg:"The finaliser was not run"
         false !finaliser_completed;
       assert_equal 1 !@p;
     end in
   begin
-    Gc.major ();
+    Gc.full_major ();
     assert_equal ~msg:"The finaliser was run"
       true !finaliser_completed;
   end
@@ -69,7 +69,7 @@ let test_struct_finaliser _ =
           addr s
         end in
       begin
-        Gc.major ();
+        Gc.full_major ();
         assert_equal ~msg:"The finaliser was not run"
           false !finaliser_completed;
         assert_equal 10l !@(from_voidp int32_t (to_voidp p));
@@ -77,7 +77,7 @@ let test_struct_finaliser _ =
 
     let () =
       begin
-        Gc.major ();
+        Gc.full_major ();
         assert_equal ~msg:"The finaliser was run"
           true !finaliser_completed;
       end

--- a/tests/test-structs/test_structs.ml
+++ b/tests/test-structs/test_structs.ml
@@ -341,7 +341,7 @@ let test_field_references_not_invalidated _ =
       ()
     ) ()
     let () = begin
-      Gc.major ();
+      Gc.full_major ();
       seal s1;
       assert_equal ~printer:string_of_int
         (sizeof int) (sizeof s1)
@@ -368,7 +368,7 @@ let test_struct_ffi_type_lifetime _ =
       in
       Foreign.foreign ~from:testlib "return_struct_by_value" t
 
-    let () = Gc.major()
+    let () = Gc.full_major()
     let x = f ()
   end in ()
 

--- a/tests/test-threads/test_threads.ml
+++ b/tests/test-threads/test_threads.ml
@@ -30,8 +30,8 @@ let test_release_runtime_lock _ =
 *)
 let test_acquire_runtime_lock _ =
   begin
-    let f x y = let _ = Gc.major () in !@x + !@y in
-    let t1 = Thread.create Gc.major () in
+    let f x y = let _ = Gc.full_major () in !@x + !@y in
+    let t1 = Thread.create Gc.full_major () in
     assert (callback_with_pointers f = 7);
     Thread.join t1
   end


### PR DESCRIPTION
@LaurentMazare reports (#381) a potetntial problem that arises with the more aggressive optimization in OCaml 4.03: the optimizer detects that references to values can be eliminated altogether, so the GC collects the values earlier than intended. 285e227 introduces a fix for that problem: the values are "used" by passing them to a C function, whose implementation the optimizer cannot see.  

1f49699 adds a second fix for an optimizer/GC interaction in the tests.  The tests for closure lifetime previously contained code like this, which allocates a closure and passes it to C:

```ocaml
   let mul x y = x * y in
     c_function (mul 3)
```

The optimizer apparently transformed the code to eliminate the closure, resulting in something like this:

```ocaml
   let mul_3 y = 3 * y

     c_function mul_3
```

As a result, the closure lifetime tests failed, since no closure was allocated, and there was nothing to collect.  The fix is to change the argument so that it is no longer a static value (`3`).

This closes #381.