### PR TITLE
Add -lffi to suggested "LIBFFI_LIBS"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ test-libffi:
 	@echo " For example, if libffi is installed in /opt/local, you can type:"
 	@echo
 	@echo "   export LIBFFI_CFLAGS=-I/opt/local/include"
-	@echo "   export LIBFFI_LIBS=-L/opt/local/lib"
+	@echo "   export LIBFFI_LIBS=\"-L/opt/local/lib -lffi\""
 	@exit 1
 else:
 test-libffi:


### PR DESCRIPTION
We echo some errors and suggest the user to set "LIBFFI_LIBS" when libffi is not installed.

However, this is suggested value is inconsistent with what the build system really wants. This patch fixes it by suggesting the right value.