### PR TITLE
Revert "Fix Makefile.rules on OpenBSD"

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -78,7 +78,7 @@ INSTALL_HEADERS = $(wildcard $($(PROJECT).dir)/*.h)
 THREAD_FLAG = $(if $(filter yes,$($(PROJECT).threads)),-thread)
 LINK_FLAGS = $(as_needed_flags) $($(PROJECT).link_flags)
 OCAML_LINK_FLAGS=$(LINK_FLAGS:%=-cclib %)
-OCAMLMKLIB_FLAGS=$($(PROJECT).link_flags:%=-cclib %)
+OCAMLMKLIB_FLAGS=$($(PROJECT).link_flags)
 OCAMLFIND_PACKAGE_FLAGS=$(patsubst %,-package %,$($(PROJECT).deps)) \
                         $(patsubst %,-thread -package threads,$(THREAD_FLAG)) \
                         $(OCAMLFIND_BISECT_FLAGS)


### PR DESCRIPTION
Reverts ocamllabs/ocaml-ctypes#428.

Fixes #442.