### PR TITLE
closure api: always extend integers to full word size

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -117,7 +117,11 @@ $(BUILDDIR)/xen/%.o : %.c
 
 $(BUILDDIR)/%.cmi : %.mli
 	@mkdir -p $(@D)
-	$(OCAMLFIND) opt -bin-annot -c -o $@ $(OCAMLFIND_PACKAGE_FLAGS) $(CMI_OPTS) $(OCAMLFLAGS) $(OCAMLINCLUDES) $<
+ifeq ($(BEST),native)
+	$(OCAMLFIND) ocamlopt -bin-annot -c -o $@ $(OCAMLFIND_PACKAGE_FLAGS) $(CMI_OPTS) $(OCAMLFLAGS) $(OCAMLINCLUDES) $<
+else
+	$(OCAMLFIND) ocamlc -bin-annot -c -o $@ $(OCAMLFIND_PACKAGE_FLAGS) $(CMI_OPTS) $(OCAMLFLAGS) $(OCAMLINCLUDES) $<
+endif
 
 $(BUILDDIR)/%.native : $$(NATIVE_OBJECTS) $$(C_OBJECTS)
 	$(OCAMLFIND) opt -I $(BUILDDIR) -linkpkg $(OCAMLFLAGS) $(THREAD_FLAG) $(OCAMLFIND_PACKAGE_FLAGS) $(LOCAL_CMXAS) -o $@ $(NATIVE_OBJECTS) $(C_OBJECTS) $(OCAML_LINK_FLAGS) 

