### PR TITLE
Add support for releasing the runtime lock in generated stubs

### DIFF
--- a/Makefile.tests
+++ b/Makefile.tests
@@ -965,6 +965,14 @@ test-threads-stubs.subproject_deps = ctypes cstubs \
 test-threads-stubs: PROJECT=test-threads-stubs
 test-threads-stubs: $$(LIB_TARGETS)
 
+test-threads-stub-generator.dir = tests/test-threads/stub-generator
+test-threads-stub-generator.threads = yes
+test-threads-stub-generator.subproject_deps = ctypes cstubs \
+     ctypes-foreign-base ctypes-foreign-threaded test-threads-stubs tests-common
+test-threads-stub-generator.deps = str bigarray bytes
+test-threads-stub-generator: PROJECT=test-threads-stub-generator
+test-threads-stub-generator: $$(BEST_TARGET)
+
 test-threads.dir = tests/test-threads
 test-threads.threads = yes
 test-threads.deps = str bigarray oUnit bytes
@@ -973,6 +981,15 @@ test-threads.subproject_deps = ctypes ctypes-foreign-base \
 test-threads.link_flags = -L$(BUILDDIR)/clib -ltest_functions
 test-threads: PROJECT=test-threads
 test-threads: $$(BEST_TARGET)
+
+test-threads-generated: \
+  tests/test-threads/generated_bindings.ml \
+  tests/test-threads/generated_stubs.c
+
+tests/test-threads/generated_stubs.c: $(BUILDDIR)/test-threads-stub-generator.$(BEST)
+	$< --c-file $@
+tests/test-threads/generated_bindings.ml: $(BUILDDIR)/test-threads-stub-generator.$(BEST)
+	$< --ml-file $@
 
 TESTS =
 TESTS += test-raw
@@ -1009,8 +1026,7 @@ TESTS += test-passing-ocaml-values-stubs test-passing-ocaml-values-stub-generato
 TESTS += test-lwt-jobs-stubs test-lwt-jobs-stub-generator test-lwt-jobs-generated test-lwt-jobs
 TESTS += test-returning-errno-lwt-stubs test-returning-errno-lwt-stub-generator test-returning-errno-lwt-generated test-returning-errno-lwt
 TESTS += test-returning-errno-stubs test-returning-errno-stub-generator test-returning-errno-generated test-returning-errno
-TESTS += test-threads-stubs test-threads
-
+TESTS += test-threads-stubs test-threads-stub-generator test-threads-generated test-threads
 
 ifneq (,$(filter mingw%,$(OSYSTEM)))
 WINLDFLAGS=-Wl,--out-implib,libtest_functions.dll.a

--- a/src/cstubs/cstubs.mli
+++ b/src/cstubs/cstubs.mli
@@ -126,6 +126,10 @@ val sequential : concurrency_policy
     default.
 *)
 
+val unlocked : concurrency_policy
+(** Generate code that releases the runtime lock during C calls.
+*)
+
 val lwt_jobs : concurrency_policy
 (** Generate code which implements C function calls as Lwt jobs:
 

--- a/src/cstubs/cstubs_generate_c.ml
+++ b/src/cstubs/cstubs_generate_c.ml
@@ -85,10 +85,10 @@ struct
                    [x])
 
   let acquire_runtime_system : ccomp =
-    `App (conser "caml_acquire_runtime_system" (ptr void @-> returning void), [])
+    `App (conser "caml_acquire_runtime_system" (void @-> returning void), [])
 
   let release_runtime_system : ccomp =
-    `App (conser "caml_release_runtime_system" (ptr void @-> returning void), [])
+    `App (conser "caml_release_runtime_system" (void @-> returning void), [])
 
   let val_unit : ceff = `Global { name = "Val_unit";
                                   references_ocaml_heap = true;

--- a/src/cstubs/cstubs_generate_c.mli
+++ b/src/cstubs/cstubs_generate_c.mli
@@ -7,7 +7,7 @@
 
 (* C stub generation *)
 
-val fn : concurrency:[ `Sequential | `Lwt_jobs ] ->
+val fn : concurrency:[ `Sequential | `Lwt_jobs | `Unlocked ] ->
          errno:[ `Ignore_errno | `Return_errno ] ->
          cname:string -> stub_name:string ->
          Format.formatter -> 'a Ctypes.fn -> unit

