### PR TITLE
Update dependencies after unsigned/signed move.

### DIFF
--- a/.depend
+++ b/.depend
@@ -20,13 +20,13 @@ _build/examples/date/stub-generation/stub-generator/date_stub_generator.cmx : _b
 _build/examples/fts/foreign/fts_cmd.cmo : _build/src/ctypes/ctypes.cmi
 _build/examples/fts/foreign/fts_cmd.cmx : _build/src/ctypes/ctypes.cmx
 _build/examples/fts/foreign/fts.cmi : _build/src/ctypes/posixTypes.cmi _build/src/ctypes/ctypes.cmi
-_build/examples/fts/foreign/fts.cmo : _build/src/ctypes/unsigned.cmi _build/src/ctypes/posixTypes.cmi _build/src/ctypes-foreign-threaded/foreign.cmi _build/src/ctypes/ctypes_coerce.cmo _build/src/ctypes/ctypes.cmi _build/examples/fts/foreign/fts.cmi
-_build/examples/fts/foreign/fts.cmx : _build/src/ctypes/unsigned.cmx _build/src/ctypes/posixTypes.cmx _build/src/ctypes-foreign-threaded/foreign.cmx _build/src/ctypes/ctypes_coerce.cmx _build/src/ctypes/ctypes.cmx _build/examples/fts/foreign/fts.cmi
+_build/examples/fts/foreign/fts.cmo : _build/src/ctypes/posixTypes.cmi _build/src/ctypes-foreign-threaded/foreign.cmi _build/src/ctypes/ctypes_coerce.cmo _build/src/ctypes/ctypes.cmi _build/examples/fts/foreign/fts.cmi
+_build/examples/fts/foreign/fts.cmx : _build/src/ctypes/posixTypes.cmx _build/src/ctypes-foreign-threaded/foreign.cmx _build/src/ctypes/ctypes_coerce.cmx _build/src/ctypes/ctypes.cmx _build/examples/fts/foreign/fts.cmi
 _build/examples/fts/stub-generation/bindings/fts_bindings.cmo : _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs.cmi
 _build/examples/fts/stub-generation/bindings/fts_bindings.cmx : _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs.cmx
 _build/examples/fts/stub-generation/bindings/fts.cmi : _build/src/ctypes/ctypes.cmi
-_build/examples/fts/stub-generation/bindings/fts_types.cmo : _build/src/ctypes/unsigned.cmi _build/src/ctypes/posixTypes.cmi _build/src/ctypes-foreign-threaded/foreign.cmi _build/src/ctypes/ctypes_coerce.cmo _build/src/ctypes/ctypes.cmi
-_build/examples/fts/stub-generation/bindings/fts_types.cmx : _build/src/ctypes/unsigned.cmx _build/src/ctypes/posixTypes.cmx _build/src/ctypes-foreign-threaded/foreign.cmx _build/src/ctypes/ctypes_coerce.cmx _build/src/ctypes/ctypes.cmx
+_build/examples/fts/stub-generation/bindings/fts_types.cmo : _build/src/ctypes/posixTypes.cmi _build/src/ctypes-foreign-threaded/foreign.cmi _build/src/ctypes/ctypes_coerce.cmo _build/src/ctypes/ctypes.cmi
+_build/examples/fts/stub-generation/bindings/fts_types.cmx : _build/src/ctypes/posixTypes.cmx _build/src/ctypes-foreign-threaded/foreign.cmx _build/src/ctypes/ctypes_coerce.cmx _build/src/ctypes/ctypes.cmx
 _build/examples/fts/stub-generation/fts_cmd.cmo : _build/src/ctypes/ctypes.cmi
 _build/examples/fts/stub-generation/fts_cmd.cmx : _build/src/ctypes/ctypes.cmx
 _build/examples/fts/stub-generation/fts_generated.cmo : _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs_internals.cmi
@@ -56,27 +56,27 @@ _build/src/configure/gen_c_primitives.cmx :
 _build/src/configure/gen_libffi_abi.cmo :
 _build/src/configure/gen_libffi_abi.cmx :
 _build/src/cstubs/cstubs_analysis.cmi : _build/src/ctypes/ctypes_static.cmi
