### PR TITLE
Configuration: only include <ffi.h> when extracting libffi symbols.

### DIFF
--- a/src/configure/extract_from_c.ml
+++ b/src/configure/extract_from_c.ml
@@ -57,11 +57,11 @@ let headers = "\
 #include <complex.h>
 #include <inttypes.h>
 #include <caml/mlvalues.h>
-#include <ffi.h>
 "
 
-let integer expression =
+let integer ?(extra_headers="") expression =
   let code = Printf.sprintf "%s
+%s
 
 #define alignof(T) (offsetof(struct { char c; T t; }, t))
 
@@ -80,11 +80,12 @@ const char s[] = {
   D9((%s)),
   '-', 'E', 'N', 'D'
 };
-" headers expression in
+" headers extra_headers expression in
   int_of_string (extract (read_output code))
 
-let string expression =
+let string ?(extra_headers="") expression =
   let code = Printf.sprintf "%s
+%s
 
 #define STRINGIFY1(x) #x
 #define STRINGIFY(x) STRINGIFY1(x)
@@ -96,5 +97,5 @@ let string expression =
 #endif
 
 const char *s = \"BEGIN-\" %s \"-END\";
-" headers expression in
+" headers extra_headers expression in
   extract (read_output code)

--- a/src/configure/gen_libffi_abi.ml
+++ b/src/configure/gen_libffi_abi.ml
@@ -53,9 +53,11 @@ let symbols = [
   ("default_abi"      , "FFI_DEFAULT_ABI");
 ]
 
+let extra_headers = "#include <ffi.h>"
+
 let write_line name symbol =
   try
-    Printf.printf "let %s = Code %d\n" name (Extract_from_c.integer symbol)
+    Printf.printf "let %s = Code %d\n" name (Extract_from_c.integer ~extra_headers symbol)
   with Not_found ->
     Printf.printf "let %s = Unsupported \"%s\"\n" name symbol
 


### PR DESCRIPTION
The OS X build is currently [failing](https://travis-ci.org/ocaml/opam-repository/jobs/134712983) when `libffi` is not available, because the configuration program always includes `#include <ffi.h>`.
