### PR TITLE
Move TYPE from cstubs to ctypes

### DIFF
--- a/Makefile.tests
+++ b/Makefile.tests
@@ -238,7 +238,7 @@ tests/test-higher_order/generated_bindings.ml: $(BUILDDIR)/test-higher_order-stu
 
 test-enums-struct-stubs.dir  = tests/test-enums/struct-stubs
 test-enums-struct-stubs.threads = yes
-test-enums-struct-stubs.subproject_deps = ctypes cstubs \
+test-enums-struct-stubs.subproject_deps = ctypes \
    ctypes-foreign-base ctypes-foreign-threaded tests-common
 test-enums-struct-stubs: PROJECT=test-enums-struct-stubs
 test-enums-struct-stubs: $$(LIB_TARGETS)
@@ -246,7 +246,7 @@ test-enums-struct-stubs: $$(LIB_TARGETS)
 test-enums-stubs.dir  = tests/test-enums/stubs
 test-enums-stubs.threads = yes
 test-enums-stubs.extra_mls = generated_struct_bindings.ml
-test-enums-stubs.subproject_deps = ctypes cstubs \
+test-enums-stubs.subproject_deps = ctypes \
    test-enums-struct-stubs \
    test-enums-struct-stubs-generator \
    ctypes-foreign-base ctypes-foreign-threaded tests-common
@@ -347,7 +347,7 @@ $(BUILDDIR)/tests/test-structs/generated_struct_stubs.c: $(BUILDDIR)/test-struct
 
 test-constants-stubs.dir  = tests/test-constants/stubs
 test-constants-stubs.threads = yes
-test-constants-stubs.subproject_deps = ctypes cstubs \
+test-constants-stubs.subproject_deps = ctypes \
    ctypes-foreign-base ctypes-foreign-threaded tests-common
 test-constants-stubs: PROJECT=test-constants-stubs
 test-constants-stubs: $$(LIB_TARGETS)
@@ -962,7 +962,7 @@ tests/test-passing-ocaml-values/generated_bindings.ml: $(BUILDDIR)/test-passing-
 
 test-lwt-jobs-stubs.dir  = tests/test-lwt-jobs/stubs
 test-lwt-jobs-stubs.threads = yes
-test-lwt-jobs-stubs.subproject_deps = ctypes cstubs \
+test-lwt-jobs-stubs.subproject_deps = ctypes \
    ctypes-foreign-base ctypes-foreign-threaded tests-common
 test-lwt-jobs-stubs: PROJECT=test-lwt-jobs-stubs
 test-lwt-jobs-stubs: $$(LIB_TARGETS)
@@ -1005,7 +1005,7 @@ $(BUILDDIR)/tests/test-lwt-jobs/generated_struct_stubs.c: $(BUILDDIR)/test-lwt-j
 
 test-lwt-preemptive-stubs.dir  = tests/test-lwt-preemptive/stubs
 test-lwt-preemptive-stubs.threads = yes
-test-lwt-preemptive-stubs.subproject_deps = ctypes cstubs \
+test-lwt-preemptive-stubs.subproject_deps = ctypes \
    ctypes-foreign-base ctypes-foreign-threaded tests-common
 test-lwt-preemptive-stubs: PROJECT=test-lwt-preemptive-stubs
 test-lwt-preemptive-stubs: $$(LIB_TARGETS)
@@ -1048,7 +1048,7 @@ $(BUILDDIR)/tests/test-lwt-preemptive/generated_struct_stubs.c: $(BUILDDIR)/test
 
 test-returning-errno-lwt-jobs-stubs.dir  = tests/test-returning-errno-lwt-jobs/stubs
 test-returning-errno-lwt-jobs-stubs.threads = yes
-test-returning-errno-lwt-jobs-stubs.subproject_deps = ctypes cstubs \
+test-returning-errno-lwt-jobs-stubs.subproject_deps = ctypes \
    ctypes-foreign-base ctypes-foreign-threaded tests-common
 test-returning-errno-lwt-jobs-stubs: PROJECT=test-returning-errno-lwt-jobs-stubs
 test-returning-errno-lwt-jobs-stubs: $$(LIB_TARGETS)
