### PR TITLE
Add a top-level printer for the new 'sint' type.

### DIFF
--- a/src/ctypes-top/ctypes_printers.ml
+++ b/src/ctypes-top/ctypes_printers.ml
@@ -7,6 +7,8 @@
 
 let format_typ fmt t = Ctypes.format_typ fmt t
 let format_fn fmt fn = Ctypes.format_fn fmt fn
+let format_sint fmt v =
+  Format.fprintf fmt "<sint %s>" (Signed.SInt.to_string v)
 let format_long fmt v =
   Format.fprintf fmt "<long %s>" (Signed.Long.to_string v)
 let format_llong fmt v =

--- a/src/ctypes-top/ctypes_printers.mli
+++ b/src/ctypes-top/ctypes_printers.mli
@@ -9,6 +9,7 @@ open Format
 
 val format_typ : formatter -> 'a Ctypes.typ -> unit
 val format_fn : formatter -> 'a Ctypes.fn -> unit
+val format_sint : formatter -> Signed.SInt.t -> unit
 val format_long : formatter -> Signed.Long.t -> unit
 val format_llong : formatter -> Signed.LLong.t -> unit
 val format_uchar : formatter -> Unsigned.UChar.t -> unit

--- a/src/ctypes-top/install_ctypes_printers.ml
+++ b/src/ctypes-top/install_ctypes_printers.ml
@@ -2,6 +2,7 @@
 
 let printers = [ "Ctypes_printers.format_typ";
                  "Ctypes_printers.format_fn"; 
+                 "Ctypes_printers.format_sint";
                  "Ctypes_printers.format_long";
                  "Ctypes_printers.format_llong";
                  "Ctypes_printers.format_uchar";


### PR DESCRIPTION
```ocaml
# Signed.SInt.of_string "20";;
- : Signed.SInt.t = <sint 20>
```