### PR TITLE
Quote arguments for Sys.command properly

### DIFF
--- a/src/configure/extract_from_c.ml
+++ b/src/configure/extract_from_c.ml
@@ -23,9 +23,9 @@ let read_output program =
       (getenv ~default:"ocamlfind" "OCAMLFIND")
       ((getenv ~default:"" "CFLAGS") |>
        (nsplit " ") |>
-       (List.map (fun s -> "-ccopt '"^s^"'")) |>
+       (List.map (fun s -> "-ccopt " ^ Filename.quote s)) |>
        (String.concat " "))
-      input_filename
+      (Filename.quote input_filename)
   in
   prerr_endline cmd;
   Sys.chdir (Filename.dirname input_filename);


### PR DESCRIPTION
Otherwise it is a sheer coincidence, if the command get's the proper arguments, at least on windows. Single quotes `'` are not supported at all by `Sys.command` (cmd.exe). I wonder, why the appveyor test passes...