--- a/src/cstubs/cstubs_generate_ml.mli
+++ b/src/cstubs/cstubs_generate_ml.mli
@@ -7,12 +7,12 @@
 
 (* ML stub generation *)
 
-val extern : concurrency:[ `Sequential | `Lwt_jobs ] ->
+val extern : concurrency:[ `Sequential | `Lwt_jobs | `Unlocked ] ->
          errno:[ `Ignore_errno | `Return_errno ] ->
          stub_name:string -> external_name:string -> Format.formatter ->
          ('a -> 'b) Ctypes.fn -> unit
 
-val case : concurrency:[ `Sequential | `Lwt_jobs ] ->
+val case : concurrency:[ `Sequential | `Lwt_jobs | `Unlocked ] ->
          errno:[ `Ignore_errno | `Return_errno ] ->
          stub_name:string -> external_name:string -> Format.formatter ->
          ('a -> 'b) Ctypes.fn -> unit
@@ -20,7 +20,7 @@ val case : concurrency:[ `Sequential | `Lwt_jobs ] ->
 val val_case : stub_name:string -> external_name:string -> Format.formatter ->
          'a Ctypes.typ -> unit
 
-val constructor_decl : concurrency:[ `Sequential | `Lwt_jobs ] ->
+val constructor_decl : concurrency:[ `Sequential | `Lwt_jobs | `Unlocked ] ->
   errno:[ `Ignore_errno | `Return_errno ] ->
   string -> 'a Ctypes.fn -> Format.formatter -> unit
 

--- a/tests/test-threads/stub-generator/driver.ml
+++ b/tests/test-threads/stub-generator/driver.ml
@@ -1,0 +1,10 @@
+(*
+ * Copyright (c) 2016 Jeremy Yallop.
+ *
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+(* Stub generation driver for the threads tests. *)
+
+let () = Tests_common.run ~concurrency:Cstubs.unlocked Sys.argv (module Functions.Stubs)

--- a/tests/test-threads/stubs/functions.ml
+++ b/tests/test-threads/stubs/functions.ml
@@ -8,25 +8,16 @@
 (* Foreign function bindings for the threads tests. *)
 
 open Ctypes
-open Foreign
 
-let () =
-  (* temporary workaround due to flexlink limitations *)
-  if Sys.os_type = "Win32" then
-    ignore (Dl.(dlopen ~filename:"clib/libtest_functions.so" ~flags:[RTLD_NOW]))
+module Stubs(F: Cstubs.FOREIGN) =
+struct
+  open F
+  let initialize_waiters = foreign "initialize_waiters"
+    (void @-> returning void)
 
-let initialize_waiters = foreign "initialize_waiters"
-  (void @-> returning void)
+  let post1_wait2 = foreign "post1_wait2"
+    (void @-> returning void)
 
-let post1_wait2 = foreign "post1_wait2"
-  ~release_runtime_lock:true
-  (void @-> returning void)
-
-let post2_wait1 = foreign "post2_wait1"
-  ~release_runtime_lock:true
-  (void @-> returning void)
-
-let callback_with_pointers = foreign "passing_pointers_to_callback"
-  ~release_runtime_lock:true
-  (funptr ~runtime_lock:true
-     (ptr int @-> ptr int @-> returning int) @-> returning int)
+  let post2_wait1 = foreign "post2_wait1"
+    (void @-> returning void)
+end


### PR DESCRIPTION
Fixes #241.

This adds an extra value, [`Cstubs.unlocked`](https://github.com/yallop/ocaml-ctypes/blob/2e1d16ddbced122e3076241003dded1db3aaa959/src/cstubs/cstubs.mli#L129-L131) to the interface:

```ocaml
val unlocked : concurrency_policy
(** Generate code that releases the runtime lock during C calls. *)
```

Passing `~concurrency_policy:Cstubs.unlocked` to the `write_c` and `write_ml` functions results in generated code that releases the [runtime lock](http://caml.inria.fr/pub/docs/manual-ocaml/intfc.html#sec453) when calling C functions.