### PR TITLE
ocamldoc/odoc fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ clean:
 
 # ctypes subproject
 ctypes.cmi_only = ctypes_static ctypes_primitive_types ctypes_structs
-ctypes.public = unsigned signed lDouble complexL ctypes posixTypes ctypes_types
+ctypes.public = lDouble complexL ctypes posixTypes ctypes_types
 ctypes.dir = src/ctypes
 ctypes.extra_mls = ctypes_primitives.ml
 ctypes.deps = bigarray bytes integers

--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ uninstall:
 DOCFILES=$(foreach project,$(PROJECTS),\
            $(foreach mli,$($(project).public),\
             $($(project).dir)/$(mli).mli))
-DOCFLAGS=$(foreach project,$(PROJECTS),-I $(BUILDDIR)/$($(project).dir))
+DOCFLAGS=-I $(shell ocamlfind query integers) $(foreach project,$(PROJECTS),-I $(BUILDDIR)/$($(project).dir))
 # Avoid passing duplicate interfaces to ocamldoc.
 DOCFILES:=$(filter-out src/ctypes-foreign-threaded/foreign.mli,$(DOCFILES))
 

--- a/src/cstubs/cstubs.mli
+++ b/src/cstubs/cstubs.mli
@@ -71,11 +71,11 @@ sig
         [name], indicates an tag or an alias.  If [typedef] is [false] (the
         default) then [name] is treated as an enumeration tag:
 
-          enum letters { ... }
+          [enum letters { ... }]
 
         If [typedef] is [true] then [name] is instead treated as an alias:
 
-          typedef enum { ... } letters *)
+          [typedef enum { ... } letters] *)
   end
 
   module type BINDINGS = functor (F : TYPE) -> sig end

--- a/src/ctypes/ctypes.mli
+++ b/src/ctypes/ctypes.mli
@@ -291,7 +291,7 @@ sig
   val map : 'b typ -> ('a -> 'b) -> 'a t -> 'b t
   (** [map t f a] is analogous to [Array.map f a]: it creates a new array with
       element type [t] whose elements are obtained by applying [f] to the
-      elements of [a]]. *)
+      elements of [a]. *)
 
   val mapi : 'b typ -> (int -> 'a -> 'b) -> 'a t -> 'b t
   (** [mapi] behaves like {!Array.mapi}, except that it also passes the


### PR DESCRIPTION
Address a couple of syntax errors and some path/resolution problems with the `integers` package.