### PR TITLE
Replace usage of the "Str" module with "Re_str" from ocaml-re.

### DIFF
--- a/META
+++ b/META
@@ -1,6 +1,6 @@
 version = "0.11.3"
 description = "Combinators for binding to C libraries without writing any C."
-requires = "unix bigarray str bytes"
+requires = "unix bigarray re bytes"
 archive(byte) = "ctypes.cma"
 archive(byte, plugin) = "ctypes.cma"
 archive(byte, toploop) = "ctypes.cma ctypes-top.cma"

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ ctypes.cmi_only = ctypes_static ctypes_primitive_types ctypes_structs
 ctypes.public = unsigned signed lDouble complexL ctypes posixTypes ctypes_types
 ctypes.dir = src/ctypes
 ctypes.extra_mls = ctypes_primitives.ml
-ctypes.deps = str bigarray bytes
+ctypes.deps = re.str bigarray bytes
 ctypes.install = yes
 ctypes.install_native_objects = yes
 ifeq ($(XEN),enable)
@@ -65,7 +65,7 @@ cstubs.cmi_only = cstubs_internals
 cstubs.public = cstubs_structs cstubs cstubs_inverted
 cstubs.dir = src/cstubs
 cstubs.subproject_deps = ctypes
-cstubs.deps = str bytes
+cstubs.deps = re.str bytes
 cstubs.install = yes
 cstubs.install_native_objects = yes
 
@@ -78,7 +78,7 @@ ctypes-foreign-base.install = yes
 ctypes-foreign-base.install_native_objects = yes
 ctypes-foreign-base.threads = no
 ctypes-foreign-base.dir = src/ctypes-foreign-base
-ctypes-foreign-base.deps = bytes
+ctypes-foreign-base.deps = re.str bytes
 ctypes-foreign-base.subproject_deps = ctypes
 ctypes-foreign-base.extra_mls = libffi_abi.ml dl.ml
 ctypes-foreign-base.extra_cs = dl_stubs.c
