### PR TITLE
Only install cmti files for modules intended for end users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,8 @@ clean:
 	rm -f $(GENERATED)
 
 # ctypes subproject
-ctypes.public = ctypes_static ctypes_primitive_types unsigned signed ctypes_structs ctypes posixTypes ctypes_types
+ctypes.cmi_only = ctypes_static ctypes_primitive_types ctypes_structs
+ctypes.public = unsigned signed ctypes posixTypes ctypes_types
 ctypes.dir = src/ctypes
 ctypes.extra_mls = ctypes_primitives.ml
 ctypes.deps = str bigarray bytes
@@ -59,7 +60,8 @@ ctypes: PROJECT=ctypes
 ctypes: $(ctypes.dir)/$(ctypes.extra_mls) $$(LIB_TARGETS)
 
 # cstubs subproject
-cstubs.public = cstubs_internals cstubs_structs cstubs cstubs_inverted
+cstubs.cmi_only = cstubs_internals
+cstubs.public = cstubs_structs cstubs cstubs_inverted
 cstubs.dir = src/cstubs
 cstubs.subproject_deps = ctypes
 cstubs.deps = str bytes

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -70,7 +70,8 @@ endif
 LIB_TARGET_EXTRAS = $(if $(STUB_LIB),$(BUILDDIR)/lib$(PROJECT)_stubs.a) \
                     $(if $(XEN_LIB),$(BUILDDIR)/lib$(PROJECT)_stubs_xen.a) \
                     $(BUILDDIR)/$(PROJECT).a
-INSTALL_CMIS = $($(PROJECT).public:%=$(BUILDDIR)/$($(PROJECT).dir)/%.cmi)
+INSTALL_CMIS = $($(PROJECT).public:%=$(BUILDDIR)/$($(PROJECT).dir)/%.cmi) \
+               $($(PROJECT).cmi_only:%=$(BUILDDIR)/$($(PROJECT).dir)/%.cmi)
 INSTALL_CMTIS = $($(PROJECT).public:%=$(BUILDDIR)/$($(PROJECT).dir)/%.cmti)
 INSTALL_CMTS = $($(PROJECT).public:%=$(BUILDDIR)/$($(PROJECT).dir)/%.cmt)
 INSTALL_MLIS = $($(PROJECT).public:%=$($(PROJECT).dir)/%.mli)

--- a/src/ctypes-foreign-base/ctypes_foreign_basis.ml
+++ b/src/ctypes-foreign-base/ctypes_foreign_basis.ml
@@ -34,14 +34,17 @@ struct
     Ctypes.ptr_of_raw_address (Ctypes_ptr.Raw.to_nativeint p)
 
   let foreign_value ?from symbol t =
-    from_voidp t (ptr_of_raw_ptr (dlsym ?handle:from ~symbol))
+    from_voidp t (ptr_of_raw_ptr
+                    (Ctypes_ptr.Raw.of_nativeint (dlsym ?handle:from ~symbol)))
 
   let foreign ?(abi=Libffi_abi.default_abi) ?from ?(stub=false)
       ?(check_errno=false) ?(release_runtime_lock=false) symbol typ =
     try
       let coerce = Ctypes_coerce.coerce (static_funptr (void @-> returning void))
         (funptr ~abi ~name:symbol ~check_errno ~runtime_lock:release_runtime_lock typ) in
-      coerce (funptr_of_raw_ptr (dlsym ?handle:from ~symbol))
+      coerce (funptr_of_raw_ptr
+                (Ctypes_ptr.Raw.of_nativeint
+                   (dlsym ?handle:from ~symbol)))
     with
     | exn -> if stub then fun _ -> raise exn else raise exn
 end

--- a/src/ctypes-foreign-base/dl.ml.unix
+++ b/src/ctypes-foreign-base/dl.ml.unix
@@ -60,5 +60,5 @@ let dlclose ~handle =
 
 let dlsym ?handle ~symbol =
   match _dlsym ?handle ~symbol with
-    | Some symbol -> Ctypes_ptr.Raw.of_nativeint symbol
+    | Some symbol -> symbol
     | None        -> _report_dl_error false

--- a/src/ctypes-foreign-base/dl.ml.win
+++ b/src/ctypes-foreign-base/dl.ml.win
@@ -10,7 +10,7 @@ type dlsym_ret =
   | Dlsy_nomem
   | Dlsy_enoent
   | Dlsy_error of string
-  | Dlsy_ok of Ctypes_ptr.voidp
+  | Dlsy_ok of nativeint
 external _dlsym_default: string -> dlsym_ret = "ctypes_win32_dlsym_rtld_default"
 external _dlsym: library -> string -> dlsym_ret = "ctypes_win32_dlsym"
 

--- a/src/ctypes-foreign-base/dl.mli
+++ b/src/ctypes-foreign-base/dl.mli
@@ -41,5 +41,5 @@ Note for windows users: the filename must be encoded in UTF-8 *)
 val dlclose : handle:library -> unit
 (** Close a dynamic library. *)
 
-val dlsym : ?handle:library -> symbol:string -> Ctypes_ptr.voidp
+val dlsym : ?handle:library -> symbol:string -> nativeint
 (** Look up a symbol in a dynamic library. *)

--- a/tests/test-raw/test_raw.ml
+++ b/tests/test-raw/test_raw.ml
@@ -30,7 +30,7 @@ let test_fabs _ =
     let () = prep_callspec callspec Libffi_abi.(abi_code default_abi)
       double_ffitype in
     
-    let dlfabs = Dl.dlsym "fabs" in
+    let dlfabs = Ctypes_ptr.Raw.of_nativeint (Dl.dlsym "fabs") in
     let dlfabs_fat = Ctypes_ptr.Fat.make dlfabs
         ~reftyp:Ctypes.(double @-> returning double) in
 
@@ -65,7 +65,7 @@ let test_pow _ =
     let () = prep_callspec callspec Libffi_abi.(abi_code default_abi) 
       double_ffitype in
     
-    let dlpow = Dl.dlsym "pow" in
+    let dlpow = Ctypes_ptr.Raw.of_nativeint (Dl.dlsym "pow") in
     let dlpow_fat = Ctypes_ptr.Fat.make dlpow
         ~reftyp:Ctypes.(double @-> double @-> returning double) in
 


### PR DESCRIPTION
Also change the `Dl` interface to use only published types.

See the discussion under #444 [here](https://github.com/ocamllabs/ocaml-ctypes/pull/444#issuecomment-246335325).