### PR TITLE
wrap link options passed to ocamlmklib with -ldopt (not -cclib)

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -79,7 +79,8 @@ INSTALL_HEADERS = $(wildcard $($(PROJECT).dir)/*.h)
 THREAD_FLAG = $(if $(filter yes,$($(PROJECT).threads)),-thread)
 LINK_FLAGS = $(as_needed_flags) $($(PROJECT).link_flags)
 OCAML_LINK_FLAGS=$(LINK_FLAGS:%=-cclib %)
-OCAMLMKLIB_FLAGS=$($(PROJECT).link_flags)
+OCAMLMKLIB_FLAGS_PLAIN=$($(PROJECT).link_flags)
+OCAMLMKLIB_FLAGS=$(OCAMLMKLIB_FLAGS_PLAIN:%=-ldopt %)
 OCAMLFIND_PACKAGE_FLAGS=$(patsubst %,-package %,$($(PROJECT).deps)) \
                         $(patsubst %,-thread -package threads,$(THREAD_FLAG)) \
                         $(OCAMLFIND_BISECT_FLAGS)


### PR DESCRIPTION
the output of `pkg-config --libs libffi` can contain flags that are not understood by ocamlmklib (like `-pthread`).
The previous solution ( https://github.com/ocamllabs/ocaml-ctypes/pull/428 ) passed the wrong flag to ocamlmklib (`-cclib` instead of `-ldopt`), which caused https://github.com/ocamllabs/ocaml-ctypes/issues/442 . (`-cclib` options are ignored, because ocamlmklib neither calls ocamlc nor ocamlopt at this point, just gcc/ar)