### PR TITLE
Improved printing for tagless structs and unions

### DIFF
--- a/src/ctypes/ctypes_type_printing.ml
+++ b/src/ctypes/ctypes_type_printing.ml
@@ -26,6 +26,10 @@ let rec format_typ' : type a. a typ ->
       format_typ' ty k context fmt
     | Abstract { aname } ->
       fprintf fmt "%s%t" aname (k `nonarray)
+    | Struct { tag = "" ; fields } ->
+      fprintf fmt "struct {@;<1 2>@[";
+      format_fields fields fmt;
+      fprintf fmt "@]@;}%t" (k `nonarray)
     | Struct { tag ; spec; fields } ->
       begin match spec, context with
         | Complete _, `toplevel ->
@@ -36,6 +40,10 @@ let rec format_typ' : type a. a typ ->
           end
         | _ -> fprintf fmt "struct %s%t" tag (k `nonarray)
       end
+    | Union { utag = ""; ufields } ->
+      fprintf fmt "union {@;<1 2>@[";
+      format_fields ufields fmt;
+      fprintf fmt "@]@;}%t" (k `nonarray)
     | Union { utag; uspec; ufields } ->
       begin match uspec, context with
         | Some _, `toplevel ->

--- a/tests/test-type_printing/test_type_printing.ml
+++ b/tests/test-type_printing/test_type_printing.ml
@@ -322,6 +322,14 @@ let test_struct_and_union_printing _ =
     let _ = field inner_u "_" int in
     seal inner_u;
 
+    let anon_s = structure "" in
+    let _ = field anon_s "a" int in
+    seal anon_s;
+
+    let anon_u = union "" in
+    let _ = field anon_u "b" int in
+    seal anon_u;
+
     let struct_containing_struct = structure "scs" in
     let _ = field struct_containing_struct "inner" inner_s in
     seal struct_containing_struct;
@@ -333,6 +341,14 @@ let test_struct_and_union_printing _ =
     let struct_containing_union = structure "scu" in
     let _ = field struct_containing_union "scuf" inner_u in
     seal struct_containing_union;
+
+    let struct_containing_anonymous_struct = structure "scas" in
+    let _ = field struct_containing_anonymous_struct "scasf" anon_s in
+    seal struct_containing_anonymous_struct;
+
+    let struct_containing_anonymous_union = structure "scau" in
+    let _ = field struct_containing_anonymous_union "scauf" anon_u in
+    seal struct_containing_anonymous_union;
 
     let union_containing_union = union "ucu" in
     let _ = field union_containing_union "ucuf" inner_u in
@@ -359,6 +375,16 @@ let test_struct_and_union_printing _ =
                               union inner_u ucuf;
                            } g"
       union_containing_union;
+
+    assert_typ_printed_as "struct scas {
+                              struct { int a; } scasf;
+                           }"
+      struct_containing_anonymous_struct;
+
+    assert_typ_printed_as "struct scau {
+                              union { int b; } scauf;
+                           }"
+      struct_containing_anonymous_union;
   end
 
 


### PR DESCRIPTION
Closes #249.

Here are the examples from #249:

```ocaml
let struc = Ctypes.structure ""
let r = field struc "r" float
let g = field struc "g" float
let b = field struc "b" float
let a = field struc "a" float
let () = seal struc

let uni = union ""
let floats = field uni "rgba" (array 4 float)
let struc' = field uni "" struc
let () = seal uni

let struc'' = structure "NVGcolor"
let _ = field struc'' "" uni
let () = seal struc''
```

And here's how those types are printed before and after this change:

### Unions with tagless struct fields

#### Before

```ocaml
# uni;;
- : '_a Static.union typ = union  { float rgba[4]; struct  ;  }
```

#### After

```ocaml
# uni;;
- : '_a Ctypes_static.union typ =
union { float rgba[4]; struct { float r; float g; float b; float a;  } ;  }
```

### Structs with tagless union fields

#### Before

```ocaml
# struc'';;
- : '_a Static.structure typ = struct NVGcolor { union  ;  }
```

#### After

```ocaml
# struc'';;
- : '_a Ctypes_static.structure typ =
struct NVGcolor {
  union { float rgba[4]; struct { float r; float g; float b; float a;  } ; 
  } ; 
}
```
