### PR TITLE
Fix a memory leak with trampoline creation

### DIFF
--- a/src/ctypes-foreign-base/ctypes_ffi.ml
+++ b/src/ctypes-foreign-base/ctypes_ffi.ml
@@ -37,8 +37,18 @@ struct
 
      [keep_alive w ~while_live:v] ensures that [w] is not collected while [v] is
      still live.
+
+     If the object v in the call [keep_alive w ~while_live:v] is
+     static -- for example, if it is a top-level function -- then it
+     is not possible to attach a finaliser to [v] and [w] should be
+     kept alive indefinitely, which we achieve by adding it to the
+     list [kept_alive_indefinitely].
   *)
-  let keep_alive w ~while_live:v = Gc.finalise (fun _ -> w; ()) v
+  let kept_alive_indefinitely = ref []
+  let keep_alive w ~while_live:v =
+    try Gc.finalise (fun _ -> w; ()) v
+    with Invalid_argument "Gc.finalise" ->
+      kept_alive_indefinitely := Obj.repr w :: !kept_alive_indefinitely
 
   let report_unpassable what =
     let msg = Printf.sprintf "libffi does not support passing %s" what in
@@ -199,5 +209,13 @@ struct
     fun f ->
       let boxed = cs (Ctypes_weak_ref.make f) in
       let id = Closure_properties.record (Obj.repr f) (Obj.repr boxed) in
-      funptr_of_rawptr fn (Ctypes_ffi_stubs.make_function_pointer cs' id)
+      let funptr = Ctypes_ffi_stubs.make_function_pointer cs' id in
+      (* TODO: use a more intelligent strategy for keeping function pointers
+         associated with top-level functions alive (e.g. cache function
+         pointer creation by (function, type), or possibly even just by
+         function, since the C arity and types must be the same in each case.)
+         See the note by [kept_alive_indefinitely].  *)
+      let () = keep_alive funptr ~while_live:f in
+      funptr_of_rawptr fn
+        (Ctypes_ffi_stubs.raw_address_of_function_pointer funptr)
 end

--- a/src/ctypes-foreign-base/ctypes_ffi_stubs.ml
+++ b/src/ctypes-foreign-base/ctypes_ffi_stubs.ml
@@ -66,9 +66,14 @@ type boxedfn =
   | Done of (voidp -> unit) * callspec
   | Fn of (voidp -> boxedfn)
 
+type funptr_handle
+
 (* Construct a pointer to an OCaml function represented by an identifier *)
-external make_function_pointer : callspec -> int -> voidp
+external make_function_pointer : callspec -> int -> funptr_handle
   = "ctypes_make_function_pointer"
+
+external raw_address_of_function_pointer : funptr_handle -> voidp
+  = "ctypes_raw_address_of_function_pointer"
 
 (* Set the function used to retrieve functions by identifier. *)
 external set_closure_callback : (int -> Obj.t) -> unit

--- a/src/ctypes-foreign-base/ffi_call_stubs.c
+++ b/src/ctypes-foreign-base/ffi_call_stubs.c
@@ -523,6 +523,25 @@ static void callback_handler(ffi_cif *cif,
 }
 
 
+static void finalize_closure(value v)
+{
+  struct closure **closure = Data_custom_val(v);
+  ffi_closure_free(*closure);
+}
+
+/* A custom object whose purpose is the finalizer that calls
+   ffi_closure_free */
+static struct custom_operations closure_custom_ops = {
+  "ocaml-ctypes:closure",
+  finalize_closure,
+  custom_compare_default,
+  custom_hash_default,
+  custom_serialize_default,
+  custom_deserialize_default,
+  custom_compare_ext_default
+};
+
+
 /* Construct a pointer to an OCaml function represented by an identifier */
 /* make_function_pointer : callspec -> int -> raw_pointer */
 value ctypes_make_function_pointer(value callspec_, value fnid)
@@ -535,10 +554,6 @@ value ctypes_make_function_pointer(value callspec_, value fnid)
 
   void (*code_address)(void) = NULL;
 
-  /* TODO: we need to call ffi_closure_free at some point.  This function
-     should return a managed object to which we can attach a finaliser for the
-     closure.
-  */
   closure *closure = ffi_closure_alloc(sizeof *closure, (void *)&code_address);
 
   if (closure == NULL) {
@@ -556,7 +571,16 @@ value ctypes_make_function_pointer(value callspec_, value fnid)
 
     ctypes_check_ffi_status(status);
 
-    codeptr = CTYPES_FROM_PTR((void *)code_address);
+    codeptr =
+      caml_alloc_custom(&closure_custom_ops, sizeof(struct closure *), 1, 1);
+    *(struct closure **)Data_custom_val(codeptr) = closure;
+
     CAMLreturn (codeptr);
   }
+}
+
+/* Extract the raw address from a function pointer object */ 
+value ctypes_raw_address_of_function_pointer(value closure)
+{
+  return CTYPES_FROM_PTR(*(struct closure **)Data_custom_val(closure));
 }

--- a/tests/test-cstdlib/test_cstdlib.ml
+++ b/tests/test-cstdlib/test_cstdlib.ml
@@ -125,6 +125,7 @@ struct
         f x y
       in
       let () = qsort (to_voidp (start arr)) len size cmp in
+      let _ = Ctypes_memory_stubs.use_value cmp in
       to_list arr
       in
 

--- a/tests/test-oo_style/test_oo_style.ml
+++ b/tests/test-oo_style/test_oo_style.ml
@@ -23,19 +23,26 @@ struct
     let module M = struct
 
       let camel_vtable_singleton = make camel_methods
+
+      let idfn = (fun animal ->
+          let n = call_humps (cast camel animal) in
+          Printf.sprintf "%d-hump camel" n)
+
+      let humpsfn = (fun camel -> !@(camel |-> nhumps))
+
+      let sayfn = (fun animal -> "humph")
+
       let () = begin
         let vt = camel_vtable_singleton in
         let base_vt = !@(cast animal_methods (addr vt)) in
         (* say *)
-        setf base_vt say (fun animal -> "humph");
+        setf base_vt say sayfn;
 
         (* identify *)
-        setf base_vt identify (fun animal ->
-          let n = call_humps (cast camel animal) in
-          Printf.sprintf "%d-hump camel" n);
+        setf base_vt identify idfn;
 
         (* humps *)
-        setf vt humps (fun camel -> !@(camel |-> nhumps))
+        setf vt humps humpsfn;
       end
 
       let new_camel ~humps =
@@ -57,6 +64,8 @@ struct
           assert_equal c#say "humph";
           assert_equal c#humps 3;
         end
+
+      let _ = Ctypes_memory_stubs.use_value (idfn, humpsfn, sayfn)
 
       (* Test that we can call a virtual method in a C-created subclass from
          OCaml *)


### PR DESCRIPTION
Tie `libffi` closure lifetime to OCaml closure lifetime.
