### PR TITLE
Support for returning errno from generated stubs

### DIFF
--- a/Makefile.tests
+++ b/Makefile.tests
@@ -494,12 +494,12 @@ tests/test-arrays/generated_stubs.c: $(BUILDDIR)/test-arrays-stub-generator.nati
 tests/test-arrays/generated_bindings.ml: $(BUILDDIR)/test-arrays-stub-generator.native
 	$< --ml-file $@
 
-test-errno.dir = tests/test-errno
-test-errno.threads = yes
-test-errno.deps = str bigarray oUnit bytes
-test-errno.subproject_deps = ctypes ctypes-foreign-base ctypes-foreign-threaded
-test-errno: PROJECT=test-errno
-test-errno: $$(NATIVE_TARGET)
+test-foreign-errno.dir = tests/test-foreign-errno
+test-foreign-errno.threads = yes
+test-foreign-errno.deps = str bigarray oUnit bytes
+test-foreign-errno.subproject_deps = ctypes ctypes-foreign-base ctypes-foreign-threaded
+test-foreign-errno: PROJECT=test-foreign-errno
+test-foreign-errno: $$(NATIVE_TARGET)
 
 test-passable.dir = tests/test-passable
 test-passable.threads = yes
@@ -908,7 +908,7 @@ TESTS += test-foreign_values-stubs test-foreign_values-stub-generator test-forei
 TESTS += test-unions-stubs test-unions-stub-generator test-unions-generated test-unions
 TESTS += test-custom_ops
 TESTS += test-arrays-stubs test-arrays-stub-generator test-arrays-generated test-arrays
-TESTS += test-errno
+TESTS += test-foreign-errno
 TESTS += test-passable
 TESTS += test-alignment
 TESTS += test-views-stubs test-views-stub-generator test-views-generated test-views

--- a/Makefile.tests
+++ b/Makefile.tests
@@ -915,6 +915,46 @@ $(BUILDDIR)/test-returning-errno-lwt-ml-stub-generator.native: $(BUILDDIR)/tests
 $(BUILDDIR)/tests/test-returning-errno-lwt/generated_struct_stubs.c: $(BUILDDIR)/test-returning-errno-lwt-stub-generator.native
 	$< --c-struct-file $@
 
+test-returning-errno-stubs.dir  = tests/test-returning-errno/stubs
+test-returning-errno-stubs.threads = yes
+test-returning-errno-stubs.subproject_deps = ctypes cstubs \
+   ctypes-foreign-base ctypes-foreign-threaded tests-common
+test-returning-errno-stubs: PROJECT=test-returning-errno-stubs
+test-returning-errno-stubs: $$(LIB_TARGETS)
+
+test-returning-errno-stub-generator.dir = tests/test-returning-errno/stub-generator
+test-returning-errno-stub-generator.threads = yes
+test-returning-errno-stub-generator.subproject_deps = ctypes cstubs \
+     ctypes-foreign-base ctypes-foreign-threaded test-returning-errno-stubs tests-common
+test-returning-errno-stub-generator.deps = str bigarray bytes
+test-returning-errno-stub-generator: PROJECT=test-returning-errno-stub-generator
+test-returning-errno-stub-generator: $$(NATIVE_TARGET)
+
+test-returning-errno.dir = tests/test-returning-errno
+test-returning-errno.threads = yes
+test-returning-errno.deps = str bigarray oUnit bytes lwt.unix
+test-returning-errno.subproject_deps = ctypes ctypes-foreign-base \
+   ctypes-foreign-threaded cstubs tests-common test-returning-errno-stubs
+test-returning-errno.link_flags = -L$(BUILDDIR)/clib -ltest_functions
+test-returning-errno: PROJECT=test-returning-errno
+test-returning-errno: $$(NATIVE_TARGET)
+
+test-returning-errno-generated: \
+  tests/test-returning-errno/generated_bindings.ml \
+  tests/test-returning-errno/generated_struct_bindings.ml \
+  tests/test-returning-errno/generated_stubs.c
+
+tests/test-returning-errno/generated_stubs.c: $(BUILDDIR)/test-returning-errno-stub-generator.native
+	$< --c-file $@
+tests/test-returning-errno/generated_bindings.ml: $(BUILDDIR)/test-returning-errno-stub-generator.native
+	$< --ml-file $@
+tests/test-returning-errno/generated_struct_bindings.ml: $(BUILDDIR)/test-returning-errno-ml-stub-generator.native
+	$< > $@
+$(BUILDDIR)/test-returning-errno-ml-stub-generator.native: $(BUILDDIR)/tests/test-returning-errno/generated_struct_stubs.c
+	$(CC) -I `$(OCAMLFIND) ocamlc -where | sed 's|\r$$||'` $(CFLAGS) $(LDFLAGS) $(WINLDFLAGS) -o $@ $^
+$(BUILDDIR)/tests/test-returning-errno/generated_struct_stubs.c: $(BUILDDIR)/test-returning-errno-stub-generator.native
+	$< --c-struct-file $@
+
 
 test-threads-stubs.dir  = tests/test-threads/stubs
 test-threads-stubs.threads = yes
@@ -966,6 +1006,7 @@ TESTS += test-roots
 TESTS += test-passing-ocaml-values-stubs test-passing-ocaml-values-stub-generator test-passing-ocaml-values-generated test-passing-ocaml-values
 TESTS += test-lwt-jobs-stubs test-lwt-jobs-stub-generator test-lwt-jobs-generated test-lwt-jobs
 TESTS += test-returning-errno-lwt-stubs test-returning-errno-lwt-stub-generator test-returning-errno-lwt-generated test-returning-errno-lwt
+TESTS += test-returning-errno-stubs test-returning-errno-stub-generator test-returning-errno-generated test-returning-errno
 TESTS += test-threads-stubs test-threads
 
 