@@ -139,15 +139,15 @@ src/ctypes-foreign-base/dl_stubs.c: src/ctypes-foreign-base/dl_stubs.c$(OS_ALT_S
 	cp $< $@
 
 src/ctypes/ctypes_primitives.ml: src/configure/extract_from_c.ml src/configure/gen_c_primitives.ml
-	$(HOSTOCAMLFIND) ocamlc -o gen_c_primitives -package str,bytes -linkpkg $^ -I src/configure
+	$(HOSTOCAMLFIND) ocamlc -o gen_c_primitives -package re.str,bytes -linkpkg $^ -I src/configure
 	./gen_c_primitives > $@ 2> gen_c_primitives.log || (rm $@ && cat gen_c_primitives.log || false)
 
 src/ctypes-foreign-base/libffi_abi.ml: src/configure/extract_from_c.ml src/configure/gen_libffi_abi.ml
-	$(HOSTOCAMLFIND) ocamlc -o gen_libffi_abi -package str,bytes -linkpkg $^ -I src/configure
+	$(HOSTOCAMLFIND) ocamlc -o gen_libffi_abi -package re.str,bytes -linkpkg $^ -I src/configure
 	./gen_libffi_abi > $@ 2> gen_c_primitives.log || (rm $@ && cat gen_c_primitives.log || false)
 
 libffi.config: src/discover/commands.mli src/discover/commands.ml src/discover/discover.ml
-	$(HOSTOCAMLFIND) ocamlc -o discover -package str,bytes -linkpkg $^ -I src/discover
+	$(HOSTOCAMLFIND) ocamlc -o discover -package re.str,bytes -linkpkg $^ -I src/discover
 	./discover -ocamlc "$(OCAMLFIND) ocamlc" > $@ || (rm $@ && false)
 
 asneeded.config:

--- a/Makefile.examples
+++ b/Makefile.examples
@@ -12,7 +12,7 @@ fts-stub-generator.install = no
 fts-stub-generator.dir = examples/fts/stub-generation/stub-generator
 fts-stub-generator.subproject_deps = ctypes cstubs \
   ctypes-foreign-base ctypes-foreign-unthreaded fts-stubs
-fts-stub-generator.deps = bytes str unix bigarray
+fts-stub-generator.deps = bytes re.str unix bigarray
 fts-stub-generator: PROJECT=fts-stub-generator
 fts-stub-generator: $$(NATIVE_TARGET)
 
@@ -20,7 +20,7 @@ fts-cmd.install = no
 fts-cmd.dir = examples/fts/stub-generation
 fts-cmd.subproject_deps = ctypes cstubs \
   ctypes-foreign-base ctypes-foreign-unthreaded fts-stubs
-fts-cmd.deps = bytes str unix bigarray
+fts-cmd.deps = bytes re.str unix bigarray
 fts-cmd.extra_mls = fts_generated.ml
 fts-cmd: CFLAGS+=-D_FILE_OFFSET_BITS=32
 fts-cmd: PROJECT=fts-cmd
@@ -33,7 +33,7 @@ examples/fts/stub-generation/fts_generated.ml: fts-stub-generator
 # subproject: fts using dynamic linking (foreign)
 fts.install = no
 fts.dir = examples/fts/foreign
-fts.deps = bytes unix bigarray str
+fts.deps = bytes unix bigarray re.str
 fts.subproject_deps = ctypes ctypes-foreign-base ctypes-foreign-unthreaded
 fts: PROJECT=fts
 fts: $$(NATIVE_TARGET)
@@ -48,14 +48,14 @@ date-stubs: $$(LIB_TARGETS)
 date-stub-generator.install = no
 date-stub-generator.dir = examples/date/stub-generation/stub-generator
 date-stub-generator.subproject_deps = ctypes cstubs date-stubs
-date-stub-generator.deps = bytes str unix bigarray
+date-stub-generator.deps = bytes re.str unix bigarray
 date-stub-generator: PROJECT=date-stub-generator
 date-stub-generator: $$(NATIVE_TARGET)
 
 date-cmd.install = no
 date-cmd.dir = examples/date/stub-generation
 date-cmd.subproject_deps = ctypes cstubs date-stubs
-date-cmd.deps = bytes str unix bigarray
+date-cmd.deps = bytes re.str unix bigarray
 date-cmd.extra_mls = date_generated.ml
 date-cmd: PROJECT=date-cmd
 date-cmd: $$(NATIVE_TARGET)
@@ -68,7 +68,7 @@ examples/date/stub-generation/date_generated.ml:
 date.install = no
 date.dir = examples/date/foreign
 date.subproject_deps = ctypes ctypes-foreign-base ctypes-foreign-unthreaded
-date.deps = bytes unix bigarray str
+date.deps = bytes unix bigarray re.str
 date: PROJECT=date
 date: $$(NATIVE_TARGET)
 
@@ -76,14 +76,14 @@ date: $$(NATIVE_TARGET)
 ncurses-stubs.install = no
 ncurses-stubs.dir = examples/ncurses/stub-generation/bindings
 ncurses-stubs.subproject_deps = ctypes cstubs
-ncurses-stubs.deps = bytes str unix bigarray
+ncurses-stubs.deps = bytes re.str unix bigarray
 ncurses-stubs: PROJECT=ncurses-stubs
 ncurses-stubs: $$(NATIVE_TARGET) $$(LIB_TARGETS)
 
 ncurses-cmd.install = no
 ncurses-cmd.dir = examples/ncurses/stub-generation
 ncurses-cmd.subproject_deps = ctypes cstubs ncurses-stubs
-ncurses-cmd.deps = bytes str unix bigarray
+ncurses-cmd.deps = bytes re.str unix bigarray
 ncurses-cmd.extra_mls = ncurses_generated.ml
 ncurses-cmd.link_flags = -lncurses
 ncurses-cmd: PROJECT=ncurses-cmd
@@ -97,7 +97,7 @@ examples/ncurses/stub-generation/ncurses_generated.ml: ncurses-stubs
 ncurses.install = no
 ncurses.dir = examples/ncurses/foreign
 ncurses.subproject_deps = ctypes ctypes-foreign-base ctypes-foreign-unthreaded
-ncurses.deps = bytes unix bigarray str
+ncurses.deps = bytes unix bigarray re.str
 ncurses.link_flags = -lncurses
 ncurses: PROJECT=ncurses
 ncurses: $$(NATIVE_TARGET)

--- a/Makefile.examples
+++ b/Makefile.examples
@@ -5,6 +5,7 @@ fts-stubs.install = no
 fts-stubs.dir = examples/fts/stub-generation/bindings
 fts-stubs.subproject_deps = ctypes cstubs \
   ctypes-foreign-base ctypes-foreign-unthreaded
+fts-stubs.deps = re.str
 fts-stubs: PROJECT=fts-stubs
 fts-stubs: $$(LIB_TARGETS)
 

--- a/Makefile.tests
+++ b/Makefile.tests
@@ -19,7 +19,7 @@ tests-common: $$(LIB_TARGETS)
 
 test-raw.dir = tests/test-raw
 test-raw.threads = yes
-test-raw.deps = bigarray oUnit str bytes
+test-raw.deps = bigarray oUnit re.str bytes
 test-raw.subproject_deps = ctypes ctypes-foreign-base ctypes-foreign-threaded
 test-raw: PROJECT=test-raw
 test-raw: $$(BEST_TARGET)
@@ -35,13 +35,13 @@ test-pointers-stub-generator.dir = tests/test-pointers/stub-generator
 test-pointers-stub-generator.threads = yes
 test-pointers-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-pointers-stubs tests-common
-test-pointers-stub-generator.deps = str bigarray bytes
+test-pointers-stub-generator.deps = re.str bigarray bytes
 test-pointers-stub-generator: PROJECT=test-pointers-stub-generator
 test-pointers-stub-generator: $$(BEST_TARGET)
 
 test-pointers.dir = tests/test-pointers
 test-pointers.threads = yes
-test-pointers.deps = str bigarray oUnit bytes
+test-pointers.deps = re.str bigarray oUnit bytes
 test-pointers.subproject_deps = ctypes ctypes-foreign-base \
   ctypes-foreign-threaded cstubs tests-common test-pointers-stubs
 test-pointers.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -68,13 +68,13 @@ test-integers-stub-generator.dir = tests/test-integers/stub-generator
 test-integers-stub-generator.threads = yes
 test-integers-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-integers-stubs tests-common
-test-integers-stub-generator.deps = str bigarray bytes
+test-integers-stub-generator.deps = re.str bigarray bytes
 test-integers-stub-generator: PROJECT=test-integers-stub-generator
 test-integers-stub-generator: $$(BEST_TARGET)
 
 test-integers.dir = tests/test-integers
 test-integers.threads = yes
-test-integers.deps = str bigarray oUnit bytes
+test-integers.deps = re.str bigarray oUnit bytes
 test-integers.subproject_deps = ctypes ctypes-foreign-base \
   ctypes-foreign-threaded cstubs tests-common test-integers-stubs
 test-integers.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -101,13 +101,13 @@ test-variadic-stub-generator.dir = tests/test-variadic/stub-generator
 test-variadic-stub-generator.threads = yes
 test-variadic-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-variadic-stubs tests-common
-test-variadic-stub-generator.deps = str bigarray bytes
+test-variadic-stub-generator.deps = re.str bigarray bytes
 test-variadic-stub-generator: PROJECT=test-variadic-stub-generator
 test-variadic-stub-generator: $$(BEST_TARGET)
 
 test-variadic.dir = tests/test-variadic
 test-variadic.threads = yes
-test-variadic.deps = str bigarray oUnit bytes
+test-variadic.deps = re.str bigarray oUnit bytes
 test-variadic.subproject_deps = ctypes ctypes-foreign-base \
   ctypes-foreign-threaded cstubs tests-common test-variadic-stubs
 test-variadic.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -134,13 +134,13 @@ test-builtins-stub-generator.dir = tests/test-builtins/stub-generator
 test-builtins-stub-generator.threads = yes
 test-builtins-stub-generator.subproject_deps = ctypes cstubs \
   test-builtins-stubs ctypes-foreign-base ctypes-foreign-threaded tests-common
-test-builtins-stub-generator.deps = str bigarray bytes
+test-builtins-stub-generator.deps = re.str bigarray bytes
 test-builtins-stub-generator: PROJECT=test-builtins-stub-generator
 test-builtins-stub-generator: $$(BEST_TARGET)
 
 test-builtins.dir = tests/test-builtins
 test-builtins.threads = yes
-test-builtins.deps = str bigarray oUnit bytes
+test-builtins.deps = re.str bigarray oUnit bytes
 test-builtins.subproject_deps = ctypes cstubs test-builtins-stubs \
   ctypes-foreign-base ctypes-foreign-threaded tests-common
 test-builtins.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -167,13 +167,13 @@ test-macros-stub-generator.dir = tests/test-macros/stub-generator
 test-macros-stub-generator.threads = yes
 test-macros-stub-generator.subproject_deps = ctypes cstubs \
   test-macros-stubs ctypes-foreign-base ctypes-foreign-threaded tests-common
-test-macros-stub-generator.deps = str bigarray bytes
+test-macros-stub-generator.deps = re.str bigarray bytes
 test-macros-stub-generator: PROJECT=test-macros-stub-generator
 test-macros-stub-generator: $$(BEST_TARGET)
 
 test-macros.dir = tests/test-macros
 test-macros.threads = yes
-test-macros.deps = str bigarray oUnit bytes
+test-macros.deps = re.str bigarray oUnit bytes
 test-macros.subproject_deps = ctypes cstubs test-macros-stubs \
   ctypes-foreign-base ctypes-foreign-threaded tests-common
 test-macros.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -201,13 +201,13 @@ test-higher_order-stub-generator.dir = tests/test-higher_order/stub-generator
 test-higher_order-stub-generator.threads = yes
 test-higher_order-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-higher_order-stubs tests-common
-test-higher_order-stub-generator.deps = str bigarray bytes
+test-higher_order-stub-generator.deps = re.str bigarray bytes
 test-higher_order-stub-generator: PROJECT=test-higher_order-stub-generator
 test-higher_order-stub-generator: $$(BEST_TARGET)
 
 test-higher_order.dir = tests/test-higher_order
 test-higher_order.threads = yes
-test-higher_order.deps = str bigarray oUnit bytes
+test-higher_order.deps = re.str bigarray oUnit bytes
 test-higher_order.subproject_deps = ctypes ctypes-foreign-base \
   ctypes-foreign-threaded cstubs test-higher_order-stubs tests-common
 test-higher_order.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -245,7 +245,7 @@ test-enums-stub-generator.threads = yes
 test-enums-stub-generator.subproject_deps = ctypes cstubs \
      test-enums-struct-stubs \
      ctypes-foreign-base ctypes-foreign-threaded test-enums-stubs tests-common
-test-enums-stub-generator.deps = str bigarray bytes
+test-enums-stub-generator.deps = re.str bigarray bytes
 test-enums-stub-generator: PROJECT=test-enums-stub-generator
 test-enums-stub-generator: $$(BEST_TARGET)
 
@@ -253,13 +253,13 @@ test-enums-struct-stub-generator.dir = tests/test-enums/struct-stub-generator
 test-enums-struct-stub-generator.threads = yes
 test-enums-struct-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-enums-struct-stubs tests-common
-test-enums-struct-stub-generator.deps = str bigarray bytes
+test-enums-struct-stub-generator.deps = re.str bigarray bytes
 test-enums-struct-stub-generator: PROJECT=test-enums-struct-stub-generator
 test-enums-struct-stub-generator: $$(BEST_TARGET)
 
 test-enums.dir = tests/test-enums
 test-enums.threads = yes
-test-enums.deps = str bigarray oUnit bytes
+test-enums.deps = re.str bigarray oUnit bytes
 test-enums.subproject_deps = ctypes ctypes-foreign-base \
   ctypes-foreign-threaded cstubs test-enums-struct-stubs test-enums-stubs tests-common
 test-enums.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -296,13 +296,13 @@ test-structs-stub-generator.dir = tests/test-structs/stub-generator
 test-structs-stub-generator.threads = yes
 test-structs-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-structs-stubs tests-common
-test-structs-stub-generator.deps = str bigarray bytes
+test-structs-stub-generator.deps = re.str bigarray bytes
 test-structs-stub-generator: PROJECT=test-structs-stub-generator
 test-structs-stub-generator: $$(BEST_TARGET)
 
 test-structs.dir = tests/test-structs
 test-structs.threads = yes
-test-structs.deps = str bigarray oUnit bytes
+test-structs.deps = re.str bigarray oUnit bytes
 test-structs.subproject_deps = ctypes ctypes-foreign-base \
   ctypes-foreign-threaded cstubs test-structs-stubs tests-common
 test-structs.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -337,13 +337,13 @@ test-constants-stub-generator.dir = tests/test-constants/stub-generator
 test-constants-stub-generator.threads = yes
 test-constants-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-constants-stubs tests-common
-test-constants-stub-generator.deps = str bigarray bytes
+test-constants-stub-generator.deps = re.str bigarray bytes
 test-constants-stub-generator: PROJECT=test-constants-stub-generator
 test-constants-stub-generator: $$(BEST_TARGET)
 
 test-constants.dir = tests/test-constants
 test-constants.threads = yes
-test-constants.deps = str bigarray oUnit bytes
+test-constants.deps = re.str bigarray oUnit bytes
 test-constants.subproject_deps = ctypes ctypes-foreign-base \
   ctypes-foreign-threaded cstubs test-constants-stubs tests-common
 test-constants.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -370,7 +370,7 @@ $(BUILDDIR)/tests/test-constants/generated_struct_stubs.c: $(BUILDDIR)/test-cons
 
 test-finalisers.dir = tests/test-finalisers
 test-finalisers.threads = yes
-test-finalisers.deps = str bigarray oUnit bytes
+test-finalisers.deps = re.str bigarray oUnit bytes
 test-finalisers.subproject_deps = ctypes ctypes-foreign-base ctypes-foreign-threaded
 test-finalisers: PROJECT=test-finalisers
 test-finalisers: $$(BEST_TARGET)
@@ -386,13 +386,13 @@ test-cstdlib-stub-generator.dir = tests/test-cstdlib/stub-generator
 test-cstdlib-stub-generator.threads = yes
 test-cstdlib-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-cstdlib-stubs tests-common
-test-cstdlib-stub-generator.deps = str bigarray bytes
+test-cstdlib-stub-generator.deps = re.str bigarray bytes
 test-cstdlib-stub-generator: PROJECT=test-cstdlib-stub-generator
 test-cstdlib-stub-generator: $$(BEST_TARGET)
 
 test-cstdlib.dir = tests/test-cstdlib
 test-cstdlib.threads = yes
-test-cstdlib.deps = str bigarray oUnit bytes
+test-cstdlib.deps = re.str bigarray oUnit bytes
 test-cstdlib.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs test-cstdlib-stubs tests-common
 test-cstdlib.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -410,7 +410,7 @@ tests/test-cstdlib/generated_bindings.ml: $(BUILDDIR)/test-cstdlib-stub-generato
 
 test-sizeof.dir = tests/test-sizeof
 test-sizeof.threads = yes
-test-sizeof.deps = str bigarray oUnit bytes
+test-sizeof.deps = re.str bigarray oUnit bytes
 test-sizeof.subproject_deps = ctypes ctypes-foreign-base ctypes-foreign-threaded
 test-sizeof: PROJECT=test-sizeof
 test-sizeof: $$(BEST_TARGET)
@@ -426,13 +426,13 @@ test-foreign_values-stub-generator.dir = tests/test-foreign_values/stub-generato
 test-foreign_values-stub-generator.threads = yes
 test-foreign_values-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-foreign_values-stubs tests-common
-test-foreign_values-stub-generator.deps = str bigarray bytes
+test-foreign_values-stub-generator.deps = re.str bigarray bytes
 test-foreign_values-stub-generator: PROJECT=test-foreign_values-stub-generator
 test-foreign_values-stub-generator: $$(BEST_TARGET)
 
 test-foreign_values.dir = tests/test-foreign_values
 test-foreign_values.threads = yes
-test-foreign_values.deps = str bigarray oUnit bytes
+test-foreign_values.deps = re.str bigarray oUnit bytes
 test-foreign_values.subproject_deps = ctypes ctypes-foreign-base \
   ctypes-foreign-threaded cstubs tests-common test-foreign_values-stubs
 test-foreign_values.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -459,13 +459,13 @@ test-unions-stub-generator.dir = tests/test-unions/stub-generator
 test-unions-stub-generator.threads = yes
 test-unions-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-unions-stubs tests-common
-test-unions-stub-generator.deps = str bigarray bytes
+test-unions-stub-generator.deps = re.str bigarray bytes
 test-unions-stub-generator: PROJECT=test-unions-stub-generator
 test-unions-stub-generator: $$(BEST_TARGET)
 
 test-unions.dir = tests/test-unions
 test-unions.threads = yes
-test-unions.deps = str bigarray oUnit bytes
+test-unions.deps = re.str bigarray oUnit bytes
 test-unions.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs test-unions-stubs tests-common
 test-unions.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -491,7 +491,7 @@ $(BUILDDIR)/tests/test-unions/generated_struct_stubs.c: $(BUILDDIR)/test-unions-
 
 test-custom_ops.dir = tests/test-custom_ops
 test-custom_ops.threads = yes
-test-custom_ops.deps = str bigarray oUnit bytes
+test-custom_ops.deps = re.str bigarray oUnit bytes
 test-custom_ops.subproject_deps = ctypes ctypes-foreign-base ctypes-foreign-threaded
 test-custom_ops: PROJECT=test-custom_ops
 test-custom_ops: $$(BEST_TARGET)
@@ -507,13 +507,13 @@ test-arrays-stub-generator.dir = tests/test-arrays/stub-generator
 test-arrays-stub-generator.threads = yes
 test-arrays-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-arrays-stubs tests-common
-test-arrays-stub-generator.deps = str bigarray bytes
+test-arrays-stub-generator.deps = re.str bigarray bytes
 test-arrays-stub-generator: PROJECT=test-arrays-stub-generator
 test-arrays-stub-generator: $$(BEST_TARGET)
 
 test-arrays.dir = tests/test-arrays
 test-arrays.threads = yes
-test-arrays.deps = str bigarray oUnit bytes
+test-arrays.deps = re.str bigarray oUnit bytes
 test-arrays.subproject_deps = ctypes ctypes-foreign-base \
   ctypes-foreign-threaded cstubs test-arrays-stubs tests-common
 test-arrays.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -531,21 +531,21 @@ tests/test-arrays/generated_bindings.ml: $(BUILDDIR)/test-arrays-stub-generator.
 
 test-foreign-errno.dir = tests/test-foreign-errno
 test-foreign-errno.threads = yes
-test-foreign-errno.deps = str bigarray oUnit bytes
+test-foreign-errno.deps = re.str bigarray oUnit bytes
 test-foreign-errno.subproject_deps = ctypes ctypes-foreign-base ctypes-foreign-threaded
 test-foreign-errno: PROJECT=test-foreign-errno
 test-foreign-errno: $$(BEST_TARGET)
 
 test-passable.dir = tests/test-passable
 test-passable.threads = yes
-test-passable.deps = str bigarray oUnit bytes
+test-passable.deps = re.str bigarray oUnit bytes
 test-passable.subproject_deps = ctypes ctypes-foreign-base ctypes-foreign-threaded cstubs
 test-passable: PROJECT=test-passable
 test-passable: $$(BEST_TARGET)
 
 test-alignment.dir = tests/test-alignment
 test-alignment.threads = yes
-test-alignment.deps = str bigarray oUnit bytes
+test-alignment.deps = re.str bigarray oUnit bytes
 test-alignment.subproject_deps = ctypes ctypes-foreign-base ctypes-foreign-threaded
 test-alignment: PROJECT=test-alignment
 test-alignment: $$(BEST_TARGET)
@@ -561,13 +561,13 @@ test-views-stub-generator.dir = tests/test-views/stub-generator
 test-views-stub-generator.threads = yes
 test-views-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-views-stubs tests-common
-test-views-stub-generator.deps = str bigarray bytes
+test-views-stub-generator.deps = re.str bigarray bytes
 test-views-stub-generator: PROJECT=test-views-stub-generator
 test-views-stub-generator: $$(BEST_TARGET)
 
 test-views.dir = tests/test-views
 test-views.threads = yes
-test-views.deps = str bigarray oUnit bytes
+test-views.deps = re.str bigarray oUnit bytes
 test-views.subproject_deps = ctypes ctypes-foreign-base ctypes-foreign-threaded cstubs test-views-stubs tests-common
 test-views.link_flags = -L$(BUILDDIR)/clib -ltest_functions
 test-views: PROJECT=test-views
@@ -593,13 +593,13 @@ test-oo_style-stub-generator.dir = tests/test-oo_style/stub-generator
 test-oo_style-stub-generator.threads = yes
 test-oo_style-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-oo_style-stubs tests-common
-test-oo_style-stub-generator.deps = str bigarray bytes
+test-oo_style-stub-generator.deps = re.str bigarray bytes
 test-oo_style-stub-generator: PROJECT=test-oo_style-stub-generator
 test-oo_style-stub-generator: $$(BEST_TARGET)
 
 test-oo_style.dir = tests/test-oo_style
 test-oo_style.threads = yes
-test-oo_style.deps = str bigarray oUnit bytes
+test-oo_style.deps = re.str bigarray oUnit bytes
 test-oo_style.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs test-oo_style-stubs tests-common
 test-oo_style.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -617,7 +617,7 @@ tests/test-oo_style/generated_bindings.ml: $(BUILDDIR)/test-oo_style-stub-genera
 
 test-marshal.dir = tests/test-marshal
 test-marshal.threads = yes
-test-marshal.deps = str bigarray oUnit bytes
+test-marshal.deps = re.str bigarray oUnit bytes
 test-marshal.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs tests-common
 test-marshal.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -626,7 +626,7 @@ test-marshal: $$(BEST_TARGET)
 
 test-type_printing.dir = tests/test-type_printing
 test-type_printing.threads = yes
-test-type_printing.deps = str bigarray oUnit bytes
+test-type_printing.deps = re.str bigarray oUnit bytes
 test-type_printing.subproject_deps = ctypes ctypes-foreign-base ctypes-foreign-threaded
 test-type_printing: PROJECT=test-type_printing
 test-type_printing: $$(BEST_TARGET)
@@ -642,13 +642,13 @@ test-value_printing-stub-generator.dir = tests/test-value_printing/stub-generato
 test-value_printing-stub-generator.threads = yes
 test-value_printing-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-value_printing-stubs tests-common
-test-value_printing-stub-generator.deps = str bigarray bytes
+test-value_printing-stub-generator.deps = re.str bigarray bytes
 test-value_printing-stub-generator: PROJECT=test-value_printing-stub-generator
 test-value_printing-stub-generator: $$(BEST_TARGET)
 
 test-value_printing.dir = tests/test-value_printing
 test-value_printing.threads = yes
-test-value_printing.deps = str bigarray oUnit bytes
+test-value_printing.deps = re.str bigarray oUnit bytes
 test-value_printing.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs tests-common test-value_printing-stubs
 test-value_printing.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -675,13 +675,13 @@ test-complex-stub-generator.dir = tests/test-complex/stub-generator
 test-complex-stub-generator.threads = yes
 test-complex-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-complex-stubs tests-common
-test-complex-stub-generator.deps = str bigarray bytes
+test-complex-stub-generator.deps = re.str bigarray bytes
 test-complex-stub-generator: PROJECT=test-complex-stub-generator
 test-complex-stub-generator: $$(BEST_TARGET)
 
 test-complex.dir = tests/test-complex
 test-complex.threads = yes
-test-complex.deps = str bigarray oUnit bytes
+test-complex.deps = re.str bigarray oUnit bytes
 test-complex.subproject_deps = ctypes ctypes-foreign-base \
   ctypes-foreign-threaded cstubs tests-common test-complex-stubs
 test-complex.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -708,13 +708,13 @@ test-bools-stub-generator.dir = tests/test-bools/stub-generator
 test-bools-stub-generator.threads = yes
 test-bools-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-bools-stubs tests-common
-test-bools-stub-generator.deps = str bigarray bytes
+test-bools-stub-generator.deps = re.str bigarray bytes
 test-bools-stub-generator: PROJECT=test-bools-stub-generator
 test-bools-stub-generator: $$(BEST_TARGET)
 
 test-bools.dir = tests/test-bools
 test-bools.threads = yes
-test-bools.deps = str bigarray oUnit bytes
+test-bools.deps = re.str bigarray oUnit bytes
 test-bools.subproject_deps = ctypes ctypes-foreign-base \
   ctypes-foreign-threaded cstubs tests-common test-bools-stubs
 test-bools.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -741,13 +741,13 @@ test-callback_lifetime-stub-generator.dir = tests/test-callback_lifetime/stub-ge
 test-callback_lifetime-stub-generator.threads = yes
 test-callback_lifetime-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-callback_lifetime-stubs tests-common
-test-callback_lifetime-stub-generator.deps = str bigarray bytes
+test-callback_lifetime-stub-generator.deps = re.str bigarray bytes
 test-callback_lifetime-stub-generator: PROJECT=test-callback_lifetime-stub-generator
 test-callback_lifetime-stub-generator: $$(BEST_TARGET)
 
 test-callback_lifetime.dir = tests/test-callback_lifetime
 test-callback_lifetime.threads = yes
-test-callback_lifetime.deps = str bigarray oUnit bytes
+test-callback_lifetime.deps = re.str bigarray oUnit bytes
 test-callback_lifetime.subproject_deps = ctypes ctypes-foreign-base \
   ctypes-foreign-threaded cstubs test-callback_lifetime-stubs tests-common
 test-callback_lifetime.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -774,13 +774,13 @@ test-lifetime-stub-generator.dir = tests/test-lifetime/stub-generator
 test-lifetime-stub-generator.threads = yes
 test-lifetime-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-lifetime-stubs tests-common
-test-lifetime-stub-generator.deps = str bigarray bytes
+test-lifetime-stub-generator.deps = re.str bigarray bytes
 test-lifetime-stub-generator: PROJECT=test-lifetime-stub-generator
 test-lifetime-stub-generator: $$(BEST_TARGET)
 
 test-lifetime.dir = tests/test-lifetime
 test-lifetime.threads = yes
-test-lifetime.deps = str bigarray oUnit bytes
+test-lifetime.deps = re.str bigarray oUnit bytes
 test-lifetime.subproject_deps = ctypes ctypes-foreign-base \
   ctypes-foreign-threaded cstubs test-lifetime-stubs tests-common
 test-lifetime.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -798,7 +798,7 @@ tests/test-lifetime/generated_bindings.ml: $(BUILDDIR)/test-lifetime-stub-genera
 
 test-stubs.dir = tests/test-stubs
 test-stubs.threads = yes
-test-stubs.deps = str bigarray oUnit bytes
+test-stubs.deps = re.str bigarray oUnit bytes
 test-stubs.subproject_deps = ctypes ctypes-foreign-base ctypes-foreign-threaded
 test-stubs: PROJECT=test-stubs
 test-stubs: $$(BEST_TARGET)
@@ -814,13 +814,13 @@ test-bigarrays-stub-generator.dir = tests/test-bigarrays/stub-generator
 test-bigarrays-stub-generator.threads = yes
 test-bigarrays-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-bigarrays-stubs tests-common
-test-bigarrays-stub-generator.deps = str bigarray bytes
+test-bigarrays-stub-generator.deps = re.str bigarray bytes
 test-bigarrays-stub-generator: PROJECT=test-bigarrays-stub-generator
 test-bigarrays-stub-generator: $$(BEST_TARGET)
 
 test-bigarrays.dir = tests/test-bigarrays
 test-bigarrays.threads = yes
-test-bigarrays.deps = str bigarray oUnit bytes
+test-bigarrays.deps = re.str bigarray oUnit bytes
 test-bigarrays.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs tests-common test-bigarrays-stubs
 test-bigarrays.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -847,13 +847,13 @@ test-coercions-stub-generator.dir = tests/test-coercions/stub-generator
 test-coercions-stub-generator.threads = yes
 test-coercions-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-coercions-stubs tests-common
-test-coercions-stub-generator.deps = str bigarray bytes
+test-coercions-stub-generator.deps = re.str bigarray bytes
 test-coercions-stub-generator: PROJECT=test-coercions-stub-generator
 test-coercions-stub-generator: $$(BEST_TARGET)
 
 test-coercions.dir = tests/test-coercions
 test-coercions.threads = yes
-test-coercions.deps = str bigarray oUnit bytes
+test-coercions.deps = re.str bigarray oUnit bytes
 test-coercions.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs tests-common test-coercions-stubs
 test-coercions.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -871,7 +871,7 @@ tests/test-coercions/generated_bindings.ml: $(BUILDDIR)/test-coercions-stub-gene
 
 test-roots.dir = tests/test-roots
 test-roots.threads = yes
-test-roots.deps = str bigarray oUnit bytes
+test-roots.deps = re.str bigarray oUnit bytes
 test-roots.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs tests-common
 test-roots.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -889,13 +889,13 @@ test-passing-ocaml-values-stub-generator.dir = tests/test-passing-ocaml-values/s
 test-passing-ocaml-values-stub-generator.threads = yes
 test-passing-ocaml-values-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-passing-ocaml-values-stubs tests-common
-test-passing-ocaml-values-stub-generator.deps = str bigarray bytes
+test-passing-ocaml-values-stub-generator.deps = re.str bigarray bytes
 test-passing-ocaml-values-stub-generator: PROJECT=test-passing-ocaml-values-stub-generator
 test-passing-ocaml-values-stub-generator: $$(BEST_TARGET)
 
 test-passing-ocaml-values.dir = tests/test-passing-ocaml-values
 test-passing-ocaml-values.threads = yes
-test-passing-ocaml-values.deps = str bigarray oUnit bytes
+test-passing-ocaml-values.deps = re.str bigarray oUnit bytes
 test-passing-ocaml-values.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs tests-common test-passing-ocaml-values-stubs
 test-passing-ocaml-values.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -922,13 +922,13 @@ test-lwt-jobs-stub-generator.dir = tests/test-lwt-jobs/stub-generator
 test-lwt-jobs-stub-generator.threads = yes
 test-lwt-jobs-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-lwt-jobs-stubs tests-common
-test-lwt-jobs-stub-generator.deps = str bigarray bytes
+test-lwt-jobs-stub-generator.deps = re.str bigarray bytes
 test-lwt-jobs-stub-generator: PROJECT=test-lwt-jobs-stub-generator
 test-lwt-jobs-stub-generator: $$(BEST_TARGET)
 
 test-lwt-jobs.dir = tests/test-lwt-jobs
 test-lwt-jobs.threads = yes
-test-lwt-jobs.deps = str bigarray oUnit bytes lwt.unix
+test-lwt-jobs.deps = re.str bigarray oUnit bytes lwt.unix
 test-lwt-jobs.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs tests-common test-lwt-jobs-stubs
 test-lwt-jobs.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -963,13 +963,13 @@ test-lwt-preemptive-stub-generator.dir = tests/test-lwt-preemptive/stub-generato
 test-lwt-preemptive-stub-generator.threads = yes
 test-lwt-preemptive-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-lwt-preemptive-stubs tests-common
-test-lwt-preemptive-stub-generator.deps = str bigarray bytes
+test-lwt-preemptive-stub-generator.deps = re.str bigarray bytes
 test-lwt-preemptive-stub-generator: PROJECT=test-lwt-preemptive-stub-generator
 test-lwt-preemptive-stub-generator: $$(BEST_TARGET)
 
 test-lwt-preemptive.dir = tests/test-lwt-preemptive
 test-lwt-preemptive.threads = yes
-test-lwt-preemptive.deps = str bigarray oUnit bytes lwt.preemptive
+test-lwt-preemptive.deps = re.str bigarray oUnit bytes lwt.preemptive
 test-lwt-preemptive.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs tests-common test-lwt-preemptive-stubs
 test-lwt-preemptive.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -1004,13 +1004,13 @@ test-returning-errno-lwt-jobs-stub-generator.dir = tests/test-returning-errno-lw
 test-returning-errno-lwt-jobs-stub-generator.threads = yes
 test-returning-errno-lwt-jobs-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-returning-errno-lwt-jobs-stubs tests-common
-test-returning-errno-lwt-jobs-stub-generator.deps = str bigarray bytes
+test-returning-errno-lwt-jobs-stub-generator.deps = re.str bigarray bytes
 test-returning-errno-lwt-jobs-stub-generator: PROJECT=test-returning-errno-lwt-jobs-stub-generator
 test-returning-errno-lwt-jobs-stub-generator: $$(BEST_TARGET)
 
 test-returning-errno-lwt-jobs.dir = tests/test-returning-errno-lwt-jobs
 test-returning-errno-lwt-jobs.threads = yes
-test-returning-errno-lwt-jobs.deps = str bigarray oUnit bytes lwt.unix
+test-returning-errno-lwt-jobs.deps = re.str bigarray oUnit bytes lwt.unix
 test-returning-errno-lwt-jobs.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs tests-common test-returning-errno-lwt-jobs-stubs
 test-returning-errno-lwt-jobs.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -1044,13 +1044,13 @@ test-returning-errno-lwt-preemptive-stub-generator.dir = tests/test-returning-er
 test-returning-errno-lwt-preemptive-stub-generator.threads = yes
 test-returning-errno-lwt-preemptive-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-returning-errno-lwt-preemptive-stubs tests-common
-test-returning-errno-lwt-preemptive-stub-generator.deps = str bigarray bytes
+test-returning-errno-lwt-preemptive-stub-generator.deps = re.str bigarray bytes
 test-returning-errno-lwt-preemptive-stub-generator: PROJECT=test-returning-errno-lwt-preemptive-stub-generator
 test-returning-errno-lwt-preemptive-stub-generator: $$(BEST_TARGET)
 
 test-returning-errno-lwt-preemptive.dir = tests/test-returning-errno-lwt-preemptive
 test-returning-errno-lwt-preemptive.threads = yes
-test-returning-errno-lwt-preemptive.deps = str bigarray oUnit bytes lwt.preemptive
+test-returning-errno-lwt-preemptive.deps = re.str bigarray oUnit bytes lwt.preemptive
 test-returning-errno-lwt-preemptive.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs tests-common test-returning-errno-lwt-preemptive-stubs
 test-returning-errno-lwt-preemptive.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -1084,13 +1084,13 @@ test-returning-errno-stub-generator.dir = tests/test-returning-errno/stub-genera
 test-returning-errno-stub-generator.threads = yes
 test-returning-errno-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-returning-errno-stubs tests-common
-test-returning-errno-stub-generator.deps = str bigarray bytes
+test-returning-errno-stub-generator.deps = re.str bigarray bytes
 test-returning-errno-stub-generator: PROJECT=test-returning-errno-stub-generator
 test-returning-errno-stub-generator: $$(BEST_TARGET)
 
 test-returning-errno.dir = tests/test-returning-errno
 test-returning-errno.threads = yes
-test-returning-errno.deps = str bigarray oUnit bytes
+test-returning-errno.deps = re.str bigarray oUnit bytes
 test-returning-errno.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs tests-common test-returning-errno-stubs
 test-returning-errno.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -1125,13 +1125,13 @@ test-threads-stub-generator.dir = tests/test-threads/stub-generator
 test-threads-stub-generator.threads = yes
 test-threads-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-threads-stubs tests-common
-test-threads-stub-generator.deps = str bigarray bytes
+test-threads-stub-generator.deps = re.str bigarray bytes
 test-threads-stub-generator: PROJECT=test-threads-stub-generator
 test-threads-stub-generator: $$(BEST_TARGET)
 
 test-threads.dir = tests/test-threads
 test-threads.threads = yes
-test-threads.deps = str bigarray oUnit bytes
+test-threads.deps = re.str bigarray oUnit bytes
 test-threads.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs tests-common test-threads-stubs
 test-threads.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -1158,13 +1158,13 @@ test-closure-type-promotion-stub-generator.dir = tests/test-closure-type-promoti
 test-closure-type-promotion-stub-generator.threads = yes
 test-closure-type-promotion-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-closure-type-promotion-stubs tests-common
-test-closure-type-promotion-stub-generator.deps = str bigarray bytes
+test-closure-type-promotion-stub-generator.deps = re.str bigarray bytes
 test-closure-type-promotion-stub-generator: PROJECT=test-closure-type-promotion-stub-generator
 test-closure-type-promotion-stub-generator: $$(BEST_TARGET)
 
 test-closure-type-promotion.dir = tests/test-closure-type-promotion
 test-closure-type-promotion.threads = yes
-test-closure-type-promotion.deps = str bigarray oUnit bytes
+test-closure-type-promotion.deps = re.str bigarray oUnit bytes
 test-closure-type-promotion.subproject_deps = ctypes ctypes-foreign-base \
   ctypes-foreign-threaded cstubs test-closure-type-promotion-stubs tests-common
 test-closure-type-promotion.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -1182,7 +1182,7 @@ tests/test-closure-type-promotion/generated_bindings.ml: $(BUILDDIR)/test-closur
 
 test-ldouble.dir = tests/test-ldouble
 test-ldouble.threads = yes
-test-ldouble.deps = str bigarray oUnit bytes
+test-ldouble.deps = re.str bigarray oUnit bytes
 test-ldouble.subproject_deps = ctypes 
 test-ldouble: PROJECT=test-ldouble
 test-ldouble: $$(BEST_TARGET)

--- a/ctypes-foreign.opam
+++ b/ctypes-foreign.opam
@@ -5,6 +5,9 @@ author: "yallop@gmail.com"
 homepage: "https://github.com/ocamllabs/ocaml-ctypes"
 dev-repo: "http://github.com/ocamllabs/ocaml-ctypes.git"
 bug-reports: "http://github.com/ocamllabs/ocaml-ctypes/issues"
+deps: [
+    "re"
+ ]
 depexts: [
   [ ["debian"] [ "libffi-dev"] ]   
   [ ["ubuntu"] [ "libffi-dev" ] ]

--- a/ctypes-foreign.opam
+++ b/ctypes-foreign.opam
@@ -5,7 +5,7 @@ author: "yallop@gmail.com"
 homepage: "https://github.com/ocamllabs/ocaml-ctypes"
 dev-repo: "http://github.com/ocamllabs/ocaml-ctypes.git"
 bug-reports: "http://github.com/ocamllabs/ocaml-ctypes/issues"
-deps: [
+depends: [
     "re"
  ]
 depexts: [

--- a/ctypes.opam
+++ b/ctypes.opam
@@ -23,6 +23,7 @@ remove: [
 ]
 depends: [
    "base-bytes"
+   "re"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
    "lwt" {test}

--- a/src/configure/extract_from_c.ml
+++ b/src/configure/extract_from_c.ml
@@ -9,7 +9,7 @@ let getenv ~default name =
   try Sys.getenv name
   with Not_found -> default
 
-let nsplit sep str = Str.(split (regexp_string sep)) str
+let nsplit sep str = Re_str.(split (regexp_string sep)) str
 
 let read_output program =
   let input_filename = Filename.temp_file "ctypes_libffi_config" ".c" in
@@ -42,7 +42,7 @@ let read_output program =
   Sys.remove output_filename;
   Bytes.to_string result
 
-let find_from haystack pos needle = Str.(search_forward (regexp_string needle) haystack pos)
+let find_from haystack pos needle = Re_str.(search_forward (regexp_string needle) haystack pos)
 
 let prefix = "BEGIN-"
 let suffix = "-END"

--- a/src/cstubs/cstubs_structs.ml
+++ b/src/cstubs/cstubs_structs.ml
@@ -21,10 +21,10 @@ module type BINDINGS = functor (F : TYPE) -> sig end
 
 let cstring s =
   (* Format a string for output as a C string literal. *)
-  let mappings = [Str.regexp "\"", "\\\"";
-                  Str.regexp "\n", "\\n"] in
+  let mappings = [Re_str.regexp "\"", "\\\"";
+                  Re_str.regexp "\n", "\\n"] in
   let escaped =
-    List.fold_left (fun s (r, r') -> Str.(global_replace r r') s) s mappings
+    List.fold_left (fun s (r, r') -> Re_str.(global_replace r r') s) s mappings
   in "\""^ escaped ^"\""
 
 let cprologue = [

--- a/src/ctypes/ctypes_path.ml
+++ b/src/ctypes/ctypes_path.ml
@@ -10,10 +10,10 @@
 type path = string list
 
 let is_uident s =
-  Str.(string_match (regexp "[A-Z][a-zA-Z0-9_]*") s 0);;
+  Re_str.(string_match (regexp "[A-Z][a-zA-Z0-9_]*") s 0);;
 
 let is_ident s =
-  Str.(string_match (regexp "[A-Za-z_][a-zA-Z0-9_]*") s 0);;
+  Re_str.(string_match (regexp "[A-Za-z_][a-zA-Z0-9_]*") s 0);;
 
 let rec is_valid_path = function
   | [] -> false
@@ -21,7 +21,7 @@ let rec is_valid_path = function
   | u :: p -> is_uident u && is_valid_path p
 
 let path_of_string s = 
-  let p = Str.(split (regexp_string ".") s) in
+  let p = Re_str.(split (regexp_string ".") s) in
   if is_valid_path p then p
   else invalid_arg "Ctypes_ident.path_of_string"
 

--- a/src/discover/commands.ml
+++ b/src/discover/commands.ml
@@ -46,7 +46,7 @@ let temp_dir = "."
    build, which uses a mixture of Windows- and Unix-style paths due to using MinGW
    to compile OCaml and Bash for the shell.
 *)
-let unixify = Str.(global_replace (regexp "\\\\") "/")
+let unixify = Re_str.(global_replace (regexp_string "\\") "/")
 
 let shell_command_results command =
   let stdout_filename = Filename.temp_file ~temp_dir "ctypes_config" ".stdout" in

--- a/src/discover/discover.ml
+++ b/src/discover/discover.ml
@@ -49,12 +49,12 @@ let is_win = Sys.os_type = "Win32"
 
 let path_sep = if is_win then ";" else ":"
 
-let split_path = Str.(split (regexp (path_sep ^ "+")))
+let split_path = Re_str.(split (regexp (path_sep ^ "+")))
 
 let ( // ) = Filename.concat
 
 (** See the comment in commands.ml *)
-let unixify = Str.(global_replace (regexp "\\") "/")
+let unixify = Re_str.(global_replace (regexp_string "\\") "/")
 
 (* +-----------------------------------------------------------------+
    | Test codes                                                      |
@@ -151,7 +151,7 @@ let test_feature name test =
    | pkg-config                                                      |
    +-----------------------------------------------------------------+ *)
 
-let split = Str.(split (regexp " +"))
+let split = Re_str.(split (regexp " +"))
 
 let brew_libffi_version flags =
   match Commands.command "brew ls libffi --versions | awk '{print $NF}'" with

--- a/tests/test-foreign_values/test_foreign_values.ml
+++ b/tests/test-foreign_values/test_foreign_values.ml
@@ -75,7 +75,7 @@ struct
   *)
   let test_environ _ =
     let parse_entry s =
-      match Str.(bounded_split (regexp "=") s 2), "" with
+      match Re_str.(bounded_split (regexp_string "=") s 2), "" with
         [k; v], _ | [k], v -> (String.uppercase k, v)
       | _ -> Printf.ksprintf failwith "Parsing %S failed" s
     in

--- a/tests/test-type_printing/test_type_printing.ml
+++ b/tests/test-type_printing/test_type_printing.ml
@@ -9,7 +9,7 @@ open OUnit2
 open Ctypes
 
 
-let strip_whitespace = Str.(global_replace (regexp "[\n ]+") "")
+let strip_whitespace = Re_str.(global_replace (regexp "[\n ]+") "")
 
 let equal_ignoring_whitespace l r =
   strip_whitespace l = strip_whitespace r

--- a/tests/test-value_printing/test_value_printing.ml
+++ b/tests/test-value_printing/test_value_printing.ml
@@ -9,7 +9,7 @@ open OUnit2
 open Ctypes
 
 
-let strip_whitespace = Str.(global_replace (regexp "[\n ]+") "")
+let strip_whitespace = Re_str.(global_replace (regexp "[\n ]+") "")
 
 let equal_ignoring_whitespace l r =
   strip_whitespace l = strip_whitespace r


### PR DESCRIPTION
Fixes #519

Note that I replaced some instances of `regexp` with `regexp_string` for correctness, including an instance in `discover.ml` where we relied on Str to treat a regex consisting of a single `\` to parse as a literal `\`:
```diff
 (** See the comment in commands.ml *)
-let unixify = Str.(global_replace (regexp "\\") "/")
+let unixify = Re_str.(global_replace (regexp_string "\\") "/")
```