### PR TITLE
Extend the Cstubs.FOREIGN interface

### DIFF
--- a/examples/date/stub-generation/bindings/date_stubs.ml
+++ b/examples/date/stub-generation/bindings/date_stubs.ml
@@ -23,8 +23,7 @@ let tm_isdst = int -: "tm_isdst" (* daylight saving time *)
 let () = seal (tm : tm structure typ)
 
 module Bindings
-  (F : sig type _ fn
-           val foreign : string -> ('a -> 'b) Ctypes.fn -> ('a -> 'b) fn end) =
+  (F : Cstubs.FOREIGN) =
 struct
   open F
 

--- a/examples/fts/stub-generation/bindings/fts_bindings.ml
+++ b/examples/fts/stub-generation/bindings/fts_bindings.ml
@@ -13,25 +13,27 @@ open FTS
 
 module Bindings (F : Cstubs.FOREIGN) =
 struct
+  open F
+
   (* FTS *fts_open(char * const *path_argv, int options,
      int ( *compar)(const FTSENT **, const FTSENT ** ));
   *)
-  let _fts_open = F.foreign "fts_open"
+  let _fts_open = foreign "fts_open"
     (ptr string @-> int @-> compar_typ_opt @-> returning (ptr fts))
 
   (* FTSENT *fts_read(FTS *ftsp); *)
-  let _fts_read = F.foreign "fts_read" (* ~check_errno:true *)
+  let _fts_read = foreign "fts_read" (* ~check_errno:true *)
     (ptr fts @-> returning (ptr ftsent))
 
   (* FTSENT *fts_children(FTS *ftsp, int options); *)
-  let _fts_children = F.foreign "fts_children"
+  let _fts_children = foreign "fts_children"
     (ptr fts @-> int @-> returning (ptr ftsent))
 
   (* int fts_set(FTS *ftsp, FTSENT *f, int options); *)
-  let _fts_set = F.foreign "fts_set" (* ~check_errno:true *)
+  let _fts_set = foreign "fts_set" (* ~check_errno:true *)
     (ptr fts @-> ptr (ftsent) @-> int @-> returning int)
 
   (* int fts_close(FTS *ftsp); *)
-  let _fts_close = F.foreign "fts_close" (* ~check_errno:true *)
+  let _fts_close = foreign "fts_close" (* ~check_errno:true *)
     (ptr fts @-> returning int)
 end

--- a/src/cstubs/cstubs.mli
+++ b/src/cstubs/cstubs.mli
@@ -72,11 +72,16 @@ end
 module type FOREIGN =
 sig
   type 'a fn
-  val foreign : string -> ('a -> 'b) Ctypes.fn -> ('a -> 'b) fn
-  val foreign_value : string -> 'a Ctypes.typ -> 'a Ctypes.ptr fn
+  type 'a return
+  val (@->) : 'a Ctypes.typ -> 'b fn -> ('a -> 'b) fn
+  val returning : 'a Ctypes.typ -> 'a return fn
+
+  type 'a result
+  val foreign : string -> ('a -> 'b) fn -> ('a -> 'b) result
+  val foreign_value : string -> 'a Ctypes.typ -> 'a Ctypes.ptr result
 end
 
