### PR TITLE
Reset errno in lwt jobs before invoking job function

### DIFF
--- a/src/cstubs/cstubs_generate_c.ml
+++ b/src/cstubs/cstubs_generate_c.ml
@@ -378,11 +378,12 @@ struct
             `Ignore_errno -> r (`Return (Ty Void, (`Int Signed.SInt.zero)))
           | `Return_errno ->
             let open Generate_C in
-              r
-              (`LetAssign
-                 (`PointerField (`Local j, "error_status"),
-                  errno,
-                  `Return (Ty Void, (`Int Signed.SInt.zero))))
+            `LetAssign (errno, `Int Signed.SInt.zero,
+                        r
+                          (`LetAssign
+                             (`PointerField (`Local j, "error_status"),
+                              errno,
+                              `Return (Ty Void, (`Int Signed.SInt.zero)))))
         end
       | (BoxedType ty, x) :: xs ->
         Generate_C.((`DerefField (`Local j, x), ty) >>= fun y ->


### PR DESCRIPTION
Otherwise, APIs which rely on errno to resolve exit code ambiguity (e.g. `readdir`) are not bindable correctly. See dsheets/ocaml-unix-dirent#17 for an example/work-around in that
particular case.