--- a/Makefile.tests
+++ b/Makefile.tests
@@ -875,6 +875,47 @@ $(BUILDDIR)/test-lwt-jobs-ml-stub-generator.native: $(BUILDDIR)/tests/test-lwt-j
 $(BUILDDIR)/tests/test-lwt-jobs/generated_struct_stubs.c: $(BUILDDIR)/test-lwt-jobs-stub-generator.native
 	$< --c-struct-file $@
 
+test-returning-errno-lwt-stubs.dir  = tests/test-returning-errno-lwt/stubs
+test-returning-errno-lwt-stubs.threads = yes
+test-returning-errno-lwt-stubs.subproject_deps = ctypes cstubs \
+   ctypes-foreign-base ctypes-foreign-threaded tests-common
+test-returning-errno-lwt-stubs: PROJECT=test-returning-errno-lwt-stubs
+test-returning-errno-lwt-stubs: $$(LIB_TARGETS)
+
+test-returning-errno-lwt-stub-generator.dir = tests/test-returning-errno-lwt/stub-generator
+test-returning-errno-lwt-stub-generator.threads = yes
+test-returning-errno-lwt-stub-generator.subproject_deps = ctypes cstubs \
+     ctypes-foreign-base ctypes-foreign-threaded test-returning-errno-lwt-stubs tests-common
+test-returning-errno-lwt-stub-generator.deps = str bigarray bytes
+test-returning-errno-lwt-stub-generator: PROJECT=test-returning-errno-lwt-stub-generator
+test-returning-errno-lwt-stub-generator: $$(NATIVE_TARGET)
+
+test-returning-errno-lwt.dir = tests/test-returning-errno-lwt
+test-returning-errno-lwt.threads = yes
+test-returning-errno-lwt.deps = str bigarray oUnit bytes lwt.unix
+test-returning-errno-lwt.subproject_deps = ctypes ctypes-foreign-base \
+   ctypes-foreign-threaded cstubs tests-common test-returning-errno-lwt-stubs
+test-returning-errno-lwt.link_flags = -L$(BUILDDIR)/clib -ltest_functions
+test-returning-errno-lwt: PROJECT=test-returning-errno-lwt
+test-returning-errno-lwt: $$(NATIVE_TARGET)
+
+test-returning-errno-lwt-generated: \
+  tests/test-returning-errno-lwt/generated_bindings.ml \
+  tests/test-returning-errno-lwt/generated_struct_bindings.ml \
+  tests/test-returning-errno-lwt/generated_stubs.c
+
+tests/test-returning-errno-lwt/generated_stubs.c: $(BUILDDIR)/test-returning-errno-lwt-stub-generator.native
+	$< --c-file $@
+tests/test-returning-errno-lwt/generated_bindings.ml: $(BUILDDIR)/test-returning-errno-lwt-stub-generator.native
+	$< --ml-file $@
+tests/test-returning-errno-lwt/generated_struct_bindings.ml: $(BUILDDIR)/test-returning-errno-lwt-ml-stub-generator.native
+	$< > $@
+$(BUILDDIR)/test-returning-errno-lwt-ml-stub-generator.native: $(BUILDDIR)/tests/test-returning-errno-lwt/generated_struct_stubs.c
+	$(CC) -I `$(OCAMLFIND) ocamlc -where | sed 's|\r$$||'` $(CFLAGS) $(LDFLAGS) $(WINLDFLAGS) -o $@ $^
+$(BUILDDIR)/tests/test-returning-errno-lwt/generated_struct_stubs.c: $(BUILDDIR)/test-returning-errno-lwt-stub-generator.native
+	$< --c-struct-file $@
+
+
 test-threads-stubs.dir  = tests/test-threads/stubs
 test-threads-stubs.threads = yes
 test-threads-stubs.subproject_deps = ctypes cstubs \
@@ -924,6 +965,7 @@ TESTS += test-coercions-stubs test-coercions-stub-generator test-coercions-gener
 TESTS += test-roots
 TESTS += test-passing-ocaml-values-stubs test-passing-ocaml-values-stub-generator test-passing-ocaml-values-generated test-passing-ocaml-values
 TESTS += test-lwt-jobs-stubs test-lwt-jobs-stub-generator test-lwt-jobs-generated test-lwt-jobs
+TESTS += test-returning-errno-lwt-stubs test-returning-errno-lwt-stub-generator test-returning-errno-lwt-generated test-returning-errno-lwt
 TESTS += test-threads-stubs test-threads
 
 

