### PR TITLE
Use -opaque for module interfaces whose cmx files are not installed.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .SECONDEXPANSION:
 
 BEST:=$(shell if ocamlopt > /dev/null 2>&1; then echo native; else echo byte; fi)
+OPAQUE:=$(shell if ocamlopt -opaque 2>/dev/null; then echo -opaque; fi) 
 DEBUG=true
 COVERAGE=false
 OCAML=ocaml
@@ -93,6 +94,7 @@ ctypes-foreign-threaded.subproject_deps = ctypes ctypes-foreign-base
 ctypes-foreign-threaded.link_flags = $(libffi_lib) $(lib_process)
 ctypes-foreign-threaded.cmo_opts = $(OCAML_FFI_INCOPTS:%=-ccopt %)
 ctypes-foreign-threaded.cmx_opts = $(OCAML_FFI_INCOPTS:%=-ccopt %)
+ctypes-foreign-threaded.cmi_opts = $(OPAQUE)
 ctypes-foreign-threaded.install_native_objects = no
 
 ctypes-foreign-threaded: PROJECT=ctypes-foreign-threaded
@@ -107,6 +109,7 @@ ctypes-foreign-unthreaded.subproject_deps = ctypes ctypes-foreign-base
 ctypes-foreign-unthreaded.link_flags = $(libffi_lib) $(lib_process)
 ctypes-foreign-unthreaded.cmo_opts = $(OCAML_FFI_INCOPTS:%=-ccopt %)
 ctypes-foreign-unthreaded.cmx_opts = $(OCAML_FFI_INCOPTS:%=-ccopt %)
+ctypes-foreign-unthreaded.cmi_opts = $(OPAQUE)
 ctypes-foreign-unthreaded.install_native_objects = no
 
 ctypes-foreign-unthreaded: PROJECT=ctypes-foreign-unthreaded

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -45,6 +45,7 @@ XEN_CFLAGS=$(if $(XEN_LIB), \
 
 CMO_OPTS = $($(PROJECT).cmo_opts)
 CMX_OPTS = $($(PROJECT).cmx_opts)
+CMI_OPTS = $($(PROJECT).cmi_opts)
 CMA_OPTS = $(if $(C_OBJECTS),-cclib -l$(PROJECT)_stubs -dllib -l$(PROJECT)_stubs)
 SUBPROJECT_DEPS = $($(PROJECT).subproject_deps)
 LOCAL_CMXAS = $(SUBPROJECT_DEPS:%=$(BUILDDIR)/%.cmxa)
@@ -114,7 +115,7 @@ $(BUILDDIR)/xen/%.o : %.c
 
 $(BUILDDIR)/%.cmi : %.mli
 	@mkdir -p $(@D)
-	$(OCAMLFIND) ocamlc -bin-annot -c -o $@ $(OCAMLFIND_PACKAGE_FLAGS) $(OCAMLFLAGS) $(OCAMLINCLUDES) $<
+	$(OCAMLFIND) opt -bin-annot -c -o $@ $(OCAMLFIND_PACKAGE_FLAGS) $(CMI_OPTS) $(OCAMLFLAGS) $(OCAMLINCLUDES) $<
 
 $(BUILDDIR)/%.native : $$(NATIVE_OBJECTS) $$(C_OBJECTS)
 	$(OCAMLFIND) opt -I $(BUILDDIR) -linkpkg $(OCAMLFLAGS) $(THREAD_FLAG) $(OCAMLFIND_PACKAGE_FLAGS) $(LOCAL_CMXAS) -o $@ $(NATIVE_OBJECTS) $(C_OBJECTS) $(OCAML_LINK_FLAGS) 


### PR DESCRIPTION
Fixes #422