### PR TITLE
Attach ocaml_integers.h to the cstubs sub-package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ cstubs.subproject_deps = ctypes
 cstubs.deps = str bytes integers
 cstubs.install = yes
 cstubs.install_native_objects = yes
+cstubs.extra_hs = $(package_integers_path)/ocaml_integers.h
 
 cstubs: PROJECT=cstubs
 cstubs: $(cstubs.dir)/$(cstubs.extra_mls) $$(LIB_TARGETS)

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -80,8 +80,7 @@ INSTALL_CMIS = $($(PROJECT).public:%=$(BUILDDIR)/$($(PROJECT).dir)/%.cmi) \
 INSTALL_CMTIS = $($(PROJECT).public:%=$(BUILDDIR)/$($(PROJECT).dir)/%.cmti)
 INSTALL_CMTS = $($(PROJECT).public:%=$(BUILDDIR)/$($(PROJECT).dir)/%.cmt)
 INSTALL_MLIS = $($(PROJECT).public:%=$($(PROJECT).dir)/%.mli)
-INSTALL_HEADERS = $(wildcard $($(PROJECT).dir)/*.h) \
-                  $(package_integers_path)/ocaml_integers.h
+INSTALL_HEADERS = $(wildcard $($(PROJECT).dir)/*.h) $($(PROJECT).extra_hs)
 THREAD_FLAG = $(if $(filter yes,$($(PROJECT).threads)),-thread)
 LINK_FLAGS = $(as_needed_flags) $($(PROJECT).link_flags)
 OCAML_LINK_FLAGS=$(LINK_FLAGS:%=-cclib %)


### PR DESCRIPTION
Previously `ocaml_integers.h` was installed once for every sub-package (`ctypes.top`, `ctypes.stubs`, etc.), causing problems for nix and opam2nix (#555).

This PR associates `ocaml_integers.h` with a particular sub-package (`ctypes.stubs`) so that it's installed exactly once.