### PR TITLE
Add support for binding foreign arrays

### DIFF
--- a/src/cstubs/cstubs_generate_ml.ml
+++ b/src/cstubs/cstubs_generate_ml.ml
@@ -453,6 +453,10 @@ let rec pattern_of_typ : type a. a typ -> ml_pat = function
   | View { ty } ->
     static_con "View"
       [`Record [path_of_string "CI.ty", pattern_of_typ ty]]
+  | Array (_, _) ->
+     static_con "Array" [`Underscore; `Underscore]
+  | Bigarray _ ->
+     static_con "Bigarray" [`Underscore]
   | OCaml String ->
     Ctypes_static.unsupported
       "cstubs does not support OCaml strings as global values"
@@ -465,14 +469,6 @@ let rec pattern_of_typ : type a. a typ -> ml_pat = function
   | Abstract _ as ty ->
     internal_error
       "Unexpected abstract type encountered during ML code generation: %s"
-      (Ctypes.string_of_typ ty)
-  | Array _ as ty ->
-    internal_error
-      "Unexpected array type encountered during ML code generation: %s"
-      (Ctypes.string_of_typ ty)
-  | Bigarray _ as ty ->
-    internal_error
-      "Unexpected bigarray type encountered during ML code generation: %s"
       (Ctypes.string_of_typ ty)
 
 type wrapper_state = {

--- a/tests/clib/test_functions.c
+++ b/tests/clib/test_functions.c
@@ -700,3 +700,6 @@ GEN_RETURN_F(int64_t)
 GEN_RETURN_F(float)
 GEN_RETURN_F(double)
 GEN_RETURN_F(bool)
+
+char *string_array[2] = { "Hello", "world" };
+int32_t int_array[5] = { 0, 1, 2, 3, 4 };

--- a/tests/clib/test_functions.h
+++ b/tests/clib/test_functions.h
@@ -251,4 +251,7 @@ float callback_returns_float(float (*f)(void));
 double callback_returns_double(double (*f)(void));
 bool callback_returns_bool(bool (*f)(void));
 
+extern char *string_array[2];
+extern int32_t int_array[5];
+
 #endif /* TEST_FUNCTIONS_H */

--- a/tests/test-foreign_values/stubs/functions.ml
+++ b/tests/test-foreign_values/stubs/functions.ml
@@ -25,6 +25,9 @@ struct
 
   let sum = F.(foreign "sum_range_with_plus_callback"
                  (int @-> int @-> returning int))
+
+  let string_array = F.(foreign_value "string_array" (array 2 string))
+  let int_array = F.(foreign_value "int_array" (bigarray array1 5 Bigarray.int32))
 end
 
 

--- a/tests/test-foreign_values/test_foreign_values.ml
+++ b/tests/test-foreign_values/test_foreign_values.ml
@@ -43,6 +43,24 @@ struct
 
       plus <-@ None;
     end
+
+  (* Access an array exposed as a global value *)
+  let test_retrieving_array _ =
+    let sarr = !@string_array in
+    begin
+      assert_equal "Hello" (CArray.get sarr 0);
+      assert_equal "world" (CArray.get sarr 1);
+    end;
+
+    let iarr = !@int_array in
+    begin
+      let expected_ints = Bigarray.(Array1.create int32 c_layout 5) in
+      for i = 0 to 4 do
+	Bigarray.Array1.set expected_ints i (Int32.of_int i)
+      done;
+      assert_equal expected_ints iarr
+    end
+
 end
 
 
@@ -91,8 +109,14 @@ let suite = "Foreign value tests" >:::
    "global callback function (foreign)"
     >:: Foreign_tests.test_global_callback;
 
+   "retrieving global array (foreign)"
+    >:: Foreign_tests.test_retrieving_array;
+
    "retrieving global struct (stubs)"
     >:: Stub_tests.test_retrieving_struct;
+
+   "retrieving global array (stubs)"
+    >:: Stub_tests.test_retrieving_array;
 
    "global callback function (stubs)"
     >:: Stub_tests.test_global_callback;


### PR DESCRIPTION
Fixes #469.

This PR adds support for binding accessing global array values via generated stubs.  For example, given the C value

```C
char *strings[2] = { "Hello", "world" };
```

the following OCaml expression yields a pointer to `strings` that can be used for reading and writing:

```OCaml
F.foreign "strings" (array 2 string)
```
