### PR TITLE
Support for Fortran-layout bigarrays

### DIFF
--- a/src/cstubs/cstubs_analysis.ml
+++ b/src/cstubs/cstubs_analysis.ml
@@ -55,7 +55,7 @@ type _ alloc =
 | Alloc_funptr : _ static_funptr alloc
 | Alloc_structured : (_, _) structured alloc
 | Alloc_array : _ carray alloc
-| Alloc_bigarray : (_, 'a) Ctypes_bigarray.t -> 'a alloc
+| Alloc_bigarray : (_, 'a, _) Ctypes_bigarray.t -> 'a alloc
 | Alloc_view : ('a, 'b) view * 'b alloc -> 'a alloc
 
 type 'a allocation = [ `Noalloc of 'a noalloc | `Alloc of 'a alloc ]

--- a/src/cstubs/cstubs_internals.mli
+++ b/src/cstubs/cstubs_internals.mli
@@ -41,7 +41,7 @@ type 'a typ = 'a Ctypes_static.typ =
   | Abstract        : Ctypes_static.abstract_type      -> 'a Ctypes_static.abstract typ
   | View            : ('a, 'b) view             -> 'a typ
   | Array           : 'a typ * int              -> 'a Ctypes_static.carray typ
-  | Bigarray        : (_, 'a) Ctypes_bigarray.t -> 'a typ
+  | Bigarray        : (_, 'a, _) Ctypes_bigarray.t -> 'a typ
   | OCaml           : 'a ocaml_type             -> 'a ocaml typ
 and ('a, 'b) pointer = ('a, 'b) Ctypes_static.pointer =
   CPointer : 'a typ Ctypes_ptr.Fat.t -> ('a, [`C]) pointer

--- a/src/ctypes/ctypes.mli
+++ b/src/ctypes/ctypes.mli
@@ -46,6 +46,7 @@ type 'a bigarray_class = 'a Ctypes_static.bigarray_class
 
 val genarray :
   < element: 'a;
+    layout: Bigarray.c_layout;
     ba_repr: 'b;
     bigarray: ('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t;
     carray: 'a carray;
@@ -54,6 +55,7 @@ val genarray :
 
 val array1 :
   < element: 'a;
+    layout: Bigarray.c_layout;
     ba_repr: 'b;
     bigarray: ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t;
     carray: 'a carray;
@@ -62,6 +64,7 @@ val array1 :
 
 val array2 :
   < element: 'a;
+    layout: Bigarray.c_layout;
     ba_repr: 'b;
     bigarray: ('a, 'b, Bigarray.c_layout) Bigarray.Array2.t;
     carray: 'a carray carray;
@@ -70,6 +73,7 @@ val array2 :
 
 val array3 :
   < element: 'a;
+    layout: Bigarray.c_layout;
     ba_repr: 'b;
     bigarray: ('a, 'b, Bigarray.c_layout) Bigarray.Array3.t;
     carray: 'a carray carray carray;
@@ -338,6 +342,7 @@ end
 (** {4 Bigarray values} *)
 
 val bigarray_start : < element: 'a;
+                       layout: Bigarray.c_layout;
                        ba_repr: _;
                        bigarray: 'b;
                        carray: _;
@@ -345,6 +350,7 @@ val bigarray_start : < element: 'a;
 (** Return the address of the first element of the given Bigarray value. *)
 
 val bigarray_of_ptr : < element: 'a;
+                        layout: Bigarray.c_layout;
                         ba_repr: 'f;
                         bigarray: 'b;
                         carray: _;
@@ -355,6 +361,7 @@ val bigarray_of_ptr : < element: 'a;
     [p]. *)
 
 val array_of_bigarray : < element: _;
+                          layout: Bigarray.c_layout;
                           ba_repr: _;
                           bigarray: 'b;
                           carray: 'c;
@@ -366,6 +373,7 @@ val array_of_bigarray : < element: _;
 (** Convert a Bigarray value to a C array. *)
 
 val bigarray_of_array : < element: 'a;
+                          layout: Bigarray.c_layout;
                           ba_repr: 'f;
                           bigarray: 'b;
                           carray: 'c carray;

--- a/src/ctypes/ctypes.mli
+++ b/src/ctypes/ctypes.mli
@@ -46,36 +46,36 @@ type 'a bigarray_class = 'a Ctypes_static.bigarray_class
 
 val genarray :
   < element: 'a;
-    layout: Bigarray.c_layout;
+    layout: 'l;
     ba_repr: 'b;
