### PR TITLE
Add win32 depexts to ctypes-foreign.

### DIFF
--- a/ctypes-foreign.opam
+++ b/ctypes-foreign.opam
@@ -14,6 +14,7 @@ depexts: [
   [ ["fedora"] ["libffi-devel"] ]
   [ ["alpine"] ["libffi-dev"] ]
   [ ["opensuse"] ["libffi-devel"] ]
+  [ ["win32" "cygwinports"] ["libffi" "pkg-config"] ]
  ]
 tags: ["org:ocamllabs" "org:mirage"]
 post-messages: [


### PR DESCRIPTION
Cf. [opam-repository-mingw metadata](https://github.com/fdopen/opam-repository-mingw/blob/c94d3820/packages/ctypes-foreign/ctypes-foreign.0.4.0/opam#L15).