### PR TITLE
Remove a GCC warning when compiling with -pedantic

### DIFF
--- a/src/ctypes/ctypes_primitives.h
+++ b/src/ctypes/ctypes_primitives.h
@@ -44,7 +44,7 @@ enum ctypes_primitive {
   Ctypes_Float,
   Ctypes_Double,
   Ctypes_Complex32,
-  Ctypes_Complex64,
+  Ctypes_Complex64
 };
 
 /* short is at least 16 bits. */


### PR DESCRIPTION
Previously, when compiling a C file with:
- GCC
- the option -pedantic
- the include line #include "ctypes_cstubs_internals.h"

We had the following warning:

ctypes_primitives.h:47:19: warning: comma at end of enumerator list [-Wpedantic]
   Ctypes_Complex64,

This commit remove this warning.