-module type BINDINGS = functor (F : FOREIGN with type 'a fn = unit) -> sig end
+module type BINDINGS = functor (F : FOREIGN with type 'a result = unit) -> sig end
 
 val write_c : Format.formatter -> prefix:string -> (module BINDINGS) -> unit
 (** [write_c fmt ~prefix bindings] generates C stubs for the functions bound

--- a/tests/test-arrays/test_array.ml
+++ b/tests/test-arrays/test_array.ml
@@ -153,7 +153,8 @@ let test_pointer_to_array_arithmetic _ =
   assert_equal 12 a.(3).(2);
   assert_equal 1 a.(0).(0)
 
-module Common_tests(S : Cstubs.FOREIGN with type 'a fn = 'a) =
+module Common_tests(S : Cstubs.FOREIGN with type 'a result = 'a
+                                        and type 'a return = 'a) =
 struct
   module M = Functions.Stubs(S)
   open M

--- a/tests/test-bigarrays/test_bigarrays.ml
+++ b/tests/test-bigarrays/test_bigarrays.ml
@@ -320,7 +320,8 @@ let test_ctypes_array_of_bigarray _ =
   end
 
 
-module Common_tests(S : Cstubs.FOREIGN with type 'a fn = 'a) =
+module Common_tests(S : Cstubs.FOREIGN with type 'a result = 'a
+                                        and type 'a return = 'a) =
 struct
   module M = Functions.Stubs(S)
   open M

--- a/tests/test-bools/stubs/functions.ml
+++ b/tests/test-bools/stubs/functions.ml
@@ -13,5 +13,5 @@ open Ctypes
    using stub generation. *)
 module Common(F : Cstubs.FOREIGN) =
 struct
-  let bool_and = F.foreign "bool_and" (bool @-> bool @-> returning bool)
+  let bool_and = F.(foreign "bool_and" (bool @-> bool @-> returning bool))
 end

--- a/tests/test-bools/test_bools.ml
+++ b/tests/test-bools/test_bools.ml
@@ -9,7 +9,8 @@ open OUnit2
 open Ctypes
 
 
-module Common_tests(S : Cstubs.FOREIGN with type 'a fn = 'a) =
+module Common_tests(S : Cstubs.FOREIGN with type 'a result = 'a
+                                        and type 'a return = 'a) =
 struct
   module M = Functions.Common(S)
   open M

--- a/tests/test-callback_lifetime/stubs/functions.ml
+++ b/tests/test-callback_lifetime/stubs/functions.ml
@@ -14,7 +14,7 @@ module Stubs (F: Cstubs.FOREIGN) =
 struct
   open F
 
-  let callback_type_ptr = funptr (int @-> returning int)
+  let callback_type_ptr = funptr Ctypes.(int @-> returning int)
 
   let store_callback = foreign "store_callback"
     (callback_type_ptr @-> returning void)

--- a/tests/test-callback_lifetime/test_callback_lifetime.ml
+++ b/tests/test-callback_lifetime/test_callback_lifetime.ml
@@ -10,7 +10,8 @@ open Ctypes
 open Foreign
 
 
-module Common_tests(S : Cstubs.FOREIGN with type 'a fn = 'a) =
+module Common_tests(S : Cstubs.FOREIGN with type 'a result = 'a
+                                        and type 'a return = 'a) =
 struct
   module M = Functions.Stubs(S)
   open M

--- a/tests/test-coercions/test_coercions.ml
+++ b/tests/test-coercions/test_coercions.ml
@@ -134,7 +134,8 @@ let test_view_coercions _ =
   end in ()
 
 
-module Common_tests(S : Cstubs.FOREIGN with type 'a fn = 'a) =
+module Common_tests(S : Cstubs.FOREIGN with type 'a result = 'a
+                                        and type 'a return = 'a) =
 struct
   module M = Functions.Stubs(S)
   open M

--- a/tests/test-complex/stubs/functions.ml
+++ b/tests/test-complex/stubs/functions.ml
@@ -14,8 +14,8 @@ open Ctypes
 module Common(F : Cstubs.FOREIGN) =
 struct
   let bind typ name =
-    F.foreign name
-      (ptr typ @-> ptr typ @-> ptr typ @-> returning void)
+    F.(foreign name
+         (ptr typ @-> ptr typ @-> ptr typ @-> returning void))
 
   let add_complexd = bind complex64 "add_complexd"
   let mul_complexd = bind complex64 "mul_complexd"
@@ -28,7 +28,7 @@ end
 module Stubs_only(F : Cstubs.FOREIGN) =
 struct
   let bind typ name =
-    F.foreign name (typ @-> typ @-> returning typ)
+    F.(foreign name (typ @-> typ @-> returning typ))
 
   let add_complexd_val = bind complex64 "add_complexd_val"
   let mul_complexd_val = bind complex64 "mul_complexd_val"

--- a/tests/test-complex/test_complex.ml
+++ b/tests/test-complex/test_complex.ml
@@ -12,7 +12,8 @@ open Ctypes
 let testlib = Dl.(dlopen ~filename:"clib/libtest_functions.so" ~flags:[RTLD_NOW])
 
 
-module Common_tests(S : Cstubs.FOREIGN with type 'a fn = 'a) =
+module Common_tests(S : Cstubs.FOREIGN with type 'a result = 'a
+                                        and type 'a return = 'a) =
 struct
   module M = Functions.Common(S)
   open M
@@ -58,7 +59,8 @@ struct
 end
 
 
-module Build_stub_tests(S : Cstubs.FOREIGN with type 'a fn = 'a) =
+module Build_stub_tests(S : Cstubs.FOREIGN with type 'a result = 'a
+                                            and type 'a return = 'a) =
 struct
   module N = Functions.Stubs(S)
   open N

--- a/tests/test-cstdlib/stubs/functions.ml
+++ b/tests/test-cstdlib/stubs/functions.ml
@@ -49,12 +49,12 @@ struct
 
   let qsort = foreign "qsort"
     (ptr void @-> size_t @-> size_t @->
-     funptr (ptr void @-> ptr void @-> returning int) @->
+     funptr Ctypes.(ptr void @-> ptr void @-> returning int) @->
      returning void)
 
   let bsearch = foreign "bsearch"
     (ptr void @-> ptr void @-> size_t @-> size_t @->
-     funptr (ptr void @-> ptr void @-> returning int) @->
+     funptr Ctypes.(ptr void @-> ptr void @-> returning int) @->
      returning (ptr void))
 
   let strlen = foreign "strlen" (ptr char @-> returning size_t)

--- a/tests/test-cstdlib/test_cstdlib.ml
+++ b/tests/test-cstdlib/test_cstdlib.ml
@@ -11,7 +11,8 @@ open Unsigned
 open Foreign
 
 
-module Common_tests(S : Cstubs.FOREIGN with type 'a fn = 'a) =
+module Common_tests(S : Cstubs.FOREIGN with type 'a result = 'a
+                                        and type 'a return = 'a) =
 struct
   module M = Functions.Stubs(S)
   open M

--- a/tests/test-enums/stubs/functions.ml
+++ b/tests/test-enums/stubs/functions.ml
@@ -13,15 +13,16 @@ open Ctypes
    doesn't support passing enums. *)
 module Stubs(F : Cstubs.FOREIGN) =
 struct
+  open F
 
   module T = Types.Struct_stubs(Generated_struct_bindings)
 
-  let classify_integer = F.foreign "classify_integer"
+  let classify_integer = foreign "classify_integer"
       (int @-> returning T.signed)
 
-  let out_of_range = F.foreign "out_of_range"
+  let out_of_range = foreign "out_of_range"
       (void @-> returning T.signed)
 
-  let next_fruit = F.foreign "next_fruit"
+  let next_fruit = foreign "next_fruit"
       (T.fruit @-> returning T.fruit)
 end

--- a/tests/test-enums/test_enums.ml
+++ b/tests/test-enums/test_enums.ml
@@ -66,7 +66,8 @@ struct
     end
 
   module Build_call_tests
-      (F : Cstubs.FOREIGN with type 'a fn = 'a) =
+      (F : Cstubs.FOREIGN with type 'a result = 'a
+                           and type 'a return = 'a) =
   struct
     module F = Functions.Stubs(F)
     open F

--- a/tests/test-foreign_values/stubs/functions.ml
+++ b/tests/test-foreign_values/stubs/functions.ml
@@ -20,16 +20,16 @@ struct
   let global_struct = F.foreign_value "global_struct" s
 
   let plus =
-    F.foreign_value "plus_callback"
-      (Foreign.funptr_opt (int @-> int @-> returning int))
+    F.(foreign_value "plus_callback"
+         (Foreign.funptr_opt Ctypes.(int @-> int @-> returning int)))
 
-  let sum = F.foreign "sum_range_with_plus_callback"
-      (int @-> int @-> returning int)
+  let sum = F.(foreign "sum_range_with_plus_callback"
+                 (int @-> int @-> returning int))
 end
 
 
 module Stubs (F: Cstubs.FOREIGN) =
 struct
   include Common(F)
-  let environ = F.foreign_value "environ" (ptr string_opt)
+  let environ = F.(foreign_value "environ" (ptr string_opt))
 end

--- a/tests/test-foreign_values/test_foreign_values.ml
+++ b/tests/test-foreign_values/test_foreign_values.ml
@@ -9,7 +9,8 @@ open OUnit2
 open Ctypes
 
 
-module Common_tests(S : Cstubs.FOREIGN with type 'a fn = 'a) =
+module Common_tests(S : Cstubs.FOREIGN with type 'a result = 'a
+                                        and type 'a return = 'a) =
 struct
   module M = Functions.Common(S)
   open M
@@ -45,7 +46,8 @@ struct
 end
 
 
-module Make_stub_tests(S : Cstubs.FOREIGN with type 'a fn = 'a) =
+module Make_stub_tests(S : Cstubs.FOREIGN with type 'a result = 'a
+                                           and type 'a return = 'a) =
 struct
   module N = Functions.Stubs(S)
   open N

--- a/tests/test-higher_order/stubs/functions.ml
+++ b/tests/test-higher_order/stubs/functions.ml
@@ -14,29 +14,31 @@ module Stubs (F: Cstubs.FOREIGN) =
 struct
   open F
   let higher_order_1 = foreign "higher_order_1"
-    (funptr (int @-> int @-> returning int) @-> int @-> int @-> returning int)
+    (funptr Ctypes.(int @-> int @-> returning int) @-> int @-> int @->
+     returning int)
 
   let higher_order_1_static = foreign "higher_order_1"
-    (static_funptr (int @-> int @-> returning int) @-> int @-> int @-> returning int)
+    (static_funptr Ctypes.(int @-> int @-> returning int) @-> int @-> int @->
+     returning int)
 
   let higher_order_3 = foreign "higher_order_3"
-    (funptr (funptr (int @-> int @-> returning int) @->
+    (funptr Ctypes.(funptr (int @-> int @-> returning int) @->
              int @-> int @-> returning int) @->
-     funptr (int @-> int @-> returning int) @->
+     funptr Ctypes.(int @-> int @-> returning int) @->
      int @-> int @-> returning int)
 
   let returning_funptr = foreign "returning_funptr"
-    (int @-> returning (funptr (int @-> int @-> returning int)))
+    (int @-> returning (funptr Ctypes.(int @-> int @-> returning int)))
 
   let returning_funptr_static = foreign "returning_funptr"
-    (int @-> returning (static_funptr (int @-> int @-> returning int)))
+    (int @-> returning (static_funptr Ctypes.(int @-> int @-> returning int)))
 
   let callback_returns_funptr = foreign "callback_returns_funptr"
-    (funptr (int @-> returning (funptr (int @-> returning int))) @->
+    (funptr Ctypes.(int @-> returning (funptr (int @-> returning int))) @->
      int @-> returning int)
 
   let register_callback = foreign "register_callback"
-      (funptr (void @-> returning int) @-> returning void)
+      (funptr Ctypes.(void @-> returning int) @-> returning void)
 
   let call_registered_callback = foreign "call_registered_callback"
       (int @-> int @-> returning void)

--- a/tests/test-higher_order/test_higher_order.ml
+++ b/tests/test-higher_order/test_higher_order.ml
@@ -10,7 +10,8 @@ open OUnit2
 open Foreign
 
 
-module Common_tests(S : Cstubs.FOREIGN with type 'a fn = 'a) =
+module Common_tests(S : Cstubs.FOREIGN with type 'a result = 'a
+                                        and type 'a return = 'a) =
 struct
   module M = Functions.Stubs(S)
   open M

--- a/tests/test-oo_style/stubs/functions.ml
+++ b/tests/test-oo_style/stubs/functions.ml
@@ -36,8 +36,8 @@ struct
 
   (* method table layout (two virtual methods) *)
   let (-:) ty label = field animal_methods label ty
-  let say = Foreign.funptr (ptr animal @-> returning string)      -: "say"
-  let identify = Foreign.funptr (ptr animal @-> returning string) -: "identify"
+  let say = Foreign.funptr Ctypes.(ptr animal @-> returning string)      -: "say"
+  let identify = Foreign.funptr Ctypes.(ptr animal @-> returning string) -: "identify"
   let () = seal animal_methods
 
   let call_say cinstance =
@@ -67,7 +67,7 @@ struct
   (* method table layout (one additional virtual method) *)
   let (-:) ty label = field camel_methods label ty
   let _     = animal_methods                       -: "_"
-  let humps = Foreign.funptr (ptr camel @-> returning int) -: "humps"
+  let humps = Foreign.funptr Ctypes.(ptr camel @-> returning int) -: "humps"
   let () = seal camel_methods
 
   let call_humps cinstance =

--- a/tests/test-oo_style/test_oo_style.ml
+++ b/tests/test-oo_style/test_oo_style.ml
@@ -9,7 +9,8 @@ open OUnit2
 open Ctypes
 
 
-module Common_tests(S : Cstubs.FOREIGN with type 'a fn = 'a) =
+module Common_tests(S : Cstubs.FOREIGN with type 'a result = 'a
+                                        and type 'a return = 'a) =
 struct
   module M = Functions.Stubs(S)
   open M

--- a/tests/test-passing-ocaml-values/test_passing_ocaml_values.ml
+++ b/tests/test-passing-ocaml-values/test_passing_ocaml_values.ml
@@ -12,7 +12,8 @@ open Foreign
 
 let testlib = Dl.(dlopen ~filename:"clib/libtest_functions.so" ~flags:[RTLD_NOW])
 
-module Common_tests(S : Cstubs.FOREIGN with type 'a fn = 'a) =
+module Common_tests(S : Cstubs.FOREIGN with type 'a result = 'a
+                                        and type 'a return = 'a) =
 struct
   module M = Functions.Stubs(S)
   open M

--- a/tests/test-pointers/stubs/functions.ml
+++ b/tests/test-pointers/stubs/functions.ml
@@ -59,17 +59,21 @@ struct
     (ptr int @-> ptr int @-> int @-> returning (ptr int))
 
   let passing_pointers_to_callback = foreign "passing_pointers_to_callback"
-      (Foreign.funptr (ptr int @-> ptr int @-> returning int) @-> returning int)
+      (Foreign.funptr Ctypes.(ptr int @-> ptr int @-> returning int) @->
+       returning int)
 
   let accepting_pointer_from_callback =
     foreign "accepting_pointer_from_callback"
-      (Foreign.funptr (int @-> int @-> returning (ptr int)) @-> returning int)
+      (Foreign.funptr Ctypes.(int @-> int @-> returning (ptr int)) @->
+       returning int)
 
   let accepting_pointer_to_function_pointer =
     foreign "accepting_pointer_to_function_pointer"
-      (ptr (Foreign.funptr (int @-> int @-> returning int)) @-> returning int)
+      (ptr (Foreign.funptr Ctypes.(int @-> int @-> returning int)) @->
+       returning int)
 
   let returning_pointer_to_function_pointer =
     foreign "returning_pointer_to_function_pointer"
-      (void @-> returning (ptr (Foreign.funptr (int @-> int @-> returning int))))
+      (void @->
+       returning (ptr (Foreign.funptr Ctypes.(int @-> int @-> returning int))))
 end

--- a/tests/test-pointers/test_pointers.ml
+++ b/tests/test-pointers/test_pointers.ml
@@ -12,7 +12,8 @@ open Foreign
 
 let testlib = Dl.(dlopen ~filename:"clib/libtest_functions.so" ~flags:[RTLD_NOW])
 
-module Common_tests(S : Cstubs.FOREIGN with type 'a fn = 'a) =
+module Common_tests(S : Cstubs.FOREIGN with type 'a result = 'a
+                                        and type 'a return = 'a) =
 struct
   module M = Functions.Stubs(S)
   open M

--- a/tests/test-structs/stubs/functions.ml
+++ b/tests/test-structs/stubs/functions.ml
@@ -41,6 +41,8 @@ end
    doesn't support passing structs with union or array members. *)
 module Stubs_only(F : Cstubs.FOREIGN) =
 struct
+  open F
+
   type number
   let number : number union typ = union "number"
   let i = field number "i" int
@@ -58,10 +60,10 @@ struct
   let elements = field triple "elements" (array 3 double)
   let () = seal triple
 
-  let add_tagged_numbers = F.foreign "add_tagged_numbers"
+  let add_tagged_numbers = foreign "add_tagged_numbers"
     (tagged @-> tagged @-> returning tagged)
 
-  let add_triples = F.foreign "add_triples"
+  let add_triples = foreign "add_triples"
     (triple @-> triple @-> returning triple)
 end
 

--- a/tests/test-structs/test_structs.ml
+++ b/tests/test-structs/test_structs.ml
@@ -12,7 +12,8 @@ open Ctypes
 let testlib = Dl.(dlopen ~filename:"clib/libtest_functions.so" ~flags:[RTLD_NOW])
 
 
-module Build_foreign_tests(S : Cstubs.FOREIGN with type 'a fn = 'a) =
+module Build_foreign_tests(S : Cstubs.FOREIGN with type 'a result = 'a
+                                               and type 'a return = 'a) =
 struct
   module M = Functions.Common(S)
   open M
@@ -373,7 +374,8 @@ let test_struct_ffi_type_lifetime _ =
   end in ()
 
 
-module Build_stub_tests(S : Cstubs.FOREIGN with type 'a fn = 'a) =
+module Build_stub_tests(S : Cstubs.FOREIGN with type 'a result = 'a
+                                            and type 'a return = 'a) =
 struct
   open Functions
   include Build_foreign_tests(S)
@@ -557,7 +559,8 @@ struct
 
 
   module Build_call_tests
-      (F : Cstubs.FOREIGN with type 'a fn = 'a) =
+      (F : Cstubs.FOREIGN with type 'a result = 'a
+                           and type 'a return = 'a) =
   struct
     module F = Functions.Common(F)
     open F

--- a/tests/test-unions/stubs/functions.ml
+++ b/tests/test-unions/stubs/functions.ml
@@ -20,16 +20,18 @@ let () = seal padded
    using stub generation. *)
 module Common (F: Cstubs.FOREIGN) =
 struct
-  let sum_union_components = F.foreign "sum_union_components"
-    (ptr padded @-> size_t @-> returning int64_t)
+  let sum_union_components =
+    F.(foreign "sum_union_components"
+         (ptr padded @-> size_t @-> returning int64_t))
 end
 
 (* These functions can only be bound using stub generation, since Foreign
    doesn't support passing unions by value. *)
 module Stubs_only(F : Cstubs.FOREIGN) =
 struct
-  let add_unions = F.foreign "add_unions"
-    (padded @-> padded @-> returning padded)
+  let add_unions =
+    F.(foreign "add_unions"
+         (padded @-> padded @-> returning padded))
 end
 
 module Stubs (F: Cstubs.FOREIGN) =

--- a/tests/test-unions/test_unions.ml
+++ b/tests/test-unions/test_unions.ml
@@ -87,7 +87,8 @@ let test_endian_detection _ =
   end in ()
 
 
-module Build_foreign_tests(S : Cstubs.FOREIGN with type 'a fn = 'a) =
+module Build_foreign_tests(S : Cstubs.FOREIGN with type 'a result = 'a
+                                               and type 'a return = 'a) =
 struct
   open Functions
   module M = Common(S)
@@ -122,7 +123,8 @@ struct
     end in ()
 end
 
-module Build_stub_tests(S : Cstubs.FOREIGN with type 'a fn = 'a) =
+module Build_stub_tests(S : Cstubs.FOREIGN with type 'a result = 'a
+                                            and type 'a return = 'a) =
 struct
   open Functions
   include Build_foreign_tests(S)

--- a/tests/test-value_printing/test_value_printing.ml
+++ b/tests/test-value_printing/test_value_printing.ml
@@ -15,7 +15,8 @@ let equal_ignoring_whitespace l r =
   strip_whitespace l = strip_whitespace r
 
 
-module Common_tests(S : Cstubs.FOREIGN with type 'a fn = 'a) =
+module Common_tests(S : Cstubs.FOREIGN with type 'a result = 'a
+                                        and type 'a return = 'a) =
 struct
   module M = Functions.Stubs(S)
   open M

--- a/tests/test-variadic/test_variadic.ml
+++ b/tests/test-variadic/test_variadic.ml
@@ -11,7 +11,8 @@ open OUnit2
 open Ctypes
 
 
-module Common_tests(S : Cstubs.FOREIGN with type 'a fn = 'a) =
+module Common_tests(S : Cstubs.FOREIGN with type 'a result = 'a
+                                        and type 'a return = 'a) =
 struct
   module M = Functions.Stubs(S)
   open Signed

--- a/tests/test-views/stubs/functions.ml
+++ b/tests/test-views/stubs/functions.ml
@@ -15,7 +15,8 @@ struct
 
   let charish = view ~read:Char.chr ~write:Char.code int
 
-  let nullable_intptr = Foreign.funptr_opt (int @-> int @-> returning int)
+  let nullable_intptr = Foreign.funptr_opt Ctypes.(int @-> int @->
+                                                   returning int)
 
   let concat_strings = foreign "concat_strings"
     (ptr string @-> int @-> ptr char @-> returning void)

--- a/tests/test-views/test_views.ml
+++ b/tests/test-views/test_views.ml
@@ -9,7 +9,8 @@ open OUnit2
 open Ctypes
 
 
-module Common_tests(S : Cstubs.FOREIGN with type 'a fn = 'a) =
+module Common_tests(S : Cstubs.FOREIGN with type 'a result = 'a
+                                        and type 'a return = 'a) =
 struct
   module M = Functions.Stubs(S)
   open M

--- a/tests/tests-common/tests_common.ml
+++ b/tests/tests-common/tests_common.ml
@@ -27,9 +27,16 @@ let filenames argv =
     (!ml_filename, !c_filename, !c_struct_filename)
   end
 
-module Foreign_binder : Cstubs.FOREIGN with type 'a fn = 'a =
+module Foreign_binder : Cstubs.FOREIGN
+  with type 'a result = 'a
+   and type 'a return = 'a =
 struct
-  type 'a fn = 'a
+  type 'a fn = 'a Ctypes.fn
+  type 'a return = 'a
+  let (@->) = Ctypes.(@->)
+  let returning = Ctypes.returning
+
+  type 'a result = 'a
   let foreign name fn = Foreign.foreign name fn
   let foreign_value name fn = Foreign.foreign_value name fn
 end


### PR DESCRIPTION
This pull request changes the interface `Cstubs.FOREIGN` which is used when writing bindings for stub generation.  The changes form a basis for generating different types of bindings in a way that maintains type safety.

The [current interface][current-foreign-interface] exposes two functions, `foreign` and `foreign_value` which act as "destructors" for (i.e. consumers of) Ctypes function type descriptions:

```ocaml
module type FOREIGN =
sig
  type 'a fn
  val foreign : string -> ('a -> 'b) Ctypes.fn -> ('a -> 'b) fn
  val foreign_value : string -> 'a Ctypes.typ -> 'a Ctypes.ptr fn
end
```

Here is a bindings description that uses `foreign` to bind the function `puts` from the C standard library:


```ocaml
module Bindings(F: FOREIGN) =
struct
  open F
  let puts = foreign "puts"
     (string @-> returning int)
end
```

Code generation involves instantiating the `Bindings` functor multiple times with different implementations of `FOREIGN`.

The abstract type `fn` provides some type safety, and distinguishes the stages of code generation.  In the body of the functor, `puts` has the type `(string -> int) fn`.  The code generation process produces a new implementation of `FOREIGN` in which `type 'a fn = 'a`.  Applying the `Bindings` functor to this generated module results in a `puts` function with the type `string -> int`.

Here is the new `FOREIGN` interface introduced by this pull request:

```ocaml
module type FOREIGN =
sig
  type 'a fn
  type 'a return
  val (@->) : 'a Ctypes.typ -> 'b fn -> ('a -> 'b) fn
  val returning : 'a Ctypes.typ -> 'a return fn

  type 'a result
  val foreign : string -> ('a -> 'b) fn -> ('a -> 'b) result
  val foreign_value : string -> 'a Ctypes.typ -> 'a Ctypes.ptr result
end
```

The existing interface abstracted the destructors (`foreign`, `foreign_value`) of `Ctypes.fn`.  The new interface also abstracts the constructors (`@->`, `returning`).

Besides the new values in the interface, there are two new abstract types.  The first, `fn` replaces the concrete type `Ctypes.fn` in the existing interface.  The second, `return`, which allows the return type of `returning` to vary.

These additional types allow the type of generated code to vary in ways that support new binding strategies.  For example, we might generate an implementation of `FOREIGN` in which `'a fn` is instantiated to `'a` and `'a return` as `'a Lwt.t`, to support binding functions using the [Lwt jobs][lwt-jobs] framework.

### Backwards compatibility.

A change to `FOREIGN` is necessarily backwards-incompatible.  However, many existing bindings will continue to work without change, and where modifications are needed they will typically be small and straightforward.

Where bindings previously used `Ctypes.(@->)` and `Ctypes.returning` to build function type descriptions such as `string @-> returning int` they must now instead use `F.(@->)` and `F.returning`.

Bindings written in the style of `puts` above, where `F` is opened at the beginning of the module will usually work without modification, since they will automatically pick up the appropriate instances of `@->` and `returning`.


[current-foreign-interface]: https://github.com/ocamllabs/ocaml-ctypes/blob/61a2eb04/src/cstubs/cstubs.mli#L72-L77
[lwt-jobs]: http://ocsigen.org/lwt/2.5.1/api/Lwt_unix#TYPEjob
