### PR TITLE
Lwt return void

### DIFF
--- a/tests/clib/test_functions.c
+++ b/tests/clib/test_functions.c
@@ -669,6 +669,12 @@ int return_10(void)
   return 10;
 }
 
+void return_void(int *x)
+{
+  *x = 10;
+  return;
+}
+
 int callback_returns_char_a(char (*f)(void))
 {
   return f() == 'a' ? 1 : 0;

--- a/tests/clib/test_functions.h
+++ b/tests/clib/test_functions.h
@@ -233,6 +233,7 @@ void *retrieve_ocaml_value(void);
 
 int sixargs(int, int, int, int, int, int);
 int return_10(void);
+void return_void(int *);
 
 int callback_returns_char_a(char (*)(void));
 

--- a/tests/test-lwt-jobs/stubs/functions.ml
+++ b/tests/test-lwt-jobs/stubs/functions.ml
@@ -27,4 +27,7 @@ struct
 
   let return_10 = foreign "return_10"
       (void @-> returning int)
+
+  let return_void = foreign "return_void"
+      (ptr int @-> returning void)
 end

--- a/tests/test-lwt-jobs/test_lwt_jobs.ml
+++ b/tests/test-lwt-jobs/test_lwt_jobs.ml
@@ -88,6 +88,16 @@ let test_no_args _ =
      assert_equal 10 i;
      Lwt.return ())
 
+(*
+  Test calling functions that return void.
+ *)
+let test_return_void _ =
+  let open Lwt.Infix in
+  Lwt_unix.run
+    (let x_p = allocate_n ~count:1 int in
+     (Bindings.return_void x_p).Generated_bindings.lwt >>= fun () ->
+     assert_equal 10 (!@ x_p);
+     Lwt.return ())
 
 let suite = "Lwt job tests" >:::
   ["calling sqrt"
@@ -104,6 +114,9 @@ let suite = "Lwt job tests" >:::
 
    "functions with no arguments"
     >:: test_no_args;
+
+   "functions that return void"
+    >:: test_return_void;
   ]
 
 

--- a/tests/test-lwt-preemptive/stubs/functions.ml
+++ b/tests/test-lwt-preemptive/stubs/functions.ml
@@ -27,4 +27,7 @@ struct
 
   let return_10 = foreign "return_10"
       (void @-> returning int)
+
+  let return_void = foreign "return_void"
+      (ptr int @-> returning void)
 end

--- a/tests/test-lwt-preemptive/test_lwt_jobs.ml
+++ b/tests/test-lwt-preemptive/test_lwt_jobs.ml
@@ -88,6 +88,17 @@ let test_no_args _ =
      assert_equal 10 i;
      Lwt.return ())
 
+(*
+  Test calling functions that return void.
+ *)
+let test_return_void _ =
+  let open Lwt.Infix in
+  Lwt_unix.run
+    (let x_p = allocate_n ~count:1 int in
+     (Bindings.return_void x_p).Generated_bindings.lwt >>= fun () ->
+     assert_equal 10 (!@ x_p);
+     Lwt.return ())
+
 
 let suite = "Lwt job tests" >:::
   ["calling sqrt"
@@ -104,6 +115,9 @@ let suite = "Lwt job tests" >:::
 
    "functions with no arguments"
     >:: test_no_args;
+
+   "functions that return void"
+    >:: test_return_void;
   ]
 
 

--- a/tests/test-returning-errno-lwt-jobs/stubs/functions.ml
+++ b/tests/test-returning-errno-lwt-jobs/stubs/functions.ml
@@ -22,4 +22,7 @@ struct
 
   let return_10 = foreign "return_10"
       (void @-> returning int)
+
+  let return_void = foreign "return_void"
+      (ptr int @-> returning void)
 end

--- a/tests/test-returning-errno-lwt-jobs/test_returning_errno.ml
+++ b/tests/test-returning-errno-lwt-jobs/test_returning_errno.ml
@@ -53,6 +53,17 @@ let test_no_args _ =
      assert_equal 10 i;
      Lwt.return ())
 
+(*
+  Test calling functions that return void.
+ *)
+let test_return_void _ =
+  let open Lwt.Infix in
+  Lwt_unix.run
+    (let x_p = allocate_n ~count:1 int in
+     (Bindings.return_void x_p).Generated_bindings.lwt >>= fun ((), errno) ->
+     assert_equal 10 (!@ x_p);
+     Lwt.return ())
+
 
 let suite = "Errno tests" >:::
   ["calling stat"
@@ -63,6 +74,9 @@ let suite = "Errno tests" >:::
 
    "functions with no arguments"
     >:: test_no_args;
+
+   "functions that return void"
+    >:: test_return_void;
   ]
 
 

--- a/tests/test-returning-errno-lwt-preemptive/stubs/functions.ml
+++ b/tests/test-returning-errno-lwt-preemptive/stubs/functions.ml
@@ -22,4 +22,7 @@ struct
 
   let return_10 = foreign "return_10"
       (void @-> returning int)
+
+  let return_void = foreign "return_void"
+      (ptr int @-> returning void)
 end

--- a/tests/test-returning-errno-lwt-preemptive/test_returning_errno.ml
+++ b/tests/test-returning-errno-lwt-preemptive/test_returning_errno.ml
@@ -53,6 +53,17 @@ let test_no_args _ =
      assert_equal 10 i;
      Lwt.return ())
 
+(*
+  Test calling functions that return void.
+ *)
+let test_return_void _ =
+  let open Lwt.Infix in
+  Lwt_unix.run
+    (let x_p = allocate_n ~count:1 int in
+     (Bindings.return_void x_p).Generated_bindings.lwt >>= fun ((), errno) ->
+     assert_equal 10 (!@ x_p);
+     Lwt.return ())
+
 
 let suite = "Errno tests" >:::
   ["calling stat"
@@ -63,6 +74,9 @@ let suite = "Errno tests" >:::
 
    "functions with no arguments"
     >:: test_no_args;
+
+   "functions that return void"
+    >:: test_return_void;
   ]
 
 


### PR DESCRIPTION
This tests that generating lwt job bindings to void-returning functions is broken in `master` and then fixes that defect during stub generation by using `int` for the type of the lwt job `result` field (never initialized or used) and then returning `Val_unit` as the result.

This isn't the prettiest solution but it does unblock me. Please let me know if you'd like to see a different approach used, I'd (probably) be happy to accommodate.