### PR TITLE
Print typedefed enums correctly

### DIFF
--- a/Makefile.tests
+++ b/Makefile.tests
@@ -660,9 +660,39 @@ test-marshal: $$(BEST_TARGET)
 test-type_printing.dir = tests/test-type_printing
 test-type_printing.threads = yes
 test-type_printing.deps = str bigarray oUnit bytes integers
-test-type_printing.subproject_deps = ctypes ctypes-foreign-base ctypes-foreign-threaded
+test-type_printing.subproject_deps = ctypes ctypes-foreign-base ctypes-foreign-threaded \
+  cstubs test-type_printing-stubs tests-common
+test-type_printing.link_flags = -L$(BUILDDIR)/clib -ltest_functions
 test-type_printing: PROJECT=test-type_printing
 test-type_printing: $$(BEST_TARGET)
+
+test-type_printing-stubs.dir  = tests/test-type_printing/stubs
+test-type_printing-stubs.threads = yes
+test-type_printing-stubs.subproject_deps = ctypes \
+   ctypes-foreign-base ctypes-foreign-threaded tests-common
+test-type_printing-stubs: PROJECT=test-type_printing-stubs
+test-type_printing-stubs: $$(LIB_TARGETS)
+
+test-type_printing-stub-generator.dir = tests/test-type_printing/stub-generator
+test-type_printing-stub-generator.threads = yes
+test-type_printing-stub-generator.subproject_deps = ctypes cstubs \
+     ctypes-foreign-base ctypes-foreign-threaded test-type_printing-stubs tests-common
+test-type_printing-stub-generator.deps = str bigarray bytes integers
+test-type_printing-stub-generator: PROJECT=test-type_printing-stub-generator
+test-type_printing-stub-generator: $$(BEST_TARGET)
+
+test-type_printing-generated= \
+  tests/test-type_printing/generated_struct_bindings.ml \
+  $(BUILDDIR)/tests/test-type_printing/generated_struct_stubs.c
+
+test-type_printing-generated: $(test-type_printing-generated)
+
+tests/test-type_printing/generated_struct_bindings.ml: $(BUILDDIR)/test-type_printing-ml-stub-generator.$(BEST)
+	$< > $@
+$(BUILDDIR)/test-type_printing-ml-stub-generator.$(BEST): $(BUILDDIR)/tests/test-type_printing/generated_struct_stubs.c
+	$(CC) -I `$(OCAMLFIND) ocamlc -where | sed 's|\r$$||'` $(CFLAGS) $(LDFLAGS) $(WINLDFLAGS) -o $@ $^
+$(BUILDDIR)/tests/test-type_printing/generated_struct_stubs.c: $(BUILDDIR)/test-type_printing-stub-generator.$(BEST)
+	$< --c-struct-file $@
 
 test-value_printing-stubs.dir  = tests/test-value_printing/stubs
 test-value_printing-stubs.threads = yes
@@ -1274,7 +1304,7 @@ TESTS += test-alignment
 TESTS += test-views-stubs test-views-stub-generator test-views-generated test-views
 TESTS += test-oo_style-stubs test-oo_style-stub-generator test-oo_style-generated test-oo_style
 TESTS += test-marshal
-TESTS += test-type_printing
+TESTS += test-type_printing-stubs test-type_printing-stub-generator test-type_printing-generated test-type_printing
 TESTS += test-value_printing-stubs test-value_printing-stub-generator test-value_printing-generated test-value_printing
 TESTS += test-complex-stubs test-complex-stub-generator test-complex-generated test-complex
 TESTS += test-bools-stubs test-bools-stub-generator test-bools-generated test-bools