--- a/src/cstubs/cstubs.ml
+++ b/src/cstubs/cstubs.ml
@@ -25,7 +25,7 @@ module type BINDINGS = functor (F : FOREIGN') -> sig end
 
 type concurrency_policy = [ `Sequential | `Lwt_jobs ]
 
-type errno_policy = [`Ignore_errno ]
+type errno_policy = [ `Ignore_errno | `Return_errno ]
 
 let gen_c ~concurrency prefix fmt : (module FOREIGN') =
   (module
@@ -148,13 +148,15 @@ let gen_ml ~concurrency prefix fmt : (module FOREIGN') * (unit -> unit) =
 let sequential = `Sequential
 let lwt_jobs = `Lwt_jobs
 let ignore_errno = `Ignore_errno
+let return_errno = `Return_errno
 
 let concurrency_headers = function
     `Sequential -> []
   | `Lwt_jobs ->   ["\"lwt_unix.h\"";  "<caml/memory.h>"]
 
 let errno_headers = function
-  `Ignore_errno -> []
+    `Ignore_errno -> []
+  | `Return_errno -> ["<errno.h>"]
 
 let headers : concurrency_policy -> errno_policy -> string list =
   fun concurrency errno ->

--- a/src/cstubs/cstubs.ml
+++ b/src/cstubs/cstubs.ml
@@ -27,7 +27,7 @@ type concurrency_policy = [ `Sequential | `Lwt_jobs ]
 
 type errno_policy = [ `Ignore_errno | `Return_errno ]
 
-let gen_c ~concurrency prefix fmt : (module FOREIGN') =
+let gen_c ~concurrency ~errno prefix fmt : (module FOREIGN') =
   (module
    struct
      let counter = ref 0
@@ -37,7 +37,7 @@ let gen_c ~concurrency prefix fmt : (module FOREIGN') =
      type 'a return = 'a
      type 'a result = unit
      let foreign cname fn =
-       Cstubs_generate_c.fn ~concurrency
+       Cstubs_generate_c.fn ~concurrency ~errno
          ~cname ~stub_name:(var prefix cname) fmt fn
      let foreign_value cname typ =
        Cstubs_generate_c.value ~cname ~stub_name:(var prefix cname) fmt typ
@@ -167,7 +167,7 @@ let headers : concurrency_policy -> errno_policy -> string list =
 let write_c ?(concurrency=`Sequential) ?(errno=`Ignore_errno)
     fmt ~prefix (module B : BINDINGS) =
   List.iter (Format.fprintf fmt "#include %s@\n") (headers concurrency errno);
-  let module M = B((val gen_c ~concurrency prefix fmt)) in ()
+  let module M = B((val gen_c ~concurrency ~errno prefix fmt)) in ()
 
 let write_ml ?(concurrency=`Sequential) ?(errno=`Ignore_errno)
     fmt ~prefix (module B : BINDINGS) =

--- a/src/cstubs/cstubs.mli
+++ b/src/cstubs/cstubs.mli
@@ -91,6 +91,30 @@ type errno_policy
 val ignore_errno : errno_policy
 (** Generate code with no special support for errno.  This is the default. *)
 
+val return_errno : errno_policy
+(** Generate code that returns errno in addition to the return value of each function.
+
+    Passing [return_errno] as the [errno] argument to {!Cstubs.write_c} and
+    {!Cstubs.write_ml} changes the return type of bound functions from a
+    single value to a pair of values.  For example, the binding
+    specification 
+
+       [let realpath = foreign "reaplath" (string @-> string @-> returning string)]
+
+    generates a value of the following type by default:
+
+       [val realpath : string -> string -> stirng]
+
+    but when using [return_errno] the generated type is as follows:
+
+       [val realpath : string -> string -> stirng * int]
+
+    and when using both [return_errno] and [lwt_jobs] the generated type is as
+    follows:
+
+       [val realpath : string -> string -> (stirng * int) Lwt.t]
+*)
+
 type concurrency_policy
 (** Values of the [concurrency_policy] type specify the concurrency support
     provided by the generated code.  See {!sequential} and {!lwt_jobs} for the

--- a/src/cstubs/cstubs.mli
+++ b/src/cstubs/cstubs.mli
@@ -83,6 +83,14 @@ end
 
 module type BINDINGS = functor (F : FOREIGN with type 'a result = unit) -> sig end
 
+type errno_policy
+(** Values of the [errno_policy] type specify the errno support provided by
+    the generated code.  See {!ignore_errno} for the available option.
+*)
+
+val ignore_errno : errno_policy
+(** Generate code with no special support for errno.  This is the default. *)
+
 type concurrency_policy
 (** Values of the [concurrency_policy] type specify the concurrency support
     provided by the generated code.  See {!sequential} and {!lwt_jobs} for the
@@ -114,7 +122,7 @@ val lwt_jobs : concurrency_policy
        [val unlink : string -> int Lwt.t]
 *)
 
-val write_c : ?concurrency:concurrency_policy ->
+val write_c : ?concurrency:concurrency_policy -> ?errno:errno_policy ->
   Format.formatter -> prefix:string -> (module BINDINGS) -> unit
 (** [write_c fmt ~prefix bindings] generates C stubs for the functions bound
     with [foreign] in [bindings].  The stubs are intended to be used in
@@ -127,7 +135,7 @@ val write_c : ?concurrency:concurrency_policy ->
     [ctypes_cstubs_internals.h].
 *)
 
-val write_ml : ?concurrency:concurrency_policy ->
+val write_ml : ?concurrency:concurrency_policy -> ?errno:errno_policy ->
   Format.formatter -> prefix:string -> (module BINDINGS) -> unit
 (** [write_ml fmt ~prefix bindings] generates ML bindings for the functions
     bound with [foreign] in [bindings].  The generated code conforms to the

--- a/src/cstubs/cstubs_c_language.ml
+++ b/src/cstubs/cstubs_c_language.ml
@@ -41,7 +41,7 @@ type cexp = [ cconst
             | clocal
             | `Cast of ty * cexp
             | `Addr of cvar ]
-type clvalue = [ clocal
+type clvalue = [ cvar
                | `Index of clvalue * cexp
                | `Field of clvalue * fieldname 
                | `PointerField of clvalue * fieldname ]

--- a/src/cstubs/cstubs_emit_c.ml
+++ b/src/cstubs/cstubs_emit_c.ml
@@ -48,7 +48,7 @@ let rec cexp fmt : cexp -> unit = function
   | `Addr (`Local (name, _)) -> fprintf fmt "@[&@[%s@]@]" name
 
 let rec clvalue fmt : clvalue -> unit = function
-  | `Local _ as x -> cvar fmt x
+  | #cvar as x -> cvar fmt x
   | `Index (lv, i) ->
     fprintf fmt "@[@[%a@]@[[%a]@]@]" clvalue lv cexp i
   | `Field (lv, f) ->

--- a/src/cstubs/cstubs_generate_c.mli
+++ b/src/cstubs/cstubs_generate_c.mli
@@ -8,6 +8,7 @@
 (* C stub generation *)
 
 val fn : concurrency:[ `Sequential | `Lwt_jobs ] ->
+         errno:[ `Ignore_errno | `Return_errno ] ->
          cname:string -> stub_name:string ->
          Format.formatter -> 'a Ctypes.fn -> unit
 

--- a/src/cstubs/cstubs_generate_ml.ml
+++ b/src/cstubs/cstubs_generate_ml.ml
@@ -16,6 +16,7 @@ type concurrency_policy = [ `Sequential | `Lwt_jobs ]
 type lident = string
 type ml_type = [ `Ident of path
                | `Appl of path * ml_type list
+               | `Pair of ml_type * ml_type
                | `Fn of ml_type * ml_type ]
 
 type ml_external_type = [ `Prim of ml_type list * ml_type ]
@@ -92,6 +93,8 @@ struct
       fprintf fmt "@[(%a@ ->@ %a)@]" (ml_type ArrowParens) t (ml_type NoArrowParens) t'
     | NoArrowParens, `Fn (t, t') ->
       fprintf fmt "@[%a@ ->@]@ %a" (ml_type ArrowParens) t (ml_type NoArrowParens) t'
+    | _, `Pair (t, t') ->
+      fprintf fmt "@[(%a@ *@ %a)@]" (ml_type NoArrowParens) t (ml_type NoArrowParens) t'
 
   let ml_external_type fmt (`Prim (args, ret) : ml_external_type) =
     List.iter (fprintf fmt "@[%a@ ->@]@ " (ml_type ArrowParens)) args;

--- a/src/cstubs/cstubs_generate_ml.ml
+++ b/src/cstubs/cstubs_generate_ml.ml
@@ -12,6 +12,7 @@ open Ctypes_path
 open Cstubs_errors
 
 type concurrency_policy = [ `Sequential | `Lwt_jobs ]
+type errno_policy = [ `Ignore_errno | `Return_errno ]
 
 type lident = string
 type ml_type = [ `Ident of path
@@ -282,16 +283,22 @@ let ml_typ_of_typ = function
   | Out -> ml_typ_of_return_typ
 
 let lwt_job_type = Ctypes_path.path_of_string "Lwt_unix.job"
+let int_type = `Ident (Ctypes_path.path_of_string "int")
 
 let rec ml_external_type_of_fn :
-  type a. concurrency:concurrency_policy -> a fn -> polarity -> ml_external_type =
-  fun ~concurrency fn polarity -> match fn, concurrency with
-    | Returns t, `Sequential ->
+  type a. concurrency:concurrency_policy -> errno:errno_policy ->
+  a fn -> polarity -> ml_external_type =
+  fun ~concurrency ~errno fn polarity -> match fn, concurrency, errno with
+    | Returns t, `Sequential, `Ignore_errno ->
       `Prim ([], ml_typ_of_typ polarity t)
-    | Returns t, `Lwt_jobs ->
+    | Returns t, `Sequential, `Return_errno ->
+      `Prim ([], `Pair (ml_typ_of_typ polarity t, int_type))
+    | Returns t, `Lwt_jobs, `Ignore_errno ->
       `Prim ([], `Appl (lwt_job_type, [ml_typ_of_typ polarity t]))
-    | Function (f, t), _ ->
-      let `Prim (l, t) = ml_external_type_of_fn ~concurrency t polarity in
+    | Returns t, `Lwt_jobs, `Return_errno ->
+      `Prim ([], `Appl (lwt_job_type, [`Pair (ml_typ_of_typ polarity t, int_type)]))
+    | Function (f, t), _, _ ->
+      let `Prim (l, t) = ml_external_type_of_fn ~concurrency ~errno t polarity in
       `Prim (ml_typ_of_typ (flip polarity) f :: l, t)
 
 let var_counter = ref 0
@@ -299,9 +306,9 @@ let fresh_var () =
   incr var_counter;
   Printf.sprintf "x%d" !var_counter
 
-let extern ~concurrency ~stub_name ~external_name fmt fn =
+let extern ~concurrency ~errno ~stub_name ~external_name fmt fn =
   let ext =
-    let typ = ml_external_type_of_fn ~concurrency fn Out in
+    let typ = ml_external_type_of_fn ~concurrency ~errno fn Out in
     ({ ident = external_name;
        typ = typ;
        primname = stub_name;
@@ -315,29 +322,34 @@ let static_con c args =
 let local_con c args =
   `Con (Ctypes_path.path_of_string c, args)
 
-let lwt_map_id = Ctypes_path.path_of_string "Lwt.map"
+let map_result_id = Ctypes_path.path_of_string "map_result"
 let make_ptr = Ctypes_path.path_of_string "CI.make_ptr"
 let make_fun_ptr = Ctypes_path.path_of_string "CI.make_fun_ptr"
 let make_structured = Ctypes_path.path_of_string "CI.make_structured"
 
-let map_result ~concurrency f e =
-  let lwt_map f x = `Appl (`Appl (`Ident lwt_map_id, f), x) in
-  match concurrency, f with
-    `Sequential, `MakePtr x -> `MakePtr (`Ident (path_of_string x), e)
-  | `Sequential, `MakeFunPtr x -> `MakeFunPtr (`Ident (path_of_string x), e)
-  | `Sequential, `MakeStructured x -> `MakeStructured (`Ident (path_of_string x), e)
-  | `Sequential, `Appl x -> `Appl (`Ident (path_of_string x), e)
-  | `Lwt_jobs, `MakePtr x -> lwt_map (`Appl (`Ident make_ptr,
-                                             `Ident (path_of_string x))) e
-  | `Lwt_jobs, `MakeFunPtr x -> lwt_map (`Appl (`Ident make_fun_ptr,
-                                                `Ident (path_of_string x))) e
-  | `Lwt_jobs, `MakeStructured x -> lwt_map (`Appl (`Ident make_structured,
-                                                    `Ident (path_of_string x))) e
-  | `Lwt_jobs, `Appl x -> lwt_map (`Ident (path_of_string x)) e
+let map_result ~concurrency ~errno f e =
+  let map_result f x = `Appl (`Appl (`Ident map_result_id, f), x) in
+  match concurrency, errno, f with
+    `Sequential, `Ignore_errno, `MakePtr x ->
+    `MakePtr (`Ident (path_of_string x), e)
+  | `Sequential, `Ignore_errno, `MakeFunPtr x ->
+    `MakeFunPtr (`Ident (path_of_string x), e)
+  | `Sequential, `Ignore_errno, `MakeStructured x ->
+    `MakeStructured (`Ident (path_of_string x), e)
+  | `Sequential, `Ignore_errno, `Appl x ->
+    `Appl (`Ident (path_of_string x), e)
+  | _, _, `MakePtr x ->
+    map_result (`Appl (`Ident make_ptr, `Ident (path_of_string x))) e
+  | _, _, `MakeFunPtr x ->
+    map_result (`Appl (`Ident make_fun_ptr, `Ident (path_of_string x))) e
+  | _, _, `MakeStructured x ->
+    map_result (`Appl (`Ident make_structured, `Ident (path_of_string x))) e
+  | _, _, `Appl x ->
+    map_result (`Ident (path_of_string x)) e 
 
-let rec pattern_and_exp_of_typ : type a. concurrency:concurrency_policy ->
+let rec pattern_and_exp_of_typ : type a. concurrency:concurrency_policy -> errno:errno_policy ->
   a typ -> ml_exp -> polarity -> (lident * ml_exp) list -> ml_pat * ml_exp option * (lident * ml_exp) list =
-  fun ~concurrency typ e pol binds -> match typ with
+  fun ~concurrency ~errno typ e pol binds -> match typ with
   | Void ->
     (static_con "Void" [], None, binds)
   | Primitive p ->
@@ -348,14 +360,14 @@ let rec pattern_and_exp_of_typ : type a. concurrency:concurrency_policy ->
     let pat = static_con "Pointer" [`Var x] in
     begin match pol with
     | In -> (pat, Some (`Appl (`Ident (path_of_string "CI.cptr"), e)), binds)
-    | Out -> (pat, Some (map_result ~concurrency (`MakePtr x) e), binds)
+    | Out -> (pat, Some (map_result ~concurrency ~errno (`MakePtr x) e), binds)
     end
   | Funptr _ ->
     let x = fresh_var () in
     let pat = static_con "Funptr" [`Var x] in
     begin match pol with
     | In -> (pat, Some (`Appl (`Ident (path_of_string "CI.fptr"), e)), binds)
-    | Out -> (pat, Some (map_result ~concurrency (`MakeFunPtr x) e), binds)
+    | Out -> (pat, Some (map_result ~concurrency ~errno (`MakeFunPtr x) e), binds)
     end
   | Struct _ ->
     begin match pol with
@@ -366,7 +378,7 @@ let rec pattern_and_exp_of_typ : type a. concurrency:concurrency_policy ->
     | Out ->
       let x = fresh_var () in
       let pat = `As (static_con "Struct" [`Underscore], x) in
-      (pat, Some (map_result ~concurrency (`MakeStructured x) e), binds)
+      (pat, Some (map_result ~concurrency ~errno (`MakeStructured x) e), binds)
     end
   | Union _ ->
     begin match pol with
@@ -377,7 +389,7 @@ let rec pattern_and_exp_of_typ : type a. concurrency:concurrency_policy ->
     | Out ->
       let x = fresh_var () in
       let pat = `As (static_con "Union" [`Underscore], x) in
-      (pat, Some (map_result ~concurrency (`MakeStructured x) e), binds)
+      (pat, Some (map_result ~concurrency ~errno (`MakeStructured x) e), binds)
     end
   | View { ty } ->
     begin match pol  with
@@ -386,19 +398,19 @@ let rec pattern_and_exp_of_typ : type a. concurrency:concurrency_policy ->
       let y = fresh_var () in
       let e = `Appl (`Ident (path_of_string x), e) in
       let (p, None, binds), e | (p, Some e, binds), _ =
-        pattern_and_exp_of_typ ~concurrency ty e pol binds, e in
+        pattern_and_exp_of_typ ~concurrency ~errno ty e pol binds, e in
       let pat = static_con "View"
         [`Record [path_of_string "CI.ty", p;
                   path_of_string "write", `Var x]] in
       (pat, Some (`Ident (Ctypes_path.path_of_string y)), (y, e) :: binds)
     | Out ->
       let (p, None, binds), e | (p, Some e, binds), _ =
-        pattern_and_exp_of_typ ~concurrency ty e pol binds, e in
+        pattern_and_exp_of_typ ~concurrency ~errno ty e pol binds, e in
       let x = fresh_var () in
       let pat = static_con "View"
         [`Record [path_of_string "CI.ty", p;
                   path_of_string "read", `Var x]] in
-      (pat, Some (map_result ~concurrency (`Appl x) e), binds)
+      (pat, Some (map_result ~concurrency ~errno (`Appl x) e), binds)
     end
   | OCaml ty ->
     begin match pol, ty with
@@ -480,12 +492,12 @@ let let_bind : (lident * ml_exp) list -> ml_exp -> ml_exp =
     ListLabels.fold_left ~init:e binds
       ~f:(fun e' (x, e) -> `Let (x, e, e'))
 
-let rec wrapper_body : type a. concurrency:concurrency_policy ->
+let rec wrapper_body : type a. concurrency:concurrency_policy -> errno:errno_policy ->
   a fn -> ml_exp -> polarity -> (lident * ml_exp) list -> wrapper_state =
-  fun ~concurrency fn exp pol binds -> match fn with
+  fun ~concurrency ~errno fn exp pol binds -> match fn with
   | Returns t ->
     let exp = run_exp ~concurrency exp in
-    begin match pattern_and_exp_of_typ ~concurrency t exp (flip pol) binds with
+    begin match pattern_and_exp_of_typ ~concurrency ~errno t exp (flip pol) binds with
       pat, None, binds -> { exp ; args = []; trivial = true; binds;
                             pat = local_con "Returns" [pat] }
     | pat, Some exp, binds -> { exp; args = []; trivial = false; binds;
@@ -493,15 +505,18 @@ let rec wrapper_body : type a. concurrency:concurrency_policy ->
     end
   | Function (f, t) ->
     let x = fresh_var () in
-    begin match pattern_and_exp_of_typ ~concurrency f (`Ident (path_of_string x)) pol binds with
+    begin match pattern_and_exp_of_typ ~concurrency ~errno
+                  f (`Ident (path_of_string x)) pol binds with
     | fpat, None, binds ->
       let { exp; args; trivial; pat = tpat; binds } =
-        wrapper_body ~concurrency t (`Appl (exp, `Ident (path_of_string x))) pol binds  in
+        wrapper_body ~concurrency ~errno
+          t (`Appl (exp, `Ident (path_of_string x))) pol binds  in
       { exp; args = x :: args; trivial; binds;
         pat = local_con "Function" [fpat; tpat] }
     | fpat, Some exp', binds ->
       let { exp; args = xs; trivial; pat = tpat; binds } =
-        wrapper_body ~concurrency t (`Appl (exp, exp')) pol binds in
+        wrapper_body ~concurrency ~errno
+          t (`Appl (exp, exp')) pol binds in
       { exp; args = x :: xs; trivial = false; binds;
         pat = local_con "Function" [fpat; tpat] }
     end
@@ -523,11 +538,11 @@ let return_result : args:lident list -> ml_exp =
                          ~f:(fun x -> `Ident (Ctypes_path.path_of_string x)))),
              `Appl (`Ident lwt_return, `Ident (Ctypes_path.path_of_string x))))
 
-let wrapper : type a. concurrency:concurrency_policy -> path ->
-  a fn -> string -> polarity -> ml_pat * ml_exp =
-  fun ~concurrency id fn f pol ->
-    let p = wrapper_body ~concurrency fn (`Ident (path_of_string f)) pol [], concurrency in
-    match p with
+let wrapper : type a. concurrency:concurrency_policy -> errno:errno_policy ->
+  path -> a fn -> string -> polarity -> ml_pat * ml_exp =
+  fun ~concurrency ~errno id fn f pol ->
+    let p = wrapper_body ~concurrency ~errno fn (`Ident (path_of_string f)) pol [] in
+    match p, concurrency with
       { trivial = true; pat; binds }, `Sequential ->
       (pat, let_bind binds (run_exp ~concurrency (`Ident id)))
     | { exp; args; pat; binds }, `Sequential ->
@@ -547,8 +562,9 @@ let wrapper : type a. concurrency:concurrency_policy -> path ->
                             `Appl (`Appl (`Ident lwt_bind, exp),
                                    return_result ~args:(args @ (List.map fst binds)))))))
 
-let case ~concurrency ~stub_name ~external_name fmt fn =
-  let p, e = wrapper ~concurrency (path_of_string external_name) fn external_name In in
+let case ~concurrency ~errno ~stub_name ~external_name fmt fn =
+  let p, e = wrapper ~concurrency ~errno
+      (path_of_string external_name) fn external_name In in
   Format.fprintf fmt "@[<hov 2>@[<h 2>|@ @[@[%a@],@ %S@]@ ->@]@ "
     Emit_ML.(ml_pat NoApplParens) p stub_name;
   Format.fprintf fmt "@[<hov 2>@[%a@]@]@]@." Emit_ML.(ml_exp ApplParens) e
@@ -564,13 +580,14 @@ let val_case ~stub_name ~external_name fmt typ =
     Emit_ML.(ml_exp (ApplParens)) rhs
 
 let constructor_decl : type a. concurrency:concurrency_policy ->
-  string -> a fn -> Format.formatter -> unit =
-  fun ~concurrency name fn fmt ->
+  errno:errno_policy -> string -> a fn -> Format.formatter -> unit =
+  fun ~concurrency ~errno name fn fmt ->
     Format.fprintf fmt "@[|@ %s@ : (@[%a@])@ name@]@\n" name
-      Emit_ML.ml_external_type (ml_external_type_of_fn ~concurrency fn In)
+      Emit_ML.ml_external_type (ml_external_type_of_fn ~concurrency ~errno fn In)
 
 let inverse_case ~register_name ~constructor name fmt fn : unit =
-  let p, e = wrapper ~concurrency:`Sequential (path_of_string "f") fn "f" Out in
+  let p, e = wrapper ~concurrency:`Sequential ~errno:`Ignore_errno
+      (path_of_string "f") fn "f" Out in
   Format.fprintf fmt "|@[ @[%a, %S@] -> %s %s (%a)@]@\n"
     Emit_ML.(ml_pat NoApplParens) p name register_name constructor
     Emit_ML.(ml_exp ApplParens) 

--- a/src/cstubs/cstubs_generate_ml.mli
+++ b/src/cstubs/cstubs_generate_ml.mli
@@ -8,10 +8,12 @@
 (* ML stub generation *)
 
 val extern : concurrency:[ `Sequential | `Lwt_jobs ] ->
+         errno:[ `Ignore_errno | `Return_errno ] ->
          stub_name:string -> external_name:string -> Format.formatter ->
          ('a -> 'b) Ctypes.fn -> unit
 
 val case : concurrency:[ `Sequential | `Lwt_jobs ] ->
+         errno:[ `Ignore_errno | `Return_errno ] ->
          stub_name:string -> external_name:string -> Format.formatter ->
          ('a -> 'b) Ctypes.fn -> unit
 
@@ -19,6 +21,7 @@ val val_case : stub_name:string -> external_name:string -> Format.formatter ->
          'a Ctypes.typ -> unit
 
 val constructor_decl : concurrency:[ `Sequential | `Lwt_jobs ] ->
+  errno:[ `Ignore_errno | `Return_errno ] ->
   string -> 'a Ctypes.fn -> Format.formatter -> unit
 
 val inverse_case : register_name:string -> constructor:string -> string ->

--- a/src/cstubs/cstubs_inverted.ml
+++ b/src/cstubs/cstubs_inverted.ml
@@ -134,8 +134,9 @@ let gen_ml fmt register (infos : fn_info list) : unit =
     "type 'a name = @\n";
   ListLabels.iter infos
     ~f:(fun (Fn ({fn_name}, fn)) ->
-      Cstubs_generate_ml.constructor_decl ~concurrency:`Sequential
-        (Printf.sprintf "Fn_%s" fn_name) fn fmt);
+        Cstubs_generate_ml.constructor_decl ~concurrency:`Sequential
+          ~errno:`Ignore_errno
+          (Printf.sprintf "Fn_%s" fn_name) fn fmt);
   Format.fprintf fmt
     "@\n";
   Format.fprintf fmt

--- a/src/ctypes/ctypes_cstubs_internals.h
+++ b/src/ctypes/ctypes_cstubs_internals.h
@@ -19,5 +19,18 @@
   (String_val(Field(s, 1)) + Int_val(Field(s, 0)))
 #define Ctypes_val_char(c) \
   (Val_int((c + 256) % 256))
+#define CTYPES_PAIR_WITH_ERRNO(v)
+
+#include <caml/memory.h>
+#include <errno.h>
+static inline value ctypes_pair_with_errno(value p)
+{
+  CAMLparam1 (p);
+  CAMLlocal1 (v);
+  v = caml_alloc_tuple(2);
+  Store_field (v, 0, p);
+  Store_field (v, 1, Val_int(errno));
+  CAMLreturn (v);
+}
 
 #endif /* CTYPES_CSTUBS_INTERNALS_H */

--- a/tests/test-foreign-errno/test_errno.ml
+++ b/tests/test-foreign-errno/test_errno.ml
@@ -48,7 +48,7 @@ let test_errno_no_exception_raised _ =
 
     
 
-let suite = "errno tests" >:::
+let suite = "foreign+errno tests" >:::
   ["Exception from close"
     >:: test_errno_exception_raised;
 

--- a/tests/test-returning-errno-lwt/stub-generator/driver.ml
+++ b/tests/test-returning-errno-lwt/stub-generator/driver.ml
@@ -1,0 +1,20 @@
+(*
+ * Copyright (c) 2016 Jeremy Yallop.
+ *
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+(* Stub generation driver for the errno tests. *)
+
+let cheader = "#include <stdlib.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+"
+
+let () = Tests_common.run ~cheader Sys.argv (module Functions.Stubs)
+    ~structs:(module Types.Struct_stubs)
+    ~concurrency:Cstubs.lwt_jobs
+    ~errno:Cstubs.return_errno

--- a/tests/test-returning-errno-lwt/stubs/functions.ml
+++ b/tests/test-returning-errno-lwt/stubs/functions.ml
@@ -1,0 +1,19 @@
+(*
+ * Copyright (c) 2016 Jeremy Yallop.
+ *
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+(* Foreign function bindings for the Errno tests. *)
+
+open Ctypes
+
+module Stubs (F: Cstubs.FOREIGN) =
+struct
+  open F
+
+  let struct_stat : [`stat] structure typ = structure "stat"
+  let stat = foreign "stat"
+      (string @-> ptr struct_stat @-> returning int)
+end

--- a/tests/test-returning-errno-lwt/stubs/types.ml
+++ b/tests/test-returning-errno-lwt/stubs/types.ml
@@ -1,0 +1,23 @@
+(*
+ * Copyright (c) 2016 Jeremy Yallop.
+ *
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+open Ctypes
+open PosixTypes
+
+module Struct_stubs(S : Cstubs.Types.TYPE) =
+struct
+  open S
+
+  let _ENOENT = constant "ENOENT" int
+
+  let ifdir = constant "S_IFDIR" (lift_typ mode_t)
+  let ifmt = constant "S_IFMT" (lift_typ mode_t)
+
+  let stat : [`stat] structure typ = structure "stat"
+  let st_mode = field stat "st_mode" (lift_typ mode_t)
+  let () = seal stat
+end

--- a/tests/test-returning-errno-lwt/test_returning_errno.ml
+++ b/tests/test-returning-errno-lwt/test_returning_errno.ml
@@ -1,0 +1,42 @@
+(*
+ * Copyright (c) 2016 Jeremy Yallop.
+ *
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+open OUnit2
+open Ctypes
+
+
+module Bindings = Functions.Stubs(Generated_bindings)
+module Constants = Types.Struct_stubs(Generated_struct_bindings)
+
+
+(*
+  Test the binding to "stat".
+ *)
+let test_stat _ =
+  let s = make Constants.stat in
+  begin
+    Lwt_unix.run
+      Lwt.((Bindings.stat "." (addr s)).lwt >>= fun (x, errno) ->
+           assert_equal 0 x;
+           assert_equal 0 errno;
+           return ());
+    Lwt_unix.run
+      Lwt.((Bindings.stat "/does-not-exist" (addr s)).lwt >>= fun (x, errno) ->
+           assert_equal (-1) x;
+           assert_equal Constants._ENOENT errno;
+           return ())
+  end
+
+
+let suite = "Errno tests" >:::
+  ["calling stat"
+    >:: test_stat;
+  ]
+
+
+let _ =
+  run_test_tt_main suite

--- a/tests/test-returning-errno/stub-generator/driver.ml
+++ b/tests/test-returning-errno/stub-generator/driver.ml
@@ -1,0 +1,19 @@
+(*
+ * Copyright (c) 2016 Jeremy Yallop.
+ *
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+(* Stub generation driver for the errno tests. *)
+
+let cheader = "#include <stdlib.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+"
+
+let () = Tests_common.run ~cheader Sys.argv (module Functions.Stubs)
+    ~structs:(module Types.Struct_stubs)
+    ~errno:Cstubs.return_errno

--- a/tests/test-returning-errno/stubs/functions.ml
+++ b/tests/test-returning-errno/stubs/functions.ml
@@ -1,0 +1,19 @@
+(*
+ * Copyright (c) 2016 Jeremy Yallop.
+ *
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+(* Foreign function bindings for the Errno tests. *)
+
+open Ctypes
+
+module Stubs (F: Cstubs.FOREIGN) =
+struct
+  open F
+
+  let struct_stat : [`stat] structure typ = structure "stat"
+  let stat = foreign "stat"
+      (string @-> ptr struct_stat @-> returning int)
+end

--- a/tests/test-returning-errno/stubs/types.ml
+++ b/tests/test-returning-errno/stubs/types.ml
@@ -1,0 +1,23 @@
+(*
+ * Copyright (c) 2016 Jeremy Yallop.
+ *
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+open Ctypes
+open PosixTypes
+
+module Struct_stubs(S : Cstubs.Types.TYPE) =
+struct
+  open S
+
+  let _ENOENT = constant "ENOENT" int
+
+  let ifdir = constant "S_IFDIR" (lift_typ mode_t)
+  let ifmt = constant "S_IFMT" (lift_typ mode_t)
+
+  let stat : [`stat] structure typ = structure "stat"
+  let st_mode = field stat "st_mode" (lift_typ mode_t)
+  let () = seal stat
+end

--- a/tests/test-returning-errno/test_returning_errno.ml
+++ b/tests/test-returning-errno/test_returning_errno.ml
@@ -1,0 +1,39 @@
+(*
+ * Copyright (c) 2016 Jeremy Yallop.
+ *
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+open OUnit2
+open Ctypes
+
+
+module Bindings = Functions.Stubs(Generated_bindings)
+module Constants = Types.Struct_stubs(Generated_struct_bindings)
+
+
+(*
+  Test the binding to "stat".
+ *)
+let test_stat _ =
+  let st = make Constants.stat in
+  begin
+    let x, errno = Bindings.stat "." (addr st) in
+    assert_equal 0 x;
+    assert_equal 0 errno;
+
+    let x, errno = Bindings.stat "/does-not-exist" (addr st) in
+    assert_equal (-1) x;
+    assert_equal Constants._ENOENT errno;
+  end
+
+
+let suite = "Errno tests" >:::
+  ["calling stat"
+    >:: test_stat;
+  ]
+
+
+let _ =
+  run_test_tt_main suite

--- a/tests/tests-common/tests_common.ml
+++ b/tests/tests-common/tests_common.ml
@@ -57,17 +57,19 @@ let with_open_formatter filename f =
 
 let header = "#include \"clib/test_functions.h\""
 
-let run ?concurrency ?(cheader="") argv ?structs specs =
+let run ?concurrency ?errno ?(cheader="") argv ?structs specs =
   let ml_filename, c_filename, c_struct_filename = filenames argv
   in
   if ml_filename <> "" then
     with_open_formatter ml_filename
-      (fun fmt -> Cstubs.write_ml ?concurrency fmt ~prefix:"cstubs_tests" specs);
+      (fun fmt -> Cstubs.write_ml ?concurrency ?errno
+          fmt ~prefix:"cstubs_tests" specs);
   if c_filename <> "" then
     with_open_formatter c_filename
       (fun fmt -> 
         Format.fprintf fmt "%s@\n%s@\n" header cheader;
-        Cstubs.write_c ?concurrency fmt ~prefix:"cstubs_tests" specs);
+        Cstubs.write_c ?concurrency ?errno
+          fmt ~prefix:"cstubs_tests" specs);
   begin match structs, c_struct_filename with
    | None, _ -> ()
    | Some _, "" -> ()


### PR DESCRIPTION
This pull request adds support for returning [`errno`][errno] alongside the return value of bound functions in generated stubs.  As with #391, the interface changes are fairly modest: there is an additional argument, `errno` to [`write_c`][write_c] and [`write_ml`][write_ml], specifying the policy to use.

Besides the default, `ignore_errno`, there is one additional option, `return_errno`, which changes the return type of each function binding from `t` to `t * int`.

For example, here is the example bindings description for `puts` and `rmdir` from #391:

```ocaml
module Bindings(F: Cstubs.FOREIGN) =
struct
  open F
  let puts = foreign "puts" (string @-> returning int)
  let rmdir = foreign "rmdir" (string @-> returning int)
end
```

The C and OCaml portions of the bindings may be generated in the usual way, specifying `return_errno` with a keyword argument:

```ocaml
write_c fmt ~errno:return_errno ~prefix (module Bindings)
write_ml fmt ~errno:return_errno ~prefix (module Bindings)
```

In the module signature built by the linking step (i.e. by applying `Bindings` to the generated OCaml module) each function binding returns a pair of the return value of the bound C function and the value of `errno` just after the call:

```ocaml
(*
sig
  val puts : string -> int * int
  val rmdir : string -> int * int
end
*)
module C_errno = Bindings(Generated_module)
```

### Errno and Lwt 

There is also support for the combination of the new `errno` and `concurrency` options.

Passing `~concurrency:lwt_jobs` to `write_c` and `write_ml` changes the return type of a function binding from `t` to `Lwt.t` (or rather to the wrapper type [`return`](https://github.com/ocamllabs/ocaml-ctypes/pull/391)).

Passing `~errno:return_errno` changes the return type from `t` to `t * int`.

Passing both `~concurrency:lwt_jobs` and `~errno:return_errno` changes the return type from `t` to `(t * int) Lwt.t` --- that is, to an `Lwt` job that returns both the result of calling the bound C function and the value of `errno` just after the call.

[write_c]: http://ocamllabs.github.io/ocaml-ctypes/Cstubs.html#VALwrite_c
[write_ml]: http://ocamllabs.github.io/ocaml-ctypes/Cstubs.html#VALwrite_ml
[errno]: http://man7.org/linux/man-pages/man3/errno.3.html
