### PR TITLE
Makefile.rules: fix build when shared libraries are not available

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -64,7 +64,7 @@ LIB_TARGETS = $(BUILDDIR)/$(PROJECT).cma \
 ifeq ($(BEST),native)
 LIB_TARGETS += $(BUILDDIR)/$(PROJECT).cmxa
 endif
-ifneq ($(wildcard $(shell ocamlc -where)/dynlink.cmxa),)
+ifneq ($(wildcard $(shell $(OCAMLFIND) ocamlc -where)/dynlink.cmxa),)
 LIB_TARGETS += $(BUILDDIR)/$(PROJECT).cmxs
 endif
 LIB_TARGET_EXTRAS = $(if $(STUB_LIB),$(BUILDDIR)/lib$(PROJECT)_stubs.a) \


### PR DESCRIPTION
I mean cross-compilation build, specifically.