### PR TITLE
Add support for tagless enums.

### DIFF
--- a/src/cstubs/cstubs.mli
+++ b/src/cstubs/cstubs.mli
@@ -29,7 +29,8 @@ sig
 
            warning: overflow in implicit constant conversion *)
 
-    val enum : string -> ?unexpected:(int64 -> 'a) -> ('a * int64 const) list -> 'a typ
+    val enum : string -> ?typedef:bool ->
+      ?unexpected:(int64 -> 'a) -> ('a * int64 const) list -> 'a typ
     (** [enum name ?unexpected alist] builds a type representation for the
         enum named [name].  The size and alignment are retrieved so that the
         resulting type can be used everywhere an integer type can be used: as
@@ -64,7 +65,17 @@ sig
         The [unexpected] function specifies the value to return in the case
         that some unexpected value is encountered -- for example, if a
         function with the return type 'enum letters' actually returns the
-        value [-1]. *)
+        value [-1].
+
+        The optional flag [typedef] specifies whether the first argument,
+        [name], indicates an tag or an alias.  If [typedef] is [false] (the
+        default) then [name] is treated as an enumeration tag:
+
+          enum letters { ... }
+
+        If [typedef] is [true] then [name] is instead treated as an alias:
+
+          typedef enum { ... } letters *)
   end
 
   module type BINDINGS = functor (F : TYPE) -> sig end

--- a/src/cstubs/cstubs_structs.mli
+++ b/src/cstubs/cstubs_structs.mli
@@ -12,7 +12,7 @@ sig
   type 'a const
   val constant : string -> 'a typ -> 'a const
 
-  val enum : string -> ?unexpected:(int64 -> 'a) -> ('a * int64 const) list -> 'a typ
+  val enum : string -> ?typedef:bool -> ?unexpected:(int64 -> 'a) -> ('a * int64 const) list -> 'a typ
 end
 
 module type BINDINGS = functor (F : TYPE) -> sig end


### PR DESCRIPTION
It's quite common in C code to create enumerations without tags, so that they can only be referred to by an alias:

```C
typedef enum {
  X,
  Y,
  Z
} xyz;
```

This PR adds support for exposing such types via an optional argument, `typedef`, to the [`enum` function](https://github.com/ocamllabs/ocaml-ctypes/blob/368e1624fe9df189e7f6f90e8b13ecbd74a05b2b/src/cstubs/cstubs.mli#L32).  The `typedef` flag indicates that the name passed to `enum` represents an alias, not an enumeration tag.  With this PR the following code exposes an enueration like `xyz` above,

```ocaml
let i64 n = constant n int64_t
let t = enum "xyz" ~typedef:true [
  `X , i64 "X";
  `Y , i64 "Y";
  `Z , i64 "Z";
]
```

Omitting the `~typedef:true` gives a binding suitable for an enumeration defined with a tag:

```C
enum xyz {
  X,
  Y,
  Z
};
```