-_build/src/cstubs/cstubs_analysis.cmo : _build/src/ctypes/unsigned.cmi _build/src/ctypes/signed.cmi _build/src/ctypes/lDouble.cmi _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_bigarray.cmi _build/src/ctypes/complexL.cmi _build/src/cstubs/cstubs_analysis.cmi
-_build/src/cstubs/cstubs_analysis.cmx : _build/src/ctypes/unsigned.cmx _build/src/ctypes/signed.cmx _build/src/ctypes/lDouble.cmx _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_primitive_types.cmx _build/src/ctypes/ctypes_bigarray.cmx _build/src/ctypes/complexL.cmx _build/src/cstubs/cstubs_analysis.cmi
-_build/src/cstubs/cstubs_c_language.cmo : _build/src/ctypes/signed.cmi _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs_errors.cmi
-_build/src/cstubs/cstubs_c_language.cmx : _build/src/ctypes/signed.cmx _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_primitive_types.cmx _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs_errors.cmx
+_build/src/cstubs/cstubs_analysis.cmo : _build/src/ctypes/lDouble.cmi _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_bigarray.cmi _build/src/ctypes/complexL.cmi _build/src/cstubs/cstubs_analysis.cmi
+_build/src/cstubs/cstubs_analysis.cmx : _build/src/ctypes/lDouble.cmx _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_primitive_types.cmx _build/src/ctypes/ctypes_bigarray.cmx _build/src/ctypes/complexL.cmx _build/src/cstubs/cstubs_analysis.cmi
+_build/src/cstubs/cstubs_c_language.cmo : _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs_errors.cmi
+_build/src/cstubs/cstubs_c_language.cmx : _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_primitive_types.cmx _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs_errors.cmx
 _build/src/cstubs/cstubs.cmi : _build/src/ctypes/ctypes_types.cmi _build/src/ctypes/ctypes.cmi
 _build/src/cstubs/cstubs.cmo : _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs_structs.cmi _build/src/cstubs/cstubs_generate_ml.cmi _build/src/cstubs/cstubs_generate_c.cmi _build/src/cstubs/cstubs.cmi
 _build/src/cstubs/cstubs.cmx : _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs_structs.cmx _build/src/cstubs/cstubs_generate_ml.cmx _build/src/cstubs/cstubs_generate_c.cmx _build/src/cstubs/cstubs.cmi
-_build/src/cstubs/cstubs_emit_c.cmo : _build/src/ctypes/signed.cmi _build/src/ctypes/ctypes_type_printing.cmi _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs_c_language.cmo
-_build/src/cstubs/cstubs_emit_c.cmx : _build/src/ctypes/signed.cmx _build/src/ctypes/ctypes_type_printing.cmx _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs_c_language.cmx
+_build/src/cstubs/cstubs_emit_c.cmo : _build/src/ctypes/ctypes_type_printing.cmi _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs_c_language.cmo
+_build/src/cstubs/cstubs_emit_c.cmx : _build/src/ctypes/ctypes_type_printing.cmx _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs_c_language.cmx
 _build/src/cstubs/cstubs_errors.cmi :
 _build/src/cstubs/cstubs_errors.cmo : _build/src/cstubs/cstubs_errors.cmi
 _build/src/cstubs/cstubs_errors.cmx : _build/src/cstubs/cstubs_errors.cmi
 _build/src/cstubs/cstubs_generate_c.cmi : _build/src/ctypes/ctypes.cmi
