### PR TITLE
Fix Makefile.rules on OpenBSD

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -78,7 +78,7 @@ INSTALL_HEADERS = $(wildcard $($(PROJECT).dir)/*.h)
 THREAD_FLAG = $(if $(filter yes,$($(PROJECT).threads)),-thread)
 LINK_FLAGS = $(as_needed_flags) $($(PROJECT).link_flags)
 OCAML_LINK_FLAGS=$(LINK_FLAGS:%=-cclib %)
-OCAMLMKLIB_FLAGS=$($(PROJECT).link_flags)
+OCAMLMKLIB_FLAGS=$($(PROJECT).link_flags:%=-cclib %)
 OCAMLFIND_PACKAGE_FLAGS=$(patsubst %,-package %,$($(PROJECT).deps)) \
                         $(patsubst %,-thread -package threads,$(THREAD_FLAG)) \
                         $(OCAMLFIND_BISECT_FLAGS)


### PR DESCRIPTION
Hello,

When compiling on OpenBSD I encountered this error
```
ocamlfind ocamlmklib -o _build/ctypes-foreign-base_stubs _build/src/ctypes-foreign-base/dl_stubs.o _build/src/ctypes-foreign-base/ffi_call_stubs.o _build/src/ctypes-foreign-base/ffi_type_stubs.o -L/usr/local/lib -pthread -lffi
ocamlfind: unknown option '-pthread'.
```
That seems related to a line in Makefile.rules.
I fixed that a few weeks ago but can't remember much about the fix itself, I'm not sure I understand what's going on.
I tested it and it looks like it works on Linux and OpenBSD at least.
Do you have any idea on what might be the issue ?

patch attached to fix the problem.