-    bigarray: ('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t;
+    bigarray: ('a, 'b, 'l) Bigarray.Genarray.t;
     carray: 'a carray;
     dims: int array > bigarray_class
 (** The class of {!Bigarray.Genarray.t} values *)
 
 val array1 :
   < element: 'a;
-    layout: Bigarray.c_layout;
+    layout: 'l;
     ba_repr: 'b;
-    bigarray: ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t;
+    bigarray: ('a, 'b, 'l) Bigarray.Array1.t;
     carray: 'a carray;
     dims: int > bigarray_class
 (** The class of {!Bigarray.Array1.t} values *)
 
 val array2 :
   < element: 'a;
-    layout: Bigarray.c_layout;
+    layout: 'l;
     ba_repr: 'b;
-    bigarray: ('a, 'b, Bigarray.c_layout) Bigarray.Array2.t;
+    bigarray: ('a, 'b, 'l) Bigarray.Array2.t;
     carray: 'a carray carray;
     dims: int * int > bigarray_class
 (** The class of {!Bigarray.Array2.t} values *)
 
 val array3 :
   < element: 'a;
-    layout: Bigarray.c_layout;
+    layout: 'l;
     ba_repr: 'b;
-    bigarray: ('a, 'b, Bigarray.c_layout) Bigarray.Array3.t;
+    bigarray: ('a, 'b, 'l) Bigarray.Array3.t;
     carray: 'a carray carray carray;
     dims: int * int * int > bigarray_class
 (** The class of {!Bigarray.Array3.t} values *)
@@ -342,7 +342,7 @@ end
 (** {4 Bigarray values} *)
 
 val bigarray_start : < element: 'a;
-                       layout: Bigarray.c_layout;
+                       layout: 'l;
                        ba_repr: _;
                        bigarray: 'b;
                        carray: _;
@@ -356,9 +356,20 @@ val bigarray_of_ptr : < element: 'a;
                         carray: _;
                         dims: 'i > bigarray_class ->
     'i -> ('a, 'f) Bigarray.kind -> 'a ptr -> 'b
-(** [bigarray_of_ptr c dims k p] converts the C pointer [p] to a bigarray
-    value.  No copy is made; the bigarray references the memory pointed to by
-    [p]. *)
+(** [bigarray_of_ptr c dims k p] converts the C pointer [p] to a C-layout
+    bigarray value.  No copy is made; the bigarray references the memory
+    pointed to by [p]. *)
+
+val fortran_bigarray_of_ptr : < element: 'a;
+                                layout: Bigarray.fortran_layout;
+                                ba_repr: 'f;
+                                bigarray: 'b;
+                                carray: _;
+                                dims: 'i > bigarray_class ->
+    'i -> ('a, 'f) Bigarray.kind -> 'a ptr -> 'b
+(** [fortran_bigarray_of_ptr c dims k p] converts the C pointer [p] to a
+    Fortran-layout bigarray value.  No copy is made; the bigarray references
+    the memory pointed to by [p]. *)
 
 val array_of_bigarray : < element: _;
                           layout: Bigarray.c_layout;
@@ -379,8 +390,9 @@ val bigarray_of_array : < element: 'a;
                           carray: 'c carray;
                           dims: 'i > bigarray_class ->
     ('a, 'f) Bigarray.kind -> 'c carray -> 'b
-(** [bigarray_of_array c k a] converts the {!CArray.t} value [a] to a bigarray
-    value.  No copy is made; the result occupies the same memory as [a]. *)
+(** [bigarray_of_array c k a] converts the {!CArray.t} value [a] to a
+    C-layout bigarray value.  No copy is made; the result occupies the
+    same memory as [a]. *)
 
 (** {3 Struct and union values} *)
 

--- a/src/ctypes/ctypes_bigarray.ml
+++ b/src/ctypes/ctypes_bigarray.ml
@@ -27,39 +27,39 @@ let bigarray_kind_sizeof k = Ctypes_primitives.sizeof (prim_of_kind k)
 
 let bigarray_kind_alignment k = Ctypes_primitives.alignment (prim_of_kind k)
 
-type (_, _) dims = 
-| DimsGen : int array -> ('a, ('a, _, Bigarray.c_layout) Bigarray.Genarray.t) dims
-| Dims1 : int -> ('a, ('a, _, Bigarray.c_layout) Bigarray.Array1.t) dims
-| Dims2 : int * int -> ('a, ('a, _, Bigarray.c_layout) Bigarray.Array2.t) dims
-| Dims3 : int * int * int -> ('a, ('a, _, Bigarray.c_layout) Bigarray.Array3.t) dims
+type (_, _, _) dims =
+| DimsGen : int array -> ('a, ('a, _, 'l) Bigarray.Genarray.t, 'l) dims
+| Dims1 : int -> ('a, ('a, _, 'l) Bigarray.Array1.t, 'l) dims
+| Dims2 : int * int -> ('a, ('a, _, 'l) Bigarray.Array2.t, 'l) dims
+| Dims3 : int * int * int -> ('a, ('a, _, 'l) Bigarray.Array3.t, 'l) dims
 
-type ('a, 'b) t = ('a, 'b) dims * 'a kind
+type ('a, 'b, 'l) t = ('a, 'b, 'l) dims * 'a kind * 'l Bigarray.layout
 
-let elements : type a b. (b, a) dims -> int = function
+let elements : type a b l. (b, a, l) dims -> int = function
   | DimsGen ds -> Array.fold_left ( * ) 1 ds
   | Dims1 d -> d
   | Dims2 (d1, d2) -> d1 * d2
   | Dims3 (d1, d2, d3) -> d1 * d2 * d3
 
-let element_type (_, k) = prim_of_kind k
+let element_type (_, k, _) = prim_of_kind k
 
-let dimensions : type a b. (b, a) t -> int array = function
-| DimsGen dims, _ -> dims
-| Dims1 x, _ -> [| x |]
-| Dims2 (x, y), _ -> [| x; y |]
-| Dims3 (x, y, z), _ -> [| x; y; z |]
+let dimensions : type a b l. (b, a, l) t -> int array = function
+| DimsGen dims, _, _ -> dims
+| Dims1 x, _, _ -> [| x |]
+| Dims2 (x, y), _, _ -> [| x; y |]
+| Dims3 (x, y, z), _, _ -> [| x; y; z |]
 
-let sizeof (d, k) = elements d * bigarray_kind_sizeof k
+let sizeof (d, k, _) = elements d * bigarray_kind_sizeof k
 
-let alignment (d, k) = bigarray_kind_alignment k
+let alignment (_, k, _) = bigarray_kind_alignment k
 
-let bigarray ds k = (DimsGen ds, kind k)
-let bigarray1 d k = (Dims1 d, kind k)
-let bigarray2 d1 d2 k = (Dims2 (d1, d2), kind k)
-let bigarray3 d1 d2 d3 k = (Dims3 (d1, d2, d3), kind k)
+let bigarray ds k l = (DimsGen ds, kind k, l)
+let bigarray1 d k l = (Dims1 d, kind k, l)
+let bigarray2 d1 d2 k l = (Dims2 (d1, d2), kind k, l)
+let bigarray3 d1 d2 d3 k l = (Dims3 (d1, d2, d3), kind k, l)
 
 let path_of_string = Ctypes_path.path_of_string
-let type_name : type a b. (b, a) dims -> Ctypes_path.path = function
+let type_name : type a b l. (b, a, l) dims -> Ctypes_path.path = function
   | DimsGen _ -> path_of_string "Bigarray.Genarray.t"
   | Dims1 _ -> path_of_string "Bigarray.Array1.t"
   | Dims2 _ -> path_of_string "Bigarray.Array2.t"
@@ -106,11 +106,20 @@ let kind_type_names : type a. a kind -> _ = function
     (`Ident (path_of_string "char"),
      `Ident (path_of_string "Bigarray.int8_unsigned_elt"))
 
-let type_expression : type a b. (a, b) t -> _ =
-  fun (t, ck) ->
+(** OCaml-4.01-compatible comparison.  This can be replaced with
+    pattern matching once ctypes requires OCaml 4.02 *)
+type boxed_layout = Boxed_layout : _ Bigarray.layout -> boxed_layout
+let layout_path : type a. a Bigarray.layout -> Ctypes_path.path =
+  fun layout ->
+    if Boxed_layout layout = Boxed_layout Bigarray.c_layout
+    then path_of_string "Bigarray.c_layout"
+    else path_of_string "Bigarray.fortran_layout"
+
+let type_expression : type a b l. (a, b, l) t -> _ =
+  fun (t, ck, l) ->
   begin
     let a, b = kind_type_names ck in
-    let layout = `Ident (path_of_string "Bigarray.c_layout") in
+    let layout = `Ident (layout_path l) in
     (`Appl (type_name t, [a; b; layout])
         : [> `Ident of Ctypes_path.path
           | `Appl of Ctypes_path.path * 'a list ] as 'a)
@@ -120,13 +129,13 @@ let prim_of_kind k = prim_of_kind (kind k)
 
 let unsafe_address b = Ctypes_bigarray_stubs.address b
 
-let view : type a b. (a, b) t -> _ Ctypes_ptr.Fat.t -> b =
+let view : type a b l. (a, b, l) t -> _ Ctypes_ptr.Fat.t -> b =
   let open Ctypes_bigarray_stubs in
-  fun (dims, kind) ptr -> let ba : b = match dims with
-  | DimsGen ds -> view kind ~dims:ds ptr
-  | Dims1 d -> view1 kind ~dims:[| d |] ptr
-  | Dims2 (d1, d2) -> view2 kind ~dims:[| d1; d2 |] ptr
-  | Dims3 (d1, d2, d3) -> view3 kind ~dims:[| d1; d2; d3 |] ptr in
+  fun (dims, kind, layout) ptr -> let ba : b = match dims with
+  | DimsGen ds -> view kind ~dims:ds ptr layout
+  | Dims1 d -> view1 kind ~dims:[| d |] ptr layout
+  | Dims2 (d1, d2) -> view2 kind ~dims:[| d1; d2 |] ptr layout
+  | Dims3 (d1, d2, d3) -> view3 kind ~dims:[| d1; d2; d3 |] ptr layout in
   match Ctypes_ptr.Fat.managed ptr with
   | None -> ba
   | Some src -> Gc.finalise (fun _ -> Ctypes_memory_stubs.use_value src) ba; ba

--- a/src/ctypes/ctypes_bigarray.mli
+++ b/src/ctypes/ctypes_bigarray.mli
@@ -7,26 +7,26 @@
 
 (** {2 Types} *)
 
-type ('a, 'b) t
+type ('a, 'b, 'l) t
 (** The type of bigarray values of particular sizes.  A value of type
-    [(a, b) t] can be used to read and write values of type [b].  *)
+    [(a, b, l) t] can be used to read and write values of type [b].  *)
 
 (** {3 Type constructors} *)
 
-val bigarray : int array -> ('a, 'b) Bigarray.kind ->
-  ('a, ('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t) t
+val bigarray : int array -> ('a, 'b) Bigarray.kind -> 'l Bigarray.layout ->
+  ('a, ('a, 'b, 'l) Bigarray.Genarray.t, 'l) t
 (** Create a {!t} value for the {!Bigarray.Genarray.t} type. *)
 
-val bigarray1 : int -> ('a, 'b) Bigarray.kind ->
-  ('a, ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t) t
+val bigarray1 : int -> ('a, 'b) Bigarray.kind -> 'l Bigarray.layout ->
+  ('a, ('a, 'b, 'l) Bigarray.Array1.t, 'l) t
 (** Create a {!t} value for the {!Bigarray.Array1.t} type. *)
 
-val bigarray2 : int -> int -> ('a, 'b) Bigarray.kind ->
-  ('a, ('a, 'b, Bigarray.c_layout) Bigarray.Array2.t) t
+val bigarray2 : int -> int -> ('a, 'b) Bigarray.kind -> 'l Bigarray.layout ->
+  ('a, ('a, 'b, 'l) Bigarray.Array2.t, 'l) t
 (** Create a {!t} value for the {!Bigarray.Array2.t} type. *)
 
-val bigarray3 : int -> int -> int -> ('a, 'b) Bigarray.kind ->
-  ('a, ('a, 'b, Bigarray.c_layout) Bigarray.Array3.t) t
+val bigarray3 : int -> int -> int -> ('a, 'b) Bigarray.kind -> 'l Bigarray.layout ->
+  ('a, ('a, 'b, 'l) Bigarray.Array3.t, 'l) t
 (** Create a {!t} value for the {!Bigarray.Array3.t} type. *)
 
 val prim_of_kind : ('a, _) Bigarray.kind -> 'a Ctypes_primitive_types.prim
@@ -34,20 +34,20 @@ val prim_of_kind : ('a, _) Bigarray.kind -> 'a Ctypes_primitive_types.prim
 
 (** {3 Type eliminators} *)
 
-val sizeof : (_, _) t -> int
+val sizeof : (_, _, _) t -> int
 (** Compute the size of a bigarray type. *)
 
-val alignment : (_, _) t -> int
+val alignment : (_, _, _) t -> int
 (** Compute the alignment of a bigarray type. *)
 
-val element_type : ('a, _) t -> 'a Ctypes_primitive_types.prim
+val element_type : ('a, _, _) t -> 'a Ctypes_primitive_types.prim
 (** Compute the element type of a bigarray type. *)
 
-val dimensions : (_, _) t -> int array
+val dimensions : (_, _, _) t -> int array
 (** Compute the dimensions of a bigarray type. *)
 
-val type_expression : ('a, 'b) t -> ([> `Appl of Ctypes_path.path * 'c list
-                                     |  `Ident of Ctypes_path.path ] as 'c)
+val type_expression : ('a, 'b, 'l) t -> ([> `Appl of Ctypes_path.path * 'c list
+                                         |  `Ident of Ctypes_path.path ] as 'c)
 (** Compute a type expression that denotes a bigarray type. *)
 
 (** {2 Values} *)
@@ -59,7 +59,7 @@ val unsafe_address : 'a -> Ctypes_ptr.voidp
     reference to the OCaml object then the array might be freed, invalidating
     the address. *)
 
-val view : (_, 'a) t -> _ Ctypes_ptr.Fat.t -> 'a
+val view : (_, 'a, _) t -> _ Ctypes_ptr.Fat.t -> 'a
 (** [view b ptr] creates a bigarray view onto existing memory.
 
     If [ptr] references an OCaml object then [view] will ensure that

--- a/src/ctypes/ctypes_bigarray_stubs.ml
+++ b/src/ctypes/ctypes_bigarray_stubs.ml
@@ -34,17 +34,17 @@ external address : 'b -> Ctypes_ptr.voidp
   = "ctypes_bigarray_address"
 
 external view : 'a kind -> dims:int array -> _ Ctypes_ptr.Fat.t ->
-  ('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t
+  'l Bigarray.layout -> ('a, 'b, 'l) Bigarray.Genarray.t
   = "ctypes_bigarray_view"
 
 external view1 : 'a kind -> dims:int array -> _ Ctypes_ptr.Fat.t ->
-  ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t
+  'l Bigarray.layout -> ('a, 'b, 'l) Bigarray.Array1.t
   = "ctypes_bigarray_view"
 
 external view2 : 'a kind -> dims:int array -> _ Ctypes_ptr.Fat.t ->
-  ('a, 'b, Bigarray.c_layout) Bigarray.Array2.t
+  'l Bigarray.layout -> ('a, 'b, 'l) Bigarray.Array2.t
   = "ctypes_bigarray_view"
 
 external view3 : 'a kind -> dims:int array -> _ Ctypes_ptr.Fat.t ->
-  ('a, 'b, Bigarray.c_layout) Bigarray.Array3.t
+  'l Bigarray.layout -> ('a, 'b, 'l) Bigarray.Array3.t
   = "ctypes_bigarray_view"

--- a/src/ctypes/ctypes_bigarrays.c
+++ b/src/ctypes/ctypes_bigarrays.c
@@ -10,24 +10,33 @@
 
 #include "ctypes_raw_pointer.h"
 
+#ifndef Caml_ba_layout_val
+/* Caml_ba_layout_val was introduced when the representation of layout
+   values changed from an integer to a GADT.  Up to that point the 
+   OCaml values c_layout and fortran_layout had the same values as
+   the C constants CAML_BA_C_LAYOUT and CAML_BA_FORTRAN_LAYOUT */
+#define Caml_ba_layout_val(v) (Int_val(v))
+#endif
+
 /* address : 'b -> pointer */
 value ctypes_bigarray_address(value ba)
 {
   return CTYPES_FROM_PTR(Caml_ba_data_val(ba));
 }
 
-/* _view : ('a, 'b) kind -> dims:int array -> fatptr ->
-           ('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t */
-value ctypes_bigarray_view(value kind_, value dims_, value ptr_)
+/* _view : ('a, 'b) kind -> dims:int array -> fatptr -> 'l layout ->
+           ('a, 'b, 'l) Bigarray.Genarray.t */
+value ctypes_bigarray_view(value kind_, value dims_, value ptr_, value layout_)
 {
   int kind = Int_val(kind_);
+  int layout = Caml_ba_layout_val(layout_);
   int ndims = Wosize_val(dims_);
   intnat dims[CAML_BA_MAX_NUM_DIMS];
   int i;
   for (i = 0; i < ndims; i++) {
     dims[i] = Long_val(Field(dims_, i));
   }
-  int flags = kind | CAML_BA_C_LAYOUT | CAML_BA_EXTERNAL;
+  int flags = kind | layout | CAML_BA_EXTERNAL;
   void *data = CTYPES_ADDR_OF_FATPTR(ptr_);
   return caml_ba_alloc(flags, ndims, data, dims);
 }

--- a/src/ctypes/ctypes_memory.ml
+++ b/src/ctypes/ctypes_memory.ml
@@ -283,18 +283,18 @@ let _bigarray_start kind ba =
   let reftyp = Primitive (Ctypes_bigarray.prim_of_kind kind) in
   CPointer (Fat.make ~managed:ba ~reftyp raw_address)
 
-let bigarray_kind : type a b c d f.
+let bigarray_kind : type a b c d f l.
   < element: a;
-    layout: Bigarray.c_layout;
+    layout: l;
     ba_repr: f;
     bigarray: b;
     carray: c;
     dims: d > bigarray_class -> b -> (a, f) Bigarray.kind =
   function
-  | Genarray _ -> Genarray.kind
-  | Array1 _ -> Array1.kind
-  | Array2 _ -> Array2.kind
-  | Array3 _ -> Array3.kind
+  | Genarray -> Genarray.kind
+  | Array1 -> Array1.kind
+  | Array2 -> Array2.kind
+  | Array3 -> Array3.kind
 
 let bigarray_start spec ba = _bigarray_start (bigarray_kind spec ba) ba
 
@@ -309,47 +309,50 @@ let array_of_bigarray : type a b c d e.
     let CPointer p as element_ptr =
       bigarray_start spec ba in
     match spec with
-  | Genarray _ ->
+  | Genarray ->
     let ds = Genarray.dims ba in
     CArray.from_ptr element_ptr (Array.fold_left ( * ) 1 ds)
-  | Array1 _ ->
+  | Array1 ->
     let d = Array1.dim ba in
     CArray.from_ptr element_ptr d
-  | Array2 _ ->
+  | Array2 ->
     let d1 = Array2.dim1 ba and d2 = Array2.dim2 ba in
     CArray.from_ptr (castp (array d2 (Fat.reftype p)) element_ptr) d1
-  | Array3 _ ->
+  | Array3 ->
     let d1 = Array3.dim1 ba and d2 = Array3.dim2 ba and d3 = Array3.dim3 ba in
     CArray.from_ptr (castp (array d2 (array d3 (Fat.reftype p))) element_ptr) d1
 
-let bigarray_elements : type a b c d f.
+let bigarray_elements : type a b c d f l.
    < element: a;
-     layout: Bigarray.c_layout;
+     layout: l;
      ba_repr: f;
      bigarray: b;
      carray: c;
      dims: d > bigarray_class -> d -> int
   = fun spec dims -> match spec, dims with
-   | Genarray _, ds -> Array.fold_left ( * ) 1 ds
-   | Array1 _, d -> d
-   | Array2 _, (d1, d2) -> d1 * d2
-   | Array3 _, (d1, d2, d3) -> d1 * d2 * d3
+   | Genarray, ds -> Array.fold_left ( * ) 1 ds
+   | Array1, d -> d
+   | Array2, (d1, d2) -> d1 * d2
+   | Array3, (d1, d2, d3) -> d1 * d2 * d3
 
 let bigarray_of_ptr spec dims kind ptr =
   !@ (castp (bigarray spec dims kind) ptr)
 
-let array_dims : type a b c d f.
+let fortran_bigarray_of_ptr spec dims kind ptr =
+  !@ (castp (fortran_bigarray spec dims kind) ptr)
+
+let array_dims : type a b c d f l.
    < element: a;
-     layout: Bigarray.c_layout;
+     layout: l;
      ba_repr: f;
      bigarray: b;
      carray: c carray;
      dims: d > bigarray_class -> c carray -> d =
    let unsupported () = raise (Unsupported "taking dimensions of non-array type") in
    fun spec a -> match spec with
-   | Genarray _ -> [| a.alength |]
-   | Array1 _ -> a.alength
-   | Array2 _ ->
+   | Genarray -> [| a.alength |]
+   | Array1 -> a.alength
+   | Array2 ->
      begin match a.astart with
      | CPointer p ->
        begin match Fat.reftype p with
@@ -357,7 +360,7 @@ let array_dims : type a b c d f.
        | _ -> unsupported ()
        end
     end
-   | Array3 _ ->
+   | Array3 ->
      begin match a.astart with
      | CPointer p ->
        begin match Fat.reftype p with
@@ -370,10 +373,10 @@ let bigarray_of_array spec kind a =
   let dims = array_dims spec a in
   !@ (castp (bigarray spec dims kind) (CArray.start a))
 
-let genarray = Genarray Bigarray.c_layout
-let array1 = Array1 Bigarray.c_layout
-let array2 = Array2 Bigarray.c_layout
-let array3 = Array3 Bigarray.c_layout
+let genarray = Genarray
+let array1 = Array1
+let array2 = Array2
+let array3 = Array3
 let typ_of_bigarray_kind k = Primitive (Ctypes_bigarray.prim_of_kind k)
 
 let string_from_ptr (CPointer p) ~length:len =

--- a/src/ctypes/ctypes_static.ml
+++ b/src/ctypes/ctypes_static.ml
@@ -86,28 +86,28 @@ and _ fn =
   | Function : 'a typ * 'b fn  -> ('a -> 'b) fn
 
 type _ bigarray_class =
-  Genarray : 'l Bigarray.layout ->
+  Genarray :
   < element: 'a;
     layout: 'l;
     dims: int array;
     ba_repr: 'b;
     bigarray: ('a, 'b, 'l) Bigarray.Genarray.t;
     carray: 'a carray > bigarray_class
-| Array1 : 'l Bigarray.layout ->
+| Array1 :
   < element: 'a;
     layout: 'l;
     dims: int;
     ba_repr: 'b;
     bigarray: ('a, 'b, 'l) Bigarray.Array1.t;
     carray: 'a carray > bigarray_class
-| Array2 : 'l Bigarray.layout ->
+| Array2 :
   < element: 'a;
     layout: 'l;
     dims: int * int;
     ba_repr: 'b;
     bigarray: ('a, 'b, 'l) Bigarray.Array2.t;
     carray: 'a carray carray > bigarray_class
-| Array3 : 'l Bigarray.layout ->
+| Array3 :
   < element: 'a;
     layout: 'l;
     dims: int * int * int;
@@ -235,21 +235,26 @@ let id v = v
 let typedef old name =
   view ~format_typ:(fun k fmt -> Format.fprintf fmt "%s%t" name k)
     ~read:id ~write:id old
-let bigarray : type a b c d e.
+
+let bigarray_ : type a b c d e l.
   < element: a;
-    layout: Bigarray.c_layout;
+    layout: l;
     dims: b;
     ba_repr: c;
     bigarray: d;
-    carray: e > bigarray_class ->
-   b -> (a, c) Bigarray.kind -> d typ =
-  fun spec dims kind -> match spec with
-  | Genarray _ -> Bigarray (Ctypes_bigarray.bigarray dims kind Bigarray.c_layout)
-  | Array1 _ -> Bigarray (Ctypes_bigarray.bigarray1 dims kind Bigarray.c_layout)
-  | Array2 _ -> let d1, d2 = dims in
-                Bigarray (Ctypes_bigarray.bigarray2 d1 d2 kind Bigarray.c_layout)
-  | Array3 _ -> let d1, d2, d3 = dims in
-                Bigarray (Ctypes_bigarray.bigarray3 d1 d2 d3 kind Bigarray.c_layout)
+    carray: e > bigarray_class -> 
+   b -> (a, c) Bigarray.kind -> l Bigarray.layout -> d typ =
+  fun spec dims kind l -> match spec with
+  | Genarray -> Bigarray (Ctypes_bigarray.bigarray dims kind l)
+  | Array1 -> Bigarray (Ctypes_bigarray.bigarray1 dims kind l)
+  | Array2 -> let d1, d2 = dims in
+              Bigarray (Ctypes_bigarray.bigarray2 d1 d2 kind l)
+  | Array3 -> let d1, d2, d3 = dims in
+              Bigarray (Ctypes_bigarray.bigarray3 d1 d2 d3 kind l)
+
+let bigarray spec c k = bigarray_ spec c k Bigarray.c_layout
+let fortran_bigarray spec c k = bigarray_ spec c k Bigarray.fortran_layout
+
 let returning v =
   if not (passable v) then
     raise (Unsupported "Unsupported return type")

--- a/src/ctypes/ctypes_static.ml
+++ b/src/ctypes/ctypes_static.ml
@@ -86,29 +86,33 @@ and _ fn =
   | Function : 'a typ * 'b fn  -> ('a -> 'b) fn
 
 type _ bigarray_class =
-  Genarray :
+  Genarray : 'l Bigarray.layout ->
   < element: 'a;
+    layout: 'l;
     dims: int array;
     ba_repr: 'b;
-    bigarray: ('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t;
+    bigarray: ('a, 'b, 'l) Bigarray.Genarray.t;
     carray: 'a carray > bigarray_class
-| Array1 :
+| Array1 : 'l Bigarray.layout ->
   < element: 'a;
+    layout: 'l;
     dims: int;
     ba_repr: 'b;
-    bigarray: ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t;
+    bigarray: ('a, 'b, 'l) Bigarray.Array1.t;
     carray: 'a carray > bigarray_class
-| Array2 :
+| Array2 : 'l Bigarray.layout ->
   < element: 'a;
+    layout: 'l;
     dims: int * int;
     ba_repr: 'b;
-    bigarray: ('a, 'b, Bigarray.c_layout) Bigarray.Array2.t;
+    bigarray: ('a, 'b, 'l) Bigarray.Array2.t;
     carray: 'a carray carray > bigarray_class
-| Array3 :
+| Array3 : 'l Bigarray.layout ->
   < element: 'a;
+    layout: 'l;
     dims: int * int * int;
     ba_repr: 'b;
-    bigarray: ('a, 'b, Bigarray.c_layout) Bigarray.Array3.t;
+    bigarray: ('a, 'b, 'l) Bigarray.Array3.t;
     carray: 'a carray carray carray > bigarray_class
 
 type boxed_typ = BoxedType : 'a typ -> boxed_typ
@@ -233,18 +237,19 @@ let typedef old name =
     ~read:id ~write:id old
 let bigarray : type a b c d e.
   < element: a;
+    layout: Bigarray.c_layout;
     dims: b;
     ba_repr: c;
     bigarray: d;
     carray: e > bigarray_class ->
    b -> (a, c) Bigarray.kind -> d typ =
   fun spec dims kind -> match spec with
-  | Genarray -> Bigarray (Ctypes_bigarray.bigarray dims kind Bigarray.c_layout)
-  | Array1 -> Bigarray (Ctypes_bigarray.bigarray1 dims kind Bigarray.c_layout)
-  | Array2 -> let d1, d2 = dims in
-              Bigarray (Ctypes_bigarray.bigarray2 d1 d2 kind Bigarray.c_layout)
-  | Array3 -> let d1, d2, d3 = dims in
-              Bigarray (Ctypes_bigarray.bigarray3 d1 d2 d3 kind Bigarray.c_layout)
+  | Genarray _ -> Bigarray (Ctypes_bigarray.bigarray dims kind Bigarray.c_layout)
+  | Array1 _ -> Bigarray (Ctypes_bigarray.bigarray1 dims kind Bigarray.c_layout)
+  | Array2 _ -> let d1, d2 = dims in
+                Bigarray (Ctypes_bigarray.bigarray2 d1 d2 kind Bigarray.c_layout)
+  | Array3 _ -> let d1, d2, d3 = dims in
+                Bigarray (Ctypes_bigarray.bigarray3 d1 d2 d3 kind Bigarray.c_layout)
 let returning v =
   if not (passable v) then
     raise (Unsupported "Unsupported return type")

--- a/src/ctypes/ctypes_static.ml
+++ b/src/ctypes/ctypes_static.ml
@@ -42,7 +42,7 @@ type _ typ =
   | Abstract        : abstract_type      -> 'a abstract typ
   | View            : ('a, 'b) view      -> 'a typ
   | Array           : 'a typ * int       -> 'a carray typ
-  | Bigarray        : (_, 'a) Ctypes_bigarray.t
+  | Bigarray        : (_, 'a, _) Ctypes_bigarray.t
                                          -> 'a typ
   | OCaml           : 'a ocaml_type      -> 'a ocaml typ
 and 'a carray = { astart : 'a ptr; alength : int }
@@ -239,12 +239,12 @@ let bigarray : type a b c d e.
     carray: e > bigarray_class ->
    b -> (a, c) Bigarray.kind -> d typ =
   fun spec dims kind -> match spec with
-  | Genarray -> Bigarray (Ctypes_bigarray.bigarray dims kind)
-  | Array1 -> Bigarray (Ctypes_bigarray.bigarray1 dims kind)
+  | Genarray -> Bigarray (Ctypes_bigarray.bigarray dims kind Bigarray.c_layout)
+  | Array1 -> Bigarray (Ctypes_bigarray.bigarray1 dims kind Bigarray.c_layout)
   | Array2 -> let d1, d2 = dims in
-              Bigarray (Ctypes_bigarray.bigarray2 d1 d2 kind)
+              Bigarray (Ctypes_bigarray.bigarray2 d1 d2 kind Bigarray.c_layout)
   | Array3 -> let d1, d2, d3 = dims in
-              Bigarray (Ctypes_bigarray.bigarray3 d1 d2 d3 kind)
+              Bigarray (Ctypes_bigarray.bigarray3 d1 d2 d3 kind Bigarray.c_layout)
 let returning v =
   if not (passable v) then
     raise (Unsupported "Unsupported return type")

--- a/src/ctypes/ctypes_static.mli
+++ b/src/ctypes/ctypes_static.mli
@@ -78,29 +78,33 @@ and _ fn =
   | Function : 'a typ * 'b fn  -> ('a -> 'b) fn
 
 type _ bigarray_class =
-  Genarray :
+  Genarray : 'l Bigarray.layout ->
   < element: 'a;
+    layout: 'l;
     dims: int array;
     ba_repr: 'b;
-    bigarray: ('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t;
+    bigarray: ('a, 'b, 'l) Bigarray.Genarray.t;
     carray: 'a carray > bigarray_class
-| Array1 :
+| Array1 : 'l Bigarray.layout ->
   < element: 'a;
+    layout: 'l;
     dims: int;
     ba_repr: 'b;
-    bigarray: ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t;
+    bigarray: ('a, 'b, 'l) Bigarray.Array1.t;
     carray: 'a carray > bigarray_class
-| Array2 :
+| Array2 : 'l Bigarray.layout ->
   < element: 'a;
+    layout: 'l;
     dims: int * int;
     ba_repr: 'b;
-    bigarray: ('a, 'b, Bigarray.c_layout) Bigarray.Array2.t;
+    bigarray: ('a, 'b, 'l) Bigarray.Array2.t;
     carray: 'a carray carray > bigarray_class
-| Array3 :
+| Array3 : 'l Bigarray.layout ->
   < element: 'a;
+    layout: 'l;
     dims: int * int * int;
     ba_repr: 'b;
-    bigarray: ('a, 'b, Bigarray.c_layout) Bigarray.Array3.t;
+    bigarray: ('a, 'b, 'l) Bigarray.Array3.t;
     carray: 'a carray carray carray > bigarray_class
 
 type boxed_typ = BoxedType : 'a typ -> boxed_typ
@@ -158,6 +162,7 @@ val bigarray : < ba_repr : 'c;
                  bigarray : 'd;
                  carray : 'e;
                  dims : 'b;
+                 layout: Bigarray.c_layout;
                  element : 'a > bigarray_class ->
                'b -> ('a, 'c) Bigarray.kind -> 'd typ
 val returning : 'a typ -> 'a fn

--- a/src/ctypes/ctypes_static.mli
+++ b/src/ctypes/ctypes_static.mli
@@ -36,7 +36,7 @@ type _ typ =
   | Abstract        : abstract_type      -> 'a abstract typ
   | View            : ('a, 'b) view      -> 'a typ
   | Array           : 'a typ * int       -> 'a carray typ
-  | Bigarray        : (_, 'a) Ctypes_bigarray.t
+  | Bigarray        : (_, 'a, _) Ctypes_bigarray.t
                                          -> 'a typ
   | OCaml           : 'a ocaml_type      -> 'a ocaml typ
 and 'a carray = { astart : 'a ptr; alength : int }

--- a/src/ctypes/ctypes_static.mli
+++ b/src/ctypes/ctypes_static.mli
@@ -78,28 +78,28 @@ and _ fn =
   | Function : 'a typ * 'b fn  -> ('a -> 'b) fn
 
 type _ bigarray_class =
-  Genarray : 'l Bigarray.layout ->
+  Genarray :
   < element: 'a;
     layout: 'l;
     dims: int array;
     ba_repr: 'b;
     bigarray: ('a, 'b, 'l) Bigarray.Genarray.t;
     carray: 'a carray > bigarray_class
-| Array1 : 'l Bigarray.layout ->
+| Array1 :
   < element: 'a;
     layout: 'l;
     dims: int;
     ba_repr: 'b;
     bigarray: ('a, 'b, 'l) Bigarray.Array1.t;
     carray: 'a carray > bigarray_class
-| Array2 : 'l Bigarray.layout ->
+| Array2 :
   < element: 'a;
     layout: 'l;
     dims: int * int;
     ba_repr: 'b;
     bigarray: ('a, 'b, 'l) Bigarray.Array2.t;
     carray: 'a carray carray > bigarray_class
-| Array3 : 'l Bigarray.layout ->
+| Array3 :
   < element: 'a;
     layout: 'l;
     dims: int * int * int;
@@ -164,7 +164,14 @@ val bigarray : < ba_repr : 'c;
                  dims : 'b;
                  layout: Bigarray.c_layout;
                  element : 'a > bigarray_class ->
-               'b -> ('a, 'c) Bigarray.kind -> 'd typ
+  'b -> ('a, 'c) Bigarray.kind -> 'd typ
+val fortran_bigarray : < ba_repr : 'c;
+                         bigarray : 'd;
+                         carray : 'e;
+                         dims : 'b;
+                         layout: Bigarray.fortran_layout;
+                         element : 'a > bigarray_class ->
+  'b -> ('a, 'c) Bigarray.kind -> 'd typ
 val returning : 'a typ -> 'a fn
 val static_funptr : 'a fn -> 'a static_funptr typ
 val structure : string -> 'a structure typ

--- a/src/ctypes/ctypes_types.mli
+++ b/src/ctypes/ctypes_types.mli
@@ -219,6 +219,7 @@ sig
 
   val bigarray :
     < element: 'a;
+      layout: Bigarray.c_layout;
       ba_repr: 'b;
       dims: 'dims;
       bigarray: 'bigarray;

--- a/src/ctypes/ctypes_types.mli
+++ b/src/ctypes/ctypes_types.mli
@@ -225,8 +225,19 @@ sig
       bigarray: 'bigarray;
       carray: _ > Ctypes_static.bigarray_class ->
      'dims -> ('a, 'b) Bigarray.kind -> 'bigarray typ
-  (** Construct a sized bigarray type representation from a bigarray class, the
-      dimensions, and the {!Bigarray.kind}. *)
+  (** Construct a sized C-layout bigarray type representation from a bigarray
+      class, the dimensions, and the {!Bigarray.kind}. *)
+
+  val fortran_bigarray :
+    < element: 'a;
+      layout: Bigarray.fortran_layout;
+      ba_repr: 'b;
+      dims: 'dims;
+      bigarray: 'bigarray;
+      carray: _ > Ctypes_static.bigarray_class ->
+     'dims -> ('a, 'b) Bigarray.kind -> 'bigarray typ
+  (** Construct a sized Fortran-layout bigarray type representation from a
+      bigarray class, the dimensions, and the {!Bigarray.kind}. *)
 
   val typ_of_bigarray_kind : ('a, 'b) Bigarray.kind -> 'a typ
   (** [typ_of_bigarray_kind k] is the type corresponding to the Bigarray kind


### PR DESCRIPTION
This PR adds support for Fortran-layout bigarrays.

### Background: existing bigarray support in ctypes 

[Bigarrays][OCaml_Bigarray] are already closely integrated into ctypes.  For example, it is possible to 
  * store bigarrays in larger ctypes values (e.g. as struct fields or array elements)
  * pass pointers to bigarrays to C functions
  * return pointers to bigarrays from C functions
  * allocate bigarray values using ctypes
  * create bigarray values from arbitrary pointers
  * convert between bigarrays and ctypes arrays

All these features are available via a small number of operations in the interface:
  * [`bigarray`][bigarray], [`genarray`][genarray], [`array1`][array1], [`array2`][array2], [`array3`][array3] construct bigarray type descriptions
  * [`bigarray_start`][bigarray_start] and [`bigarray_of_ptr`][bigarray_of_ptr] convert between bigarrays and pointers
  * [`bigarray_of_array`][bigarray_of_array] and [`array_of_bigarray`][array_of_bigarray] convert between bigarrays and [ctypes arrays][ctypes_array]

These operations construct values that can be used with the generic ctypes functions for operating on C types and values.

### Background: bigarray type descriptions 

OCaml bigarrays are divided into several classes with distinct types: [`Array1.t`][Array.1], [`Array2.t`][Array.2], [`Array3.t`][Array.3] and [`Genarray.t`][OCaml_Genarray].  In ctypes these different types of array are all described by a single type, [`bigarray_class`][bigarray_class], which is indexed by information about the type it describes.  For example, here is the type of the description of `Array2.t`:

```ocaml
val array2 :
  < element: 'a;
    ba_repr: 'b;
    bigarray: ('a, 'b, Bigarray.c_layout) Bigarray.Array2.t;
    carray: 'a carray carray;
    dims: int * int > bigarray_class
```

The various fields of the object -- `element`, `ba_repr`, `dims`, etc. -- describe the characteristics of the `Array2.t` type.  For example, `dims: int * int` indicates that the dimensions are represented as a pair of integers (since `Array2.t` has rank 2), and `carray:`a carray carray` indicates that an `Array2.t` value can be converted to a ctypes array of arrays.

These fields are used to constrain the types of the generic bigarray operations in ctypes.  For example, here is the type of `array_of_bigarray`:

```ocaml
val array_of_bigarray : < element: _;
                          ba_repr: _;
                          bigarray: 'b;
                          carray: 'c;
                          dims: _ > bigarray_class -> 'b -> 'c
```

Since `array_of_bigarray` is parameterised by a `bigarray_class` value it can operate on any kind of bigarray.  The return type of the function, `'c` is constrained to match the value of the `carray` field in the bigarray description, and so it varies with the type of the first argument.  For example, `array_of_bigarray` can convert a rank-1 bigarray to a ctypes array:

```ocaml
# array_of_bigarray array1;;
- : ('_a, '_b, Bigarray.c_layout) Bigarray.Array1.t -> '_a carray =
<fun>
```        

or convert a rank-2 bigarray to a ctypes array of arrays:


```ocaml
# array_of_bigarray array2
- : ('_a, '_b, Bigarray.c_layout) Bigarray.Array2.t -> '_a carray carray
= <fun>
```

### Interface changes

OCaml provides [support for both C-layout (0-indexed, row-major) and Fortran-layout (1-indexed, column-major) bigarrays][OCaml_Bigarray_layout].  However, at present all of the ctypes bigarray operations only support C layout.

This PR generalizes the interface to add support for Fortran layout.  The changes fall into two classes.  First, the types of most of the bigarray operations are generalized to operate on either C-layout or Fortran-layout bigarrays.  This involves the addition of an extra field, `layout`, to the `bigarray_class` index.  For example, here is the new type of `array2`:


```ocaml
val array2 :
  < element: 'a;
    ba_repr: 'b;
    layout: 'l;
    bigarray: ('a, 'b, 'l) Bigarray.Array2.t;
    carray: 'a carray carray;
    dims: int * int > bigarray_class
```

The operations `genarray`, `array1`, `array2`, `array3` and `bigarray_start` are generalized in this way.  Second, two functions, `bigarray` and `bigarray_of_ptr`, which could not be generalized without breaking backwards compatibility now have new Fortran-layout counterparts.  These functions could not be generalized because they construct bigarray type representations or bigarray values, which requires supplying them with information about layout.  It would have been possible to add an additional `layout` parameter to the functions, but to avoid breaking existing code this PR instead adds new functions `fortran_bigarray` and `fortran_bigarray_of_ptr`.

Finally, the operations `bigarray_of_array` and `array_of_bigarray` have not been generalized, since they convert between bigarrays and ctypes arrays, which are defined as having C layout.  If necessary, it is possible to convert between Fortran-layout bigarrays and ctypes arrays in two steps, by using one of the `Bigarray` `change_layout` functions, or by a combination of `bigarray_start` and `fortran_bigarray_of_ptr`.

@nilsbecker, @berke: comments on the interface would be very welcome here, if you have time to take a look.

This closes #509.

[bigarray]: https://github.com/ocamllabs/ocaml-ctypes/blob/048b81a3f49b2498fb71e4cb2691203e5ff86fdd/src/ctypes/ctypes_types.mli#L220-L228
[genarray]: https://github.com/ocamllabs/ocaml-ctypes/blob/048b81a3f49b2498fb71e4cb2691203e5ff86fdd/src/ctypes/ctypes.mli#L47-L53
[array1]: https://github.com/ocamllabs/ocaml-ctypes/blob/048b81a3f49b2498fb71e4cb2691203e5ff86fdd/src/ctypes/ctypes.mli#L55-L61
[array2]: https://github.com/ocamllabs/ocaml-ctypes/blob/048b81a3f49b2498fb71e4cb2691203e5ff86fdd/src/ctypes/ctypes.mli#L63-L69
[array3]: https://github.com/ocamllabs/ocaml-ctypes/blob/048b81a3f49b2498fb71e4cb2691203e5ff86fdd/src/ctypes/ctypes.mli#L71-L77
[bigarray_of_array]: https://github.com/ocamllabs/ocaml-ctypes/blob/048b81a3f49b2498fb71e4cb2691203e5ff86fdd/src/ctypes/ctypes.mli#L368-L375
[bigarray_of_ptr]: https://github.com/ocamllabs/ocaml-ctypes/blob/048b81a3f49b2498fb71e4cb2691203e5ff86fdd/src/ctypes/ctypes.mli#L347-L355
[bigarray_start]: https://github.com/ocamllabs/ocaml-ctypes/blob/048b81a3f49b2498fb71e4cb2691203e5ff86fdd/src/ctypes/ctypes.mli#L340-L345
[array_of_bigarray]: https://github.com/ocamllabs/ocaml-ctypes/blob/048b81a3f49b2498fb71e4cb2691203e5ff86fdd/src/ctypes/ctypes.mli#L357-L364
[OCaml_Genarray]: https://caml.inria.fr/pub/docs/manual-ocaml/libref/Bigarray.Genarray.html
[Array.1]: https://caml.inria.fr/pub/docs/manual-ocaml/libref/Bigarray.Array1.html
[Array.2]: https://caml.inria.fr/pub/docs/manual-ocaml/libref/Bigarray.Array2.html
[Array.3]: https://caml.inria.fr/pub/docs/manual-ocaml/libref/Bigarray.Array3.html
[bigarray_class]: https://github.com/ocamllabs/ocaml-ctypes/blob/048b81a3f49b2498fb71e4cb2691203e5ff86fdd/src/ctypes/ctypes.mli#L43-L45
[OCaml_Bigarray_layout]: https://caml.inria.fr/pub/docs/manual-ocaml/libref/Bigarray.html#6_Arraylayouts
[OCaml_Bigarray]: https://caml.inria.fr/pub/docs/manual-ocaml/libref/Bigarray.html
[ctypes_array]: https://github.com/ocamllabs/ocaml-ctypes/blob/048b81a3f49b2498fb71e4cb2691203e5ff86fdd/src/ctypes/ctypes.mli#L242-L335