--- a/src/cstubs/cstubs_structs.ml
+++ b/src/cstubs/cstubs_structs.ml
@@ -220,7 +220,7 @@ let write_enums fmt enums =
   let case (name, typedef) =
     printf1 fmt
       (Format.sprintf
-         "  | %S -> \n    Cstubs_internals.build_enum_type %S Ctypes_static.%%s ?unexpected alist\n"
+         "  | %S -> \n    Cstubs_internals.build_enum_type %S Ctypes_static.%%s ?typedef ?unexpected alist\n"
          name
          name)
       (fun fmt ->

--- a/src/ctypes/cstubs_internals.mli
+++ b/src/ctypes/cstubs_internals.mli
@@ -95,6 +95,7 @@ type 'a prim = 'a Ctypes_primitive_types.prim =
 | Complexld : ComplexL.t prim
 
 val build_enum_type :
-  string -> Ctypes_static.arithmetic -> ?unexpected:(int64 -> 'a) -> ('a * int64) list -> 'a typ
+  string -> Ctypes_static.arithmetic -> ?typedef:bool ->
+  ?unexpected:(int64 -> 'a) -> ('a * int64) list -> 'a typ
 
 val use_value : 'a -> unit

--- a/tests/clib/test_functions.h
+++ b/tests/clib/test_functions.h
@@ -237,6 +237,9 @@ struct fruit_cell {
   struct fruit_cell *next;
 };
 
+typedef enum letter letter_t;
+typedef enum bears bears_t;
+
 int32_t sum_int_array(int32_t *, size_t);
 
 void save_ocaml_value(void *);

--- a/tests/test-type_printing/stub-generator/driver.ml
+++ b/tests/test-type_printing/stub-generator/driver.ml
@@ -1,0 +1,13 @@
+(*
+ * Copyright (c) 2017 Jeremy Yallop.
+ *
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+(* Stub generation driver for the type printing tests. *)
+
+let () = Tests_common.run Sys.argv
+   ~structs:(module Types.Stubs)
+   (module functor (B:Ctypes.FOREIGN) -> struct end)
+

--- a/tests/test-type_printing/stubs/types.ml
+++ b/tests/test-type_printing/stubs/types.ml
@@ -1,0 +1,19 @@
+(*
+ * Copyright (c) 2017 Jeremy Yallop.
+ *
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+open Ctypes
+
+module Stubs(S : Ctypes.TYPE) =
+struct
+  open S
+  let fruit : int64 S.typ = enum "fruit" []
+
+  let bears_t : int64 S.typ = enum "bears_t" []
+      ~typedef:true
+
+  let letter_t : int64 S.typ = typedef (enum "letter" []) "letter_t"
+end

--- a/tests/test-type_printing/test_type_printing.ml
+++ b/tests/test-type_printing/test_type_printing.ml
@@ -9,6 +9,9 @@ open OUnit2
 open Ctypes
 
 
+module Struct_stubs = Types.Stubs(Generated_struct_bindings)
+
+
 let strip_whitespace = Str.(global_replace (regexp "[\n ]+") "")
 
 let equal_ignoring_whitespace l r =
@@ -540,6 +543,31 @@ let test_view_printing _ =
 
 
 
+(*
+   Test the printing of enum types
+*)
+let test_enum_printing _ =
+  begin
+    assert_typ_printed_as ~name:"f" "enum fruit f"
+      Struct_stubs.fruit;
+
+    assert_typ_printed_as "enum fruit"
+      Struct_stubs.fruit;
+
+    assert_typ_printed_as ~name:"b" "bears_t b"
+      Struct_stubs.bears_t;
+
+    assert_typ_printed_as "bears_t"
+      Struct_stubs.bears_t;
+
+    assert_typ_printed_as ~name:"l" "letter_t l"
+      Struct_stubs.letter_t;
+
+    assert_typ_printed_as "letter_t"
+      Struct_stubs.letter_t;
+  end
+
+
 let suite = "Type printing tests" >:::
   ["printing atomic types"
     >:: test_atomic_printing;
@@ -570,6 +598,9 @@ let suite = "Type printing tests" >:::
 
    "printing views"
     >:: test_view_printing;
+
+   "printing enums"
+    >:: test_enum_printing;
   ]
 
 


### PR DESCRIPTION
Apparently ctypes sometimes prints references to `typedef`ed enums as `enum foo` instead of `foo`. This patch tries to fix this. I haven't personally tested it, but I believe that it has been tested elsewhere within Jane Street.