### PR TITLE
Add -no-keep-locs to the foreign-(un)?threaded build rules.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 BEST:=$(shell if ocamlopt > /dev/null 2>&1; then echo native; else echo byte; fi)
 OPAQUE:=$(shell if ocamlopt -opaque 2>/dev/null; then echo -opaque; fi) 
+NO_KEEP_LOCS:=$(shell if ocamlopt -no-keep-locs 2>/dev/null; then echo -no-keep-locs; fi) 
 DEBUG=true
 COVERAGE=false
 OCAML=ocaml
@@ -113,7 +114,7 @@ ctypes-foreign-threaded.subproject_deps = ctypes ctypes-foreign-base
 ctypes-foreign-threaded.link_flags = $(libffi_lib) $(lib_process)
 ctypes-foreign-threaded.cmo_opts = $(OCAML_FFI_INCOPTS:%=-ccopt %)
 ctypes-foreign-threaded.cmx_opts = $(OCAML_FFI_INCOPTS:%=-ccopt %)
-ctypes-foreign-threaded.cmi_opts = $(OPAQUE)
+ctypes-foreign-threaded.cmi_opts = $(OPAQUE) $(NO_KEEP_LOCS)
 ctypes-foreign-threaded.install_native_objects = no
 
 ctypes-foreign-threaded: PROJECT=ctypes-foreign-threaded
@@ -128,7 +129,7 @@ ctypes-foreign-unthreaded.subproject_deps = ctypes ctypes-foreign-base
 ctypes-foreign-unthreaded.link_flags = $(libffi_lib) $(lib_process)
 ctypes-foreign-unthreaded.cmo_opts = $(OCAML_FFI_INCOPTS:%=-ccopt %)
 ctypes-foreign-unthreaded.cmx_opts = $(OCAML_FFI_INCOPTS:%=-ccopt %)
-ctypes-foreign-unthreaded.cmi_opts = $(OPAQUE)
+ctypes-foreign-unthreaded.cmi_opts = $(OPAQUE) $(NO_KEEP_LOCS)
 ctypes-foreign-unthreaded.install_native_objects = no
 
 ctypes-foreign-unthreaded: PROJECT=ctypes-foreign-unthreaded


### PR DESCRIPTION
Avoids ["inconsistent assumption" problems](https://github.com/dbuenzli/tsdl/issues/44) with OCaml 4.06.0.

Fixes #552.