### PR TITLE
Preserve intermediate values from views across foreign calls.

### DIFF
--- a/tests/test-views/stub-generator/driver.ml
+++ b/tests/test-views/stub-generator/driver.ml
@@ -9,6 +9,7 @@
 
 let cheader = "
 #include <ctype.h>
+#include <string.h>
 "
 
 let () = Tests_common.run ~cheader Sys.argv (module Functions.Stubs)

--- a/tests/test-views/stubs/functions.ml
+++ b/tests/test-views/stubs/functions.ml
@@ -28,4 +28,7 @@ struct
     (int @-> returning nullable_intptr)
   let accepting_possibly_null_funptr = foreign "accepting_possibly_null_funptr"
     (nullable_intptr @-> int @-> int @-> returning int)
+
+  let strcmp = foreign "strcmp"
+    (string @-> string @-> returning int)
 end

--- a/tests/test-views/test_views.ml
+++ b/tests/test-views/test_views.ml
@@ -84,7 +84,22 @@ struct
       assert_equal ~msg:"passing non-null function pointer obtained from C"
         6 (accepting_possibly_null_funptr (returning_funptr 1) 2 3);
     end
+
+
+  (*
+    Test that intermediate values from views are not prematurely collected.
+  *)
+  let test_intermediate_value_lifetime _ =
+    for i = 0 to 100_000 do
+      assert_equal 0
+        ~printer:(Printf.sprintf "%d")
+        (strcmp
+           (String.copy "abcdefg")
+           (String.copy "abcdefg"));
+      (* Gc.compact ();  *)
+    done
 end
+
 
 (*
   Use the nullable pointer view to view nulls as Nones.
@@ -175,6 +190,12 @@ let suite = "View tests" >:::
 
    "nullable function pointers (stubs)"
    >:: Stub_tests.test_nullable_function_pointer_view;
+
+   "intermediate value lifetime (foreign)"
+   >:: Foreign_tests.test_intermediate_value_lifetime;
+
+   "intermediate value lifetime (stubs)"
+   >:: Stub_tests.test_intermediate_value_lifetime;
 
    "nullable pointers"
     >:: test_nullable_pointer_view;


### PR DESCRIPTION
Fixes #530.