--- a/Makefile.tests
+++ b/Makefile.tests
@@ -1072,6 +1072,39 @@ tests/test-threads/generated_stubs.c: $(BUILDDIR)/test-threads-stub-generator.$(
 tests/test-threads/generated_bindings.ml: $(BUILDDIR)/test-threads-stub-generator.$(BEST)
 	$< --ml-file $@
 
+test-closure-type-promotion-stubs.dir  = tests/test-closure-type-promotion/stubs
+test-closure-type-promotion-stubs.threads = yes
+test-closure-type-promotion-stubs.subproject_deps = ctypes cstubs \
+   ctypes-foreign-base ctypes-foreign-threaded tests-common
+test-closure-type-promotion-stubs: PROJECT=test-closure-type-promotion-stubs
+test-closure-type-promotion-stubs: $$(LIB_TARGETS)
+
+test-closure-type-promotion-stub-generator.dir = tests/test-closure-type-promotion/stub-generator
+test-closure-type-promotion-stub-generator.threads = yes
+test-closure-type-promotion-stub-generator.subproject_deps = ctypes cstubs \
+     ctypes-foreign-base ctypes-foreign-threaded test-closure-type-promotion-stubs tests-common
+test-closure-type-promotion-stub-generator.deps = str bigarray bytes
+test-closure-type-promotion-stub-generator: PROJECT=test-closure-type-promotion-stub-generator
+test-closure-type-promotion-stub-generator: $$(BEST_TARGET)
+
+test-closure-type-promotion.dir = tests/test-closure-type-promotion
+test-closure-type-promotion.threads = yes
+test-closure-type-promotion.deps = str bigarray oUnit bytes
+test-closure-type-promotion.subproject_deps = ctypes ctypes-foreign-base \
+  ctypes-foreign-threaded cstubs test-closure-type-promotion-stubs tests-common
+test-closure-type-promotion.link_flags = -L$(BUILDDIR)/clib -ltest_functions
+test-closure-type-promotion: PROJECT=test-closure-type-promotion
+test-closure-type-promotion: $$(BEST_TARGET)
+
+test-closure-type-promotion-generated: \
+  tests/test-closure-type-promotion/generated_bindings.ml \
+  tests/test-closure-type-promotion/generated_stubs.c
+
+tests/test-closure-type-promotion/generated_stubs.c: $(BUILDDIR)/test-closure-type-promotion-stub-generator.$(BEST)
+	$< --c-file $@
+tests/test-closure-type-promotion/generated_bindings.ml: $(BUILDDIR)/test-closure-type-promotion-stub-generator.$(BEST)
+	$< --ml-file $@
+
 TESTS =
 TESTS += test-raw
 TESTS += test-pointers-stubs test-pointers-stub-generator test-pointers-generated test-pointers
@@ -1109,6 +1142,7 @@ TESTS += test-lwt-preemptive-stubs test-lwt-preemptive-stub-generator test-lwt-p
 TESTS += test-returning-errno-lwt-jobs-stubs test-returning-errno-lwt-jobs-stub-generator test-returning-errno-lwt-jobs-generated test-returning-errno-lwt-jobs
 TESTS += test-returning-errno-lwt-preemptive-stubs test-returning-errno-lwt-preemptive-stub-generator test-returning-errno-lwt-preemptive-generated test-returning-errno-lwt-preemptive
 TESTS += test-returning-errno-stubs test-returning-errno-stub-generator test-returning-errno-generated test-returning-errno
+TESTS += test-closure-type-promotion-stubs test-closure-type-promotion-stub-generator test-closure-type-promotion-generated test-closure-type-promotion
 TESTS += test-threads-stubs test-threads-stub-generator test-threads-generated test-threads
 
 ifneq (,$(filter mingw%,$(OSYSTEM)))

--- a/tests/clib/test_functions.c
+++ b/tests/clib/test_functions.c
@@ -673,3 +673,24 @@ int callback_returns_char_a(char (*f)(void))
 {
   return f() == 'a' ? 1 : 0;
 }
+
+#define GEN_RETURN_F(type)                          \
+  type callback_returns_ ## type (type  (*f)(void)) \
+  {                                                 \
+    type x = f();                                   \
+    return x;                                       \
+  }                                                 \
+
+GEN_RETURN_F(uint8_t)
+GEN_RETURN_F(uint16_t)
+GEN_RETURN_F(uint32_t)
+GEN_RETURN_F(uint64_t)
+
+GEN_RETURN_F(int8_t)
+GEN_RETURN_F(int16_t)
+GEN_RETURN_F(int32_t)
+GEN_RETURN_F(int64_t)
+
+GEN_RETURN_F(float)
+GEN_RETURN_F(double)
+GEN_RETURN_F(bool)

--- a/tests/clib/test_functions.h
+++ b/tests/clib/test_functions.h
@@ -235,4 +235,19 @@ int sixargs(int, int, int, int, int, int);
 int return_10(void);
 
 int callback_returns_char_a(char (*)(void));
+
+uint8_t callback_returns_uint8_t(uint8_t (*f)(void));
+uint16_t callback_returns_uint16_t(uint16_t (*f)(void));
+uint32_t callback_returns_uint32_t(uint32_t (*f)(void));
+uint64_t callback_returns_uint64_t(uint64_t (*f)(void));
+
+int8_t callback_returns_int8_t(int8_t (*f)(void));
+int16_t callback_returns_int16_t(int16_t (*f)(void));
+int32_t callback_returns_int32_t(int32_t (*f)(void));
+int64_t callback_returns_int64_t(int64_t (*f)(void));
+
+float callback_returns_float(float (*f)(void));
+double callback_returns_double(double (*f)(void));
+bool callback_returns_bool(bool (*f)(void));
+
 #endif /* TEST_FUNCTIONS_H */

--- a/tests/test-closure-type-promotion/stub-generator/driver.ml
+++ b/tests/test-closure-type-promotion/stub-generator/driver.ml
@@ -1,0 +1,10 @@
+(*
+ * Copyright (c) 2014 Jeremy Yallop.
+ *
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+(* Stub generation driver for the higher order tests. *)
+
+let () = Tests_common.run Sys.argv (module Functions.Stubs)

--- a/tests/test-closure-type-promotion/stubs/functions.ml
+++ b/tests/test-closure-type-promotion/stubs/functions.ml
@@ -1,0 +1,45 @@
+(*
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+open Ctypes
+open Foreign
+
+module Stubs (F: Cstubs.FOREIGN) =
+struct
+  open F
+  let callback_returns_int8_t = foreign "callback_returns_int8_t"
+      (funptr Ctypes.(void @-> returning int8_t) @-> returning int8_t)
+
+  let callback_returns_int16_t = foreign "callback_returns_int16_t"
+      (funptr Ctypes.(void @-> returning int16_t) @-> returning int16_t)
+
+  let callback_returns_int32_t = foreign "callback_returns_int32_t"
+      (funptr Ctypes.(void @-> returning int32_t) @-> returning int32_t)
+
+  let callback_returns_int64_t = foreign "callback_returns_int64_t"
+      (funptr Ctypes.(void @-> returning int64_t) @-> returning int64_t)
+
+  let callback_returns_uint8_t = foreign "callback_returns_uint8_t"
+      (funptr Ctypes.(void @-> returning uint8_t) @-> returning uint8_t)
+
+  let callback_returns_uint16_t = foreign "callback_returns_uint16_t"
+      (funptr Ctypes.(void @-> returning uint16_t) @-> returning uint16_t)
+
+  let callback_returns_uint32_t = foreign "callback_returns_uint32_t"
+      (funptr Ctypes.(void @-> returning uint32_t) @-> returning uint32_t)
+
+  let callback_returns_uint64_t = foreign "callback_returns_uint64_t"
+      (funptr Ctypes.(void @-> returning uint64_t) @-> returning uint64_t)
+
+  let callback_returns_float = foreign "callback_returns_float"
+      (funptr Ctypes.(void @-> returning float) @-> returning float)
+
+  let callback_returns_double = foreign "callback_returns_double"
+      (funptr Ctypes.(void @-> returning double) @-> returning double)
+
+  let callback_returns_bool = foreign "callback_returns_bool"
+      (funptr Ctypes.(void @-> returning bool) @-> returning bool)
+
+end

--- a/tests/test-closure-type-promotion/test_closure_type_promotion.ml
+++ b/tests/test-closure-type-promotion/test_closure_type_promotion.ml
@@ -1,0 +1,120 @@
+(*
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+open Ctypes
+open OUnit2
+open Foreign
+
+(*
+ *  Using the closure API of libffi is error prone due to differences
+ *  in endianess and calling conventions.
+ *)
+
+module Common_tests(S : Cstubs.FOREIGN with type 'a result = 'a
+                                        and type 'a return = 'a) =
+struct
+  module M = Functions.Stubs(S)
+  open M
+
+  let test x f = assert_equal x (f (fun () -> x))
+
+  let test_signed_ints _ =
+    test 127 callback_returns_int8_t;
+    test (-128) callback_returns_int8_t;
+    test (-1) callback_returns_int8_t;
+
+    test 32767 callback_returns_int16_t;
+    test (-32768) callback_returns_int16_t;
+    test (-1) callback_returns_int16_t;
+
+    test Int32.max_int callback_returns_int32_t;
+    test Int32.min_int callback_returns_int32_t;
+    test (Int32.of_int (-1)) callback_returns_int32_t;
+
+    test Int64.max_int callback_returns_int64_t;
+    test Int64.min_int callback_returns_int64_t;
+    test (Int64.of_int (-1)) callback_returns_int64_t
+
+  let test_unsigned_ints _ =
+    test Unsigned.UInt8.max_int callback_returns_uint8_t;
+    test Unsigned.UInt8.one callback_returns_uint8_t;
+
+    test Unsigned.UInt16.max_int callback_returns_uint16_t;
+    test Unsigned.UInt16.one callback_returns_uint16_t;
+
+    test Unsigned.UInt32.max_int callback_returns_uint32_t;
+    test Unsigned.UInt32.one callback_returns_uint32_t;
+
+    test Unsigned.UInt64.max_int callback_returns_uint64_t;
+    test Unsigned.UInt64.one callback_returns_uint64_t
+
+  let float_cmp a b =
+    if a = b then 0 else
+    let abs_a = abs_float a in
+    let abs_b = abs_float b in
+    let diff = abs_float ( a -. b ) in
+    let epsilon = 1.1e-7 in
+    if diff /. (min (abs_a +. abs_b) max_float) < epsilon then 0
+    else compare a b
+
+  let test_float _ =
+    let test x =
+      assert_equal 0 (float_cmp x (callback_returns_float (fun () -> x ) ))
+    in
+    test 1.e7;
+    test 1.e-3;
+    test 3.e+38
+
+  let test_double _ =
+    let test x =
+      assert_equal 0 (float_cmp x (callback_returns_double (fun () -> x ) ))
+    in
+    test 1.e7;
+    test 1.e-3;
+    test 1.e+307
+
+  let test_bool _ =
+    test true callback_returns_bool;
+    test false callback_returns_bool
+
+end
+
+module Foreign_tests = Common_tests(Tests_common.Foreign_binder)
+module Stub_tests = Common_tests(Generated_bindings)
+
+let suite = "Closure endianess tests" >:::
+  ["test_signed_ints (foreign)"
+   >:: Foreign_tests.test_signed_ints;
+
+   "test_signed_ints (stubs)"
+   >:: Stub_tests.test_signed_ints;
+
+   "test_unsigned_ints (foreign)"
+   >:: Foreign_tests.test_unsigned_ints;
+
+   "test_unsigned_ints (stubs)"
+   >:: Stub_tests.test_unsigned_ints;
+
+   "test_float (foreign)"
+   >:: Foreign_tests.test_float;
+
+   "test_float (stubs)"
+   >:: Stub_tests.test_float;
+
+   "test_double (foreign)"
+   >:: Foreign_tests.test_double;
+
+   "test_double (stubs)"
+   >:: Stub_tests.test_double;
+
+   "test_bool (foreign)"
+   >:: Foreign_tests.test_bool;
+
+   "test_bool (stubs)"
+   >:: Stub_tests.test_bool;
+  ]
+
+let _ =
+  run_test_tt_main suite


### PR DESCRIPTION
This will fix #441 and related problems on nearly all ARM and MIPS platforms (x86 doesn't seem to be affected because of different calling conventions).

The problems are return results of closures. If integers smaller than word-size are returned, they must be extended to full word-size. But they are currently always zero-extended, never sign-extended (https://github.com/ocamllabs/ocaml-ctypes/blob/0d0c62f5b2432a49c3d0c965b8fa9d0dd50ea857/src/ctypes-foreign-base/ffi_call_stubs.c#L489 ).

The first commit contains test code to demonstrate the issue: `callback_returns_int8_t (fun () -> -128)` will sometimes return `+128`.

If one byte is set to `-128` and the higher bits are set to zero, the whole word will be read as `128`. It's not a problem for the (exclusive) foreign interface, because it's hard-coded that the higher bits are ignored. But if stub code is generated, `128` is the more likely result (it depends on the compiler and its optimization settings).
