### PR TITLE
Address a couple of warnings

### DIFF
--- a/src/ctypes/ctypes_memory.ml
+++ b/src/ctypes/ctypes_memory.ml
@@ -304,7 +304,6 @@ let array_dims : type a b c d f.
        | Array (_, n) -> (a.alength, n)
        | _ -> unsupported ()
        end
-     | _ -> unsupported ()
     end
    | Array3 ->
      begin match a.astart with
@@ -313,7 +312,6 @@ let array_dims : type a b c d f.
        |  Array (Array (_, m), n) -> (a.alength, n, m)
        | _ -> unsupported ()
        end
-     | _ -> unsupported ()
      end
 
 let bigarray_of_array spec kind a =

--- a/tests/test-returning-errno-lwt-jobs/test_returning_errno.ml
+++ b/tests/test-returning-errno-lwt-jobs/test_returning_errno.ml
@@ -20,12 +20,12 @@ let test_stat _ =
   let s = make Constants.stat in
   begin
     Lwt_unix.run
-      Lwt.((Bindings.stat "." (addr s)).lwt >>= fun (x, errno) ->
+      Lwt.((Bindings.stat "." (addr s)).Generated_bindings.lwt >>= fun (x, errno) ->
            assert_equal 0 x;
            assert_equal Signed.SInt.zero errno;
            return ());
     Lwt_unix.run
-      Lwt.((Bindings.stat "/does-not-exist" (addr s)).lwt >>= fun (x, errno) ->
+      Lwt.((Bindings.stat "/does-not-exist" (addr s)).Generated_bindings.lwt >>= fun (x, errno) ->
            assert_equal (-1) x;
            assert_equal Constants._ENOENT errno;
            return ())

--- a/tests/test-returning-errno-lwt-preemptive/test_returning_errno.ml
+++ b/tests/test-returning-errno-lwt-preemptive/test_returning_errno.ml
@@ -20,12 +20,12 @@ let test_stat _ =
   let s = make Constants.stat in
   begin
     Lwt_unix.run
-      Lwt.((Bindings.stat "." (addr s)).lwt >>= fun (x, errno) ->
+      Lwt.((Bindings.stat "." (addr s)).Generated_bindings.lwt >>= fun (x, errno) ->
            assert_equal 0 x;
            assert_equal Signed.SInt.zero errno;
            return ());
     Lwt_unix.run
-      Lwt.((Bindings.stat "/does-not-exist" (addr s)).lwt >>= fun (x, errno) ->
+      Lwt.((Bindings.stat "/does-not-exist" (addr s)).Generated_bindings.lwt >>= fun (x, errno) ->
            assert_equal (-1) x;
            assert_equal Constants._ENOENT errno;
            return ())


### PR DESCRIPTION
```
File "src/ctypes/ctypes_memory.ml", line 316, characters 7-8:
Warning 56: this match case is unreachable.
Consider replacing it with a refutation case '<pat> -> .'
File "src/ctypes/ctypes_memory.ml", line 316, characters 7-8:
```

```
File "tests/test-returning-errno-lwt-jobs/test_returning_errno.ml", line 23, characters 40-43:
Warning 40: lwt was selected from type Generated_bindings.return.
It is not visible in the current scope, and will not 
be selected if the type becomes unknown.
```