-_build/src/cstubs/cstubs_generate_c.cmo : _build/src/ctypes/signed.cmi _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs_emit_c.cmo _build/src/cstubs/cstubs_c_language.cmo _build/src/cstubs/cstubs_generate_c.cmi
-_build/src/cstubs/cstubs_generate_c.cmx : _build/src/ctypes/signed.cmx _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs_emit_c.cmx _build/src/cstubs/cstubs_c_language.cmx _build/src/cstubs/cstubs_generate_c.cmi
+_build/src/cstubs/cstubs_generate_c.cmo : _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs_emit_c.cmo _build/src/cstubs/cstubs_c_language.cmo _build/src/cstubs/cstubs_generate_c.cmi
+_build/src/cstubs/cstubs_generate_c.cmx : _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs_emit_c.cmx _build/src/cstubs/cstubs_c_language.cmx _build/src/cstubs/cstubs_generate_c.cmi
 _build/src/cstubs/cstubs_generate_ml.cmi : _build/src/ctypes/ctypes.cmi
 _build/src/cstubs/cstubs_generate_ml.cmo : _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_primitive_types.cmi _build/src/cstubs/ctypes_path.cmi _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs_public_name.cmi _build/src/cstubs/cstubs_errors.cmi _build/src/cstubs/cstubs_analysis.cmi _build/src/cstubs/cstubs_generate_ml.cmi
 _build/src/cstubs/cstubs_generate_ml.cmx : _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_primitive_types.cmx _build/src/cstubs/ctypes_path.cmx _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs_public_name.cmx _build/src/cstubs/cstubs_errors.cmx _build/src/cstubs/cstubs_analysis.cmx _build/src/cstubs/cstubs_generate_ml.cmi
-_build/src/cstubs/cstubs_internals.cmi : _build/src/ctypes/unsigned.cmi _build/src/ctypes/signed.cmi _build/src/ctypes/lDouble.cmi _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_memory_stubs.cmo _build/src/ctypes/ctypes_bigarray.cmi _build/src/ctypes/ctypes.cmi _build/src/ctypes/complexL.cmi
-_build/src/cstubs/cstubs_internals.cmo : _build/src/ctypes/unsigned.cmi _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_memory_stubs.cmo _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs_internals.cmi
-_build/src/cstubs/cstubs_internals.cmx : _build/src/ctypes/unsigned.cmx _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_primitive_types.cmx _build/src/ctypes/ctypes_memory_stubs.cmx _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs_internals.cmi
+_build/src/cstubs/cstubs_internals.cmi : _build/src/ctypes/lDouble.cmi _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_memory_stubs.cmo _build/src/ctypes/ctypes_bigarray.cmi _build/src/ctypes/ctypes.cmi _build/src/ctypes/complexL.cmi
+_build/src/cstubs/cstubs_internals.cmo : _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_memory_stubs.cmo _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs_internals.cmi
+_build/src/cstubs/cstubs_internals.cmx : _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_primitive_types.cmx _build/src/ctypes/ctypes_memory_stubs.cmx _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs_internals.cmi
 _build/src/cstubs/cstubs_inverted.cmi : _build/src/ctypes/ctypes.cmi
 _build/src/cstubs/cstubs_inverted.cmo : _build/src/ctypes/ctypes_type_printing.cmi _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs_generate_ml.cmi _build/src/cstubs/cstubs_generate_c.cmi _build/src/cstubs/cstubs_inverted.cmi
 _build/src/cstubs/cstubs_inverted.cmx : _build/src/ctypes/ctypes_type_printing.cmx _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs_generate_ml.cmx _build/src/cstubs/cstubs_generate_c.cmx _build/src/cstubs/cstubs_inverted.cmi
@@ -86,6 +86,9 @@ _build/src/cstubs/cstubs_public_name.cmx : _build/src/ctypes/ctypes_primitive_ty
 _build/src/cstubs/cstubs_structs.cmi : _build/src/ctypes/ctypes_types.cmi
 _build/src/cstubs/cstubs_structs.cmo : _build/src/ctypes/ctypes_types.cmi _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_primitives.cmo _build/src/ctypes/ctypes_primitive_types.cmi _build/src/cstubs/ctypes_path.cmi _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs_public_name.cmi _build/src/cstubs/cstubs_c_language.cmo _build/src/cstubs/cstubs_structs.cmi
 _build/src/cstubs/cstubs_structs.cmx : _build/src/ctypes/ctypes_types.cmi _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_primitives.cmx _build/src/ctypes/ctypes_primitive_types.cmx _build/src/cstubs/ctypes_path.cmx _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs_public_name.cmx _build/src/cstubs/cstubs_c_language.cmx _build/src/cstubs/cstubs_structs.cmi