@@ -1090,7 +1090,7 @@ $(BUILDDIR)/tests/test-returning-errno-lwt-jobs/generated_struct_stubs.c: $(BUIL
 
 test-returning-errno-lwt-preemptive-stubs.dir  = tests/test-returning-errno-lwt-preemptive/stubs
 test-returning-errno-lwt-preemptive-stubs.threads = yes
-test-returning-errno-lwt-preemptive-stubs.subproject_deps = ctypes cstubs \
+test-returning-errno-lwt-preemptive-stubs.subproject_deps = ctypes \
    ctypes-foreign-base ctypes-foreign-threaded tests-common
 test-returning-errno-lwt-preemptive-stubs: PROJECT=test-returning-errno-lwt-preemptive-stubs
 test-returning-errno-lwt-preemptive-stubs: $$(LIB_TARGETS)
@@ -1132,7 +1132,7 @@ $(BUILDDIR)/tests/test-returning-errno-lwt-preemptive/generated_struct_stubs.c: 
 
 test-returning-errno-stubs.dir  = tests/test-returning-errno/stubs
 test-returning-errno-stubs.threads = yes
-test-returning-errno-stubs.subproject_deps = ctypes cstubs \
+test-returning-errno-stubs.subproject_deps = ctypes \
    ctypes-foreign-base ctypes-foreign-threaded tests-common
 test-returning-errno-stubs: PROJECT=test-returning-errno-stubs
 test-returning-errno-stubs: $$(LIB_TARGETS)

--- a/src/cstubs/cstubs.mli
+++ b/src/cstubs/cstubs.mli
@@ -9,74 +9,7 @@
 
 module Types :
 sig
-  module type TYPE =
-  sig
-    include Ctypes_types.TYPE
-
-    type 'a const
-    val constant : string -> 'a typ -> 'a const
-    (** [constant name typ] retrieves the value of the compile-time constant
-        [name] of type [typ].  It can be used to retrieve enum constants,
-        #defined values and other integer constant expressions.
-
-        The type [typ] must be either an integer type such as [bool], [char],
-        [int], [uint8], etc., or a view (or perhaps multiple views) where the
-        underlying type is an integer type.
-
-        When the value of the constant cannot be represented in the type there
-        will typically be a diagnostic from either the C compiler or the OCaml
-        compiler.  For example, gcc will say
-
-           warning: overflow in implicit constant conversion *)
-
-    val enum : string -> ?typedef:bool ->
-      ?unexpected:(int64 -> 'a) -> ('a * int64 const) list -> 'a typ
-    (** [enum name ?unexpected alist] builds a type representation for the
-        enum named [name].  The size and alignment are retrieved so that the
-        resulting type can be used everywhere an integer type can be used: as
-        an array element or struct member, as an argument or return value,
-        etc.
-
-        The value [alist] is an association list of OCaml values and values
-        retrieved by the [constant] function.  For example, to expose the enum
-
-          enum letters \{ A, B, C = 10, D \}; 
-
-        you might first retrieve the values of the enumeration constants:
-
-        {[
-          let a = constant "A" int64_t
-          and b = constant "B" int64_t
-          and c = constant "C" int64_t
-          and d = constant "D" int64_t
-        ]}
-
-        and then build the enumeration type
-
-        {[
-          let letters = enum "letters" [
-             `A, a;
-             `B, b;
-             `C, c;
-             `D, d;
-          ] ~unexpected:(fun i -> `E i)
-        ]}
-
-        The [unexpected] function specifies the value to return in the case
-        that some unexpected value is encountered -- for example, if a
-        function with the return type 'enum letters' actually returns the
-        value [-1].
-
-        The optional flag [typedef] specifies whether the first argument,
-        [name], indicates an tag or an alias.  If [typedef] is [false] (the
-        default) then [name] is treated as an enumeration tag:
-
-          [enum letters { ... }]
-
-        If [typedef] is [true] then [name] is instead treated as an alias:
-
-          [typedef enum { ... } letters] *)
-  end
+  module type TYPE = Ctypes.TYPE
 
   module type BINDINGS = functor (F : TYPE) -> sig end
 

--- a/src/ctypes/ctypes.ml
+++ b/src/ctypes/ctypes.ml
@@ -32,3 +32,13 @@ sig
   val foreign : string -> ('a -> 'b) fn -> ('a -> 'b) result
   val foreign_value : string -> 'a typ -> 'a ptr result
 end
+
+module type TYPE =
+sig
+  include Ctypes_types.TYPE
+
+  type 'a const
+  val constant : string -> 'a typ -> 'a const
+  val enum : string -> ?typedef:bool ->
+    ?unexpected:(int64 -> 'a) -> ('a * int64 const) list -> 'a typ
+end

--- a/tests/test-constants/stubs/types.ml
+++ b/tests/test-constants/stubs/types.ml
@@ -7,7 +7,7 @@
 
 open Ctypes
 
-module Struct_stubs(S : Cstubs.Types.TYPE) =
+module Struct_stubs(S : Ctypes.TYPE) =
 struct
   open S
 

--- a/tests/test-enums/struct-stubs/types.ml
+++ b/tests/test-enums/struct-stubs/types.ml
@@ -9,7 +9,7 @@ open Ctypes
 
 type fruit = Orange | Apple | Banana | Pear
 
-module Struct_stubs(S : Cstubs.Types.TYPE) =
+module Struct_stubs(S : Ctypes.TYPE) =
 struct
   open S
 

--- a/tests/test-lwt-jobs/stubs/types.ml
+++ b/tests/test-lwt-jobs/stubs/types.ml
@@ -8,7 +8,7 @@
 open Ctypes
 open PosixTypes
 
-module Struct_stubs(S : Cstubs.Types.TYPE) =
+module Struct_stubs(S : Ctypes.TYPE) =
 struct
   open S
 

--- a/tests/test-lwt-preemptive/stubs/types.ml
+++ b/tests/test-lwt-preemptive/stubs/types.ml
@@ -8,7 +8,7 @@
 open Ctypes
 open PosixTypes
 
-module Struct_stubs(S : Cstubs.Types.TYPE) =
+module Struct_stubs(S : Ctypes.TYPE) =
 struct
   open S
 

--- a/tests/test-returning-errno-lwt-jobs/stubs/types.ml
+++ b/tests/test-returning-errno-lwt-jobs/stubs/types.ml
@@ -8,7 +8,7 @@
 open Ctypes
 open PosixTypes
 
-module Struct_stubs(S : Cstubs.Types.TYPE) =
+module Struct_stubs(S : Ctypes.TYPE) =
 struct
   open S
 

--- a/tests/test-returning-errno-lwt-preemptive/stubs/types.ml
+++ b/tests/test-returning-errno-lwt-preemptive/stubs/types.ml
@@ -8,7 +8,7 @@
 open Ctypes
 open PosixTypes
 
-module Struct_stubs(S : Cstubs.Types.TYPE) =
+module Struct_stubs(S : Ctypes.TYPE) =
 struct
   open S
 

--- a/tests/test-returning-errno/stubs/types.ml
+++ b/tests/test-returning-errno/stubs/types.ml
@@ -8,7 +8,7 @@
 open Ctypes
 open PosixTypes
 
-module Struct_stubs(S : Cstubs.Types.TYPE) =
+module Struct_stubs(S : Ctypes.TYPE) =
 struct
   open S
 

--- a/tests/test-structs/stubs/types.ml
+++ b/tests/test-structs/stubs/types.ml
@@ -7,7 +7,7 @@
 
 open Ctypes
 
-module Struct_stubs(S : Ctypes_types.TYPE) =
+module Struct_stubs(S : Ctypes.TYPE) =
 struct
   open S
 

--- a/tests/test-structs/test_structs.ml
+++ b/tests/test-structs/test_structs.ml
@@ -436,7 +436,7 @@ module Stub_tests = Build_stub_tests(Generated_bindings)
 
 
 module Build_struct_stub_tests
-    (S : Ctypes_types.TYPE
+    (S : Ctypes.TYPE
           with type 'a typ = 'a Ctypes.typ
            and type ('a, 's) field = ('a, 's) Ctypes.field) =
 struct

--- a/tests/test-unions/stubs/types.ml
+++ b/tests/test-unions/stubs/types.ml
@@ -7,7 +7,7 @@
 
 open Ctypes
 
-module Struct_stubs(S : Ctypes_types.TYPE) =
+module Struct_stubs(S : Ctypes.TYPE) =
 struct
   open S
 

--- a/tests/test-unions/test_unions.ml
+++ b/tests/test-unions/test_unions.ml
@@ -152,7 +152,7 @@ end
 
 
 module Build_struct_stub_tests
-    (S : Ctypes_types.TYPE
+    (S : Ctypes.TYPE
           with type 'a typ = 'a Ctypes.typ
            and type ('a, 's) field = ('a, 's) Ctypes.field) =
 struct


### PR DESCRIPTION
This is a follow-up to #537, which has more details.  The high-level aim is described in #528 and #519.