+_build/src/cstubs/ctypes_path.cmi :
+_build/src/cstubs/ctypes_path.cmo : _build/src/cstubs/ctypes_path.cmi
+_build/src/cstubs/ctypes_path.cmx : _build/src/cstubs/ctypes_path.cmi
 _build/src/ctypes/coerce.cmi : _build/src/ctypes/ctypes_static.cmi
 _build/src/ctypes/complexL.cmi : _build/src/ctypes/lDouble.cmi
 _build/src/ctypes/complexL.cmo : _build/src/ctypes/lDouble.cmi _build/src/ctypes/complexL.cmi
@@ -104,23 +107,20 @@ _build/src/ctypes/ctypes_memory.cmo : _build/src/ctypes/ctypes_static.cmi _build
 _build/src/ctypes/ctypes_memory.cmx : _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_roots_stubs.cmx _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_memory_stubs.cmx _build/src/ctypes/ctypes_bigarray.cmx
 _build/src/ctypes/ctypes_memory_stubs.cmo : _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitive_types.cmi
 _build/src/ctypes/ctypes_memory_stubs.cmx : _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_primitive_types.cmx
-_build/src/cstubs/ctypes_path.cmi :
-_build/src/cstubs/ctypes_path.cmo : _build/src/cstubs/ctypes_path.cmi
-_build/src/cstubs/ctypes_path.cmx : _build/src/cstubs/ctypes_path.cmi
 _build/src/ctypes/ctypes_primitives.cmo : _build/src/ctypes/ctypes_primitive_types.cmi
 _build/src/ctypes/ctypes_primitives.cmx : _build/src/ctypes/ctypes_primitive_types.cmx
-_build/src/ctypes/ctypes_primitive_types.cmi : _build/src/ctypes/unsigned.cmi _build/src/ctypes/signed.cmi _build/src/ctypes/lDouble.cmi _build/src/ctypes/complexL.cmi
-_build/src/ctypes/ctypes_primitive_types.cmo : _build/src/ctypes/unsigned.cmi _build/src/ctypes/signed.cmi _build/src/ctypes/lDouble.cmi _build/src/ctypes/complexL.cmi _build/src/ctypes/ctypes_primitive_types.cmi
-_build/src/ctypes/ctypes_primitive_types.cmx : _build/src/ctypes/unsigned.cmx _build/src/ctypes/signed.cmx _build/src/ctypes/lDouble.cmx _build/src/ctypes/complexL.cmx _build/src/ctypes/ctypes_primitive_types.cmi
-_build/src/ctypes/ctypes_ptr.cmo : _build/src/ctypes/signed.cmi
-_build/src/ctypes/ctypes_ptr.cmx : _build/src/ctypes/signed.cmx
+_build/src/ctypes/ctypes_primitive_types.cmi : _build/src/ctypes/lDouble.cmi _build/src/ctypes/complexL.cmi
+_build/src/ctypes/ctypes_primitive_types.cmo : _build/src/ctypes/lDouble.cmi _build/src/ctypes/complexL.cmi _build/src/ctypes/ctypes_primitive_types.cmi
+_build/src/ctypes/ctypes_primitive_types.cmx : _build/src/ctypes/lDouble.cmx _build/src/ctypes/complexL.cmx _build/src/ctypes/ctypes_primitive_types.cmi
+_build/src/ctypes/ctypes_ptr.cmo :
+_build/src/ctypes/ctypes_ptr.cmx :
 _build/src/ctypes/ctypes_roots_stubs.cmo : _build/src/ctypes/ctypes_ptr.cmo
 _build/src/ctypes/ctypes_roots_stubs.cmx : _build/src/ctypes/ctypes_ptr.cmx
-_build/src/ctypes/ctypes_static.cmi : _build/src/ctypes/unsigned.cmi _build/src/ctypes/signed.cmi _build/src/ctypes/lDouble.cmi _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_bigarray.cmi _build/src/ctypes/complexL.cmi
+_build/src/ctypes/ctypes_static.cmi : _build/src/ctypes/lDouble.cmi _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_bigarray.cmi _build/src/ctypes/complexL.cmi
 _build/src/ctypes/ctypes_static.cmo : _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitives.cmo _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_bigarray.cmi _build/src/ctypes/ctypes_static.cmi
 _build/src/ctypes/ctypes_static.cmx : _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_primitives.cmx _build/src/ctypes/ctypes_primitive_types.cmx _build/src/ctypes/ctypes_bigarray.cmx _build/src/ctypes/ctypes_static.cmi
-_build/src/ctypes/ctypes_std_views.cmo : _build/src/ctypes/unsigned.cmi _build/src/ctypes/signed.cmi _build/src/ctypes/ctypes_std_view_stubs.cmo _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_memory_stubs.cmo _build/src/ctypes/ctypes_memory.cmo _build/src/ctypes/ctypes_coerce.cmo
-_build/src/ctypes/ctypes_std_views.cmx : _build/src/ctypes/unsigned.cmx _build/src/ctypes/signed.cmx _build/src/ctypes/ctypes_std_view_stubs.cmx _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_memory_stubs.cmx _build/src/ctypes/ctypes_memory.cmx _build/src/ctypes/ctypes_coerce.cmx
+_build/src/ctypes/ctypes_std_views.cmo : _build/src/ctypes/ctypes_std_view_stubs.cmo _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_memory_stubs.cmo _build/src/ctypes/ctypes_memory.cmo _build/src/ctypes/ctypes_coerce.cmo
+_build/src/ctypes/ctypes_std_views.cmx : _build/src/ctypes/ctypes_std_view_stubs.cmx _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_memory_stubs.cmx _build/src/ctypes/ctypes_memory.cmx _build/src/ctypes/ctypes_coerce.cmx
 _build/src/ctypes/ctypes_std_view_stubs.cmo : _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_memory_stubs.cmo
 _build/src/ctypes/ctypes_std_view_stubs.cmx : _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_memory_stubs.cmx
 _build/src/ctypes/ctypes_structs.cmi : _build/src/ctypes/ctypes_static.cmi
@@ -132,7 +132,7 @@ _build/src/ctypes/ctypes_structs_computed.cmx : _build/src/ctypes/ctypes_static.
 _build/src/ctypes/ctypes_type_printing.cmi : _build/src/ctypes/ctypes_static.cmi
 _build/src/ctypes/ctypes_type_printing.cmo : _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_primitives.cmo _build/src/ctypes/ctypes_bigarray.cmi _build/src/ctypes/ctypes_type_printing.cmi
 _build/src/ctypes/ctypes_type_printing.cmx : _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_primitives.cmx _build/src/ctypes/ctypes_bigarray.cmx _build/src/ctypes/ctypes_type_printing.cmi
-_build/src/ctypes/ctypes_types.cmi : _build/src/ctypes/unsigned.cmi _build/src/ctypes/signed.cmi _build/src/ctypes/lDouble.cmi _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/complexL.cmi
+_build/src/ctypes/ctypes_types.cmi : _build/src/ctypes/lDouble.cmi _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/complexL.cmi
 _build/src/ctypes/ctypes_value_printing.cmo : _build/src/ctypes/ctypes_value_printing_stubs.cmo _build/src/ctypes/ctypes_type_printing.cmi _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_memory.cmo
 _build/src/ctypes/ctypes_value_printing.cmx : _build/src/ctypes/ctypes_value_printing_stubs.cmx _build/src/ctypes/ctypes_type_printing.cmx _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_memory.cmx
 _build/src/ctypes/ctypes_value_printing_stubs.cmo : _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitive_types.cmi
@@ -169,20 +169,14 @@ _build/src/ctypes-foreign-unthreaded/foreign.cmx : _build/src/ctypes-foreign-unt
 _build/src/ctypes/lDouble.cmi :
 _build/src/ctypes/lDouble.cmo : _build/src/ctypes/lDouble.cmi
 _build/src/ctypes/lDouble.cmx : _build/src/ctypes/lDouble.cmi
-_build/src/ctypes/posixTypes.cmi : _build/src/ctypes/unsigned.cmi _build/src/ctypes/signed.cmi _build/src/ctypes/ctypes.cmi
-_build/src/ctypes/posixTypes.cmo : _build/src/ctypes/unsigned.cmi _build/src/ctypes/ctypes_std_views.cmo _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes.cmi _build/src/ctypes/posixTypes.cmi
-_build/src/ctypes/posixTypes.cmx : _build/src/ctypes/unsigned.cmx _build/src/ctypes/ctypes_std_views.cmx _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes.cmx _build/src/ctypes/posixTypes.cmi
-_build/src/ctypes/signed.cmi : _build/src/ctypes/unsigned.cmi
-_build/src/ctypes/signed.cmo : _build/src/ctypes/unsigned.cmi _build/src/ctypes/signed.cmi
-_build/src/ctypes/signed.cmx : _build/src/ctypes/unsigned.cmx _build/src/ctypes/signed.cmi
-_build/src/ctypes-top/ctypes_printers.cmi : _build/src/ctypes/unsigned.cmi _build/src/ctypes/signed.cmi _build/src/ctypes/posixTypes.cmi _build/src/ctypes/lDouble.cmi _build/src/ctypes/ctypes.cmi _build/src/ctypes/complexL.cmi
-_build/src/ctypes-top/ctypes_printers.cmo : _build/src/ctypes/unsigned.cmi _build/src/ctypes/signed.cmi _build/src/ctypes/posixTypes.cmi _build/src/ctypes/lDouble.cmi _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes.cmi _build/src/ctypes/complexL.cmi _build/src/ctypes-top/ctypes_printers.cmi
-_build/src/ctypes-top/ctypes_printers.cmx : _build/src/ctypes/unsigned.cmx _build/src/ctypes/signed.cmx _build/src/ctypes/posixTypes.cmx _build/src/ctypes/lDouble.cmx _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes.cmx _build/src/ctypes/complexL.cmx _build/src/ctypes-top/ctypes_printers.cmi
+_build/src/ctypes/posixTypes.cmi : _build/src/ctypes/ctypes.cmi
+_build/src/ctypes/posixTypes.cmo : _build/src/ctypes/ctypes_std_views.cmo _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes.cmi _build/src/ctypes/posixTypes.cmi
+_build/src/ctypes/posixTypes.cmx : _build/src/ctypes/ctypes_std_views.cmx _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes.cmx _build/src/ctypes/posixTypes.cmi
+_build/src/ctypes-top/ctypes_printers.cmi : _build/src/ctypes/posixTypes.cmi _build/src/ctypes/lDouble.cmi _build/src/ctypes/ctypes.cmi _build/src/ctypes/complexL.cmi
+_build/src/ctypes-top/ctypes_printers.cmo : _build/src/ctypes/posixTypes.cmi _build/src/ctypes/lDouble.cmi _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes.cmi _build/src/ctypes/complexL.cmi _build/src/ctypes-top/ctypes_printers.cmi
+_build/src/ctypes-top/ctypes_printers.cmx : _build/src/ctypes/posixTypes.cmx _build/src/ctypes/lDouble.cmx _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes.cmx _build/src/ctypes/complexL.cmx _build/src/ctypes-top/ctypes_printers.cmi
 _build/src/ctypes-top/install_ctypes_printers.cmo :
 _build/src/ctypes-top/install_ctypes_printers.cmx :
-_build/src/ctypes/unsigned.cmi :
-_build/src/ctypes/unsigned.cmo : _build/src/ctypes/unsigned.cmi
-_build/src/ctypes/unsigned.cmx : _build/src/ctypes/unsigned.cmi
 _build/src/discover/commands.cmi :
 _build/src/discover/commands.cmo : _build/src/discover/commands.cmi
 _build/src/discover/commands.cmx : _build/src/discover/commands.cmi


### PR DESCRIPTION
The `Signed` and `Unsigned` modules are now in a separate package (see #515)