### PR TITLE
Revive the mli for coercions

### DIFF
--- a/.depend
+++ b/.depend
@@ -1,7 +1,7 @@
-_build/examples/cstubs_structs/bindings_c_gen.cmo : _build/src/cstubs/cstubs_structs.cmi
-_build/examples/cstubs_structs/bindings_c_gen.cmx : _build/src/cstubs/cstubs_structs.cmx
 _build/examples/cstubs_structs/bindings.cmo : _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs_structs.cmi
 _build/examples/cstubs_structs/bindings.cmx : _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs_structs.cmx
+_build/examples/cstubs_structs/bindings_c_gen.cmo : _build/src/cstubs/cstubs_structs.cmi
+_build/examples/cstubs_structs/bindings_c_gen.cmx : _build/src/cstubs/cstubs_structs.cmx
 _build/examples/cstubs_structs/main.cmo : _build/src/ctypes/posixTypes.cmi _build/src/ctypes-foreign-threaded/foreign.cmi _build/src/ctypes/ctypes.cmi
 _build/examples/cstubs_structs/main.cmx : _build/src/ctypes/posixTypes.cmx _build/src/ctypes-foreign-threaded/foreign.cmx _build/src/ctypes/ctypes.cmx
 _build/examples/cstubs_structs/myocamlbuild.cmo :
@@ -9,43 +9,39 @@ _build/examples/cstubs_structs/myocamlbuild.cmx :
 _build/examples/date/foreign/date.cmi : _build/src/ctypes/posixTypes.cmi _build/src/ctypes/ctypes.cmi
 _build/examples/date/foreign/date.cmo : _build/src/ctypes/posixTypes.cmi _build/src/ctypes-foreign-threaded/foreign.cmi _build/src/ctypes/ctypes.cmi _build/examples/date/foreign/date.cmi
 _build/examples/date/foreign/date.cmx : _build/src/ctypes/posixTypes.cmx _build/src/ctypes-foreign-threaded/foreign.cmx _build/src/ctypes/ctypes.cmx _build/examples/date/foreign/date.cmi
-_build/examples/date/stub-generation/bindings/date_stubs.cmo : _build/src/ctypes/posixTypes.cmi _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs.cmi
-_build/examples/date/stub-generation/bindings/date_stubs.cmx : _build/src/ctypes/posixTypes.cmx _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs.cmx
+_build/examples/date/stub-generation/bindings/date_stubs.cmo : _build/src/ctypes/posixTypes.cmi _build/src/ctypes/ctypes.cmi
+_build/examples/date/stub-generation/bindings/date_stubs.cmx : _build/src/ctypes/posixTypes.cmx _build/src/ctypes/ctypes.cmx
 _build/examples/date/stub-generation/date_cmd.cmo : _build/src/ctypes/posixTypes.cmi _build/src/ctypes/ctypes.cmi
 _build/examples/date/stub-generation/date_cmd.cmx : _build/src/ctypes/posixTypes.cmx _build/src/ctypes/ctypes.cmx
-_build/examples/date/stub-generation/date_generated.cmo : _build/src/ctypes/ctypes.cmi _build/src/ctypes/cstubs_internals.cmi
-_build/examples/date/stub-generation/date_generated.cmx : _build/src/ctypes/ctypes.cmx _build/src/ctypes/cstubs_internals.cmx
 _build/examples/date/stub-generation/stub-generator/date_stub_generator.cmo : _build/src/cstubs/cstubs.cmi
 _build/examples/date/stub-generation/stub-generator/date_stub_generator.cmx : _build/src/cstubs/cstubs.cmx
+_build/examples/fts/foreign/fts.cmi : _build/src/ctypes/posixTypes.cmi _build/src/ctypes/ctypes.cmi
+_build/examples/fts/foreign/fts.cmo : _build/src/ctypes/posixTypes.cmi _build/src/ctypes-foreign-threaded/foreign.cmi _build/src/ctypes/ctypes_coerce.cmi _build/src/ctypes/ctypes.cmi _build/examples/fts/foreign/fts.cmi
+_build/examples/fts/foreign/fts.cmx : _build/src/ctypes/posixTypes.cmx _build/src/ctypes-foreign-threaded/foreign.cmx _build/src/ctypes/ctypes_coerce.cmx _build/src/ctypes/ctypes.cmx _build/examples/fts/foreign/fts.cmi
 _build/examples/fts/foreign/fts_cmd.cmo : _build/src/ctypes/ctypes.cmi
 _build/examples/fts/foreign/fts_cmd.cmx : _build/src/ctypes/ctypes.cmx
-_build/examples/fts/foreign/fts.cmi : _build/src/ctypes/posixTypes.cmi _build/src/ctypes/ctypes.cmi
-_build/examples/fts/foreign/fts.cmo : _build/src/ctypes/posixTypes.cmi _build/src/ctypes-foreign-threaded/foreign.cmi _build/src/ctypes/ctypes_coerce.cmo _build/src/ctypes/ctypes.cmi _build/examples/fts/foreign/fts.cmi
-_build/examples/fts/foreign/fts.cmx : _build/src/ctypes/posixTypes.cmx _build/src/ctypes-foreign-threaded/foreign.cmx _build/src/ctypes/ctypes_coerce.cmx _build/src/ctypes/ctypes.cmx _build/examples/fts/foreign/fts.cmi
-_build/examples/fts/stub-generation/bindings/fts_bindings.cmo : _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs.cmi
-_build/examples/fts/stub-generation/bindings/fts_bindings.cmx : _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs.cmx
 _build/examples/fts/stub-generation/bindings/fts.cmi : _build/src/ctypes/ctypes.cmi
-_build/examples/fts/stub-generation/bindings/fts_types.cmo : _build/src/ctypes/posixTypes.cmi _build/src/ctypes-foreign-threaded/foreign.cmi _build/src/ctypes/ctypes_coerce.cmo _build/src/ctypes/ctypes.cmi
+_build/examples/fts/stub-generation/bindings/fts_bindings.cmo : _build/src/ctypes/ctypes.cmi
+_build/examples/fts/stub-generation/bindings/fts_bindings.cmx : _build/src/ctypes/ctypes.cmx
+_build/examples/fts/stub-generation/bindings/fts_types.cmo : _build/src/ctypes/posixTypes.cmi _build/src/ctypes-foreign-threaded/foreign.cmi _build/src/ctypes/ctypes_coerce.cmi _build/src/ctypes/ctypes.cmi
 _build/examples/fts/stub-generation/bindings/fts_types.cmx : _build/src/ctypes/posixTypes.cmx _build/src/ctypes-foreign-threaded/foreign.cmx _build/src/ctypes/ctypes_coerce.cmx _build/src/ctypes/ctypes.cmx
 _build/examples/fts/stub-generation/fts_cmd.cmo : _build/src/ctypes/ctypes.cmi
 _build/examples/fts/stub-generation/fts_cmd.cmx : _build/src/ctypes/ctypes.cmx
-_build/examples/fts/stub-generation/fts_generated.cmo : _build/src/ctypes/ctypes.cmi _build/src/ctypes/cstubs_internals.cmi
-_build/examples/fts/stub-generation/fts_generated.cmx : _build/src/ctypes/ctypes.cmx _build/src/ctypes/cstubs_internals.cmx
 _build/examples/fts/stub-generation/fts_if.cmo : _build/src/ctypes/ctypes.cmi
 _build/examples/fts/stub-generation/fts_if.cmx : _build/src/ctypes/ctypes.cmx
 _build/examples/fts/stub-generation/stub-generator/fts_stub_generator.cmo : _build/src/cstubs/cstubs.cmi
 _build/examples/fts/stub-generation/stub-generator/fts_stub_generator.cmx : _build/src/cstubs/cstubs.cmx
-_build/examples/ncurses/foreign/ncurses_cmd.cmo :
-_build/examples/ncurses/foreign/ncurses_cmd.cmx :
 _build/examples/ncurses/foreign/ncurses.cmi :
 _build/examples/ncurses/foreign/ncurses.cmo : _build/src/ctypes-foreign-threaded/foreign.cmi _build/src/ctypes/ctypes.cmi _build/examples/ncurses/foreign/ncurses.cmi
 _build/examples/ncurses/foreign/ncurses.cmx : _build/src/ctypes-foreign-threaded/foreign.cmx _build/src/ctypes/ctypes.cmx _build/examples/ncurses/foreign/ncurses.cmi
-_build/examples/ncurses/stub-generation/bindings/ncurses_bindings.cmo : _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs.cmi
-_build/examples/ncurses/stub-generation/bindings/ncurses_bindings.cmx : _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs.cmx
-_build/examples/ncurses/stub-generation/ncurses_generated.cmo : _build/src/ctypes/ctypes.cmi _build/src/ctypes/cstubs_internals.cmi
-_build/examples/ncurses/stub-generation/ncurses_generated.cmx : _build/src/ctypes/ctypes.cmx _build/src/ctypes/cstubs_internals.cmx
+_build/examples/ncurses/foreign/ncurses_cmd.cmo :
+_build/examples/ncurses/foreign/ncurses_cmd.cmx :
+_build/examples/ncurses/stub-generation/bindings/ncurses_bindings.cmo : _build/src/ctypes/ctypes.cmi
+_build/examples/ncurses/stub-generation/bindings/ncurses_bindings.cmx : _build/src/ctypes/ctypes.cmx
 _build/examples/ncurses/stub-generation/ncurses_stub_cmd.cmo :
 _build/examples/ncurses/stub-generation/ncurses_stub_cmd.cmx :
+_build/examples/ncurses/stub-generation/stub-generator/ncurses_stub_generator.cmo : _build/src/cstubs/cstubs.cmi
+_build/examples/ncurses/stub-generation/stub-generator/ncurses_stub_generator.cmx : _build/src/cstubs/cstubs.cmx
 _build/examples/sigset/sigset.cmi : _build/src/ctypes/posixTypes.cmi _build/src/ctypes/ctypes.cmi
 _build/examples/sigset/sigset.cmo : _build/src/ctypes/posixTypes.cmi _build/src/ctypes-foreign-threaded/foreign.cmi _build/src/ctypes/ctypes.cmi _build/examples/sigset/sigset.cmi
 _build/examples/sigset/sigset.cmx : _build/src/ctypes/posixTypes.cmx _build/src/ctypes-foreign-threaded/foreign.cmx _build/src/ctypes/ctypes.cmx _build/examples/sigset/sigset.cmi
@@ -55,14 +51,14 @@ _build/src/configure/gen_c_primitives.cmo :
 _build/src/configure/gen_c_primitives.cmx :
 _build/src/configure/gen_libffi_abi.cmo :
 _build/src/configure/gen_libffi_abi.cmx :
+_build/src/cstubs/cstubs.cmi : _build/src/ctypes/ctypes.cmi
+_build/src/cstubs/cstubs.cmo : _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs_structs.cmi _build/src/cstubs/cstubs_generate_ml.cmi _build/src/cstubs/cstubs_generate_c.cmi _build/src/cstubs/cstubs.cmi
+_build/src/cstubs/cstubs.cmx : _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs_structs.cmx _build/src/cstubs/cstubs_generate_ml.cmx _build/src/cstubs/cstubs_generate_c.cmx _build/src/cstubs/cstubs.cmi
 _build/src/cstubs/cstubs_analysis.cmi : _build/src/ctypes/ctypes_static.cmi
 _build/src/cstubs/cstubs_analysis.cmo : _build/src/ctypes/lDouble.cmi _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_bigarray.cmi _build/src/ctypes/complexL.cmi _build/src/cstubs/cstubs_analysis.cmi
 _build/src/cstubs/cstubs_analysis.cmx : _build/src/ctypes/lDouble.cmx _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_primitive_types.cmx _build/src/ctypes/ctypes_bigarray.cmx _build/src/ctypes/complexL.cmx _build/src/cstubs/cstubs_analysis.cmi
 _build/src/cstubs/cstubs_c_language.cmo : _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs_errors.cmi
 _build/src/cstubs/cstubs_c_language.cmx : _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_primitive_types.cmx _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs_errors.cmx
-_build/src/cstubs/cstubs.cmi : _build/src/ctypes/ctypes_types.cmi _build/src/ctypes/ctypes.cmi
-_build/src/cstubs/cstubs.cmo : _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs_structs.cmi _build/src/cstubs/cstubs_generate_ml.cmi _build/src/cstubs/cstubs_generate_c.cmi _build/src/cstubs/cstubs.cmi
-_build/src/cstubs/cstubs.cmx : _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs_structs.cmx _build/src/cstubs/cstubs_generate_ml.cmx _build/src/cstubs/cstubs_generate_c.cmx _build/src/cstubs/cstubs.cmi
 _build/src/cstubs/cstubs_emit_c.cmo : _build/src/ctypes/ctypes_type_printing.cmi _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs_c_language.cmo
 _build/src/cstubs/cstubs_emit_c.cmx : _build/src/ctypes/ctypes_type_printing.cmx _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs_c_language.cmx
 _build/src/cstubs/cstubs_errors.cmi :
@@ -74,9 +70,6 @@ _build/src/cstubs/cstubs_generate_c.cmx : _build/src/ctypes/ctypes_static.cmx _b
 _build/src/cstubs/cstubs_generate_ml.cmi : _build/src/ctypes/ctypes.cmi
 _build/src/cstubs/cstubs_generate_ml.cmo : _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_primitive_types.cmi _build/src/cstubs/ctypes_path.cmi _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs_public_name.cmi _build/src/cstubs/cstubs_errors.cmi _build/src/cstubs/cstubs_analysis.cmi _build/src/cstubs/cstubs_generate_ml.cmi
 _build/src/cstubs/cstubs_generate_ml.cmx : _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_primitive_types.cmx _build/src/cstubs/ctypes_path.cmx _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs_public_name.cmx _build/src/cstubs/cstubs_errors.cmx _build/src/cstubs/cstubs_analysis.cmx _build/src/cstubs/cstubs_generate_ml.cmi
-_build/src/ctypes/cstubs_internals.cmi : _build/src/ctypes/lDouble.cmi _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_memory_stubs.cmo _build/src/ctypes/ctypes_bigarray.cmi _build/src/ctypes/ctypes.cmi _build/src/ctypes/complexL.cmi
-_build/src/ctypes/cstubs_internals.cmo : _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_memory_stubs.cmo _build/src/ctypes/ctypes.cmi _build/src/ctypes/cstubs_internals.cmi
-_build/src/ctypes/cstubs_internals.cmx : _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_primitive_types.cmx _build/src/ctypes/ctypes_memory_stubs.cmx _build/src/ctypes/ctypes.cmx _build/src/ctypes/cstubs_internals.cmi
 _build/src/cstubs/cstubs_inverted.cmi : _build/src/ctypes/ctypes.cmi
 _build/src/cstubs/cstubs_inverted.cmo : _build/src/ctypes/ctypes_type_printing.cmi _build/src/ctypes/ctypes.cmi _build/src/cstubs/cstubs_generate_ml.cmi _build/src/cstubs/cstubs_generate_c.cmi _build/src/cstubs/cstubs_inverted.cmi
 _build/src/cstubs/cstubs_inverted.cmx : _build/src/ctypes/ctypes_type_printing.cmx _build/src/ctypes/ctypes.cmx _build/src/cstubs/cstubs_generate_ml.cmx _build/src/cstubs/cstubs_generate_c.cmx _build/src/cstubs/cstubs_inverted.cmi
@@ -89,54 +82,6 @@ _build/src/cstubs/cstubs_structs.cmx : _build/src/ctypes/ctypes_types.cmi _build
 _build/src/cstubs/ctypes_path.cmi :
 _build/src/cstubs/ctypes_path.cmo : _build/src/cstubs/ctypes_path.cmi
 _build/src/cstubs/ctypes_path.cmx : _build/src/cstubs/ctypes_path.cmi
-_build/src/ctypes/coerce.cmi : _build/src/ctypes/ctypes_static.cmi
-_build/src/ctypes/complexL.cmi : _build/src/ctypes/lDouble.cmi
-_build/src/ctypes/complexL.cmo : _build/src/ctypes/lDouble.cmi _build/src/ctypes/complexL.cmi
-_build/src/ctypes/complexL.cmx : _build/src/ctypes/lDouble.cmx _build/src/ctypes/complexL.cmi
-_build/src/ctypes/ctypes_bigarray.cmi : _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitive_types.cmi
-_build/src/ctypes/ctypes_bigarray.cmo : _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitives.cmo _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_memory_stubs.cmo _build/src/ctypes/ctypes_bigarray_stubs.cmo _build/src/ctypes/ctypes_bigarray.cmi
-_build/src/ctypes/ctypes_bigarray.cmx : _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_primitives.cmx _build/src/ctypes/ctypes_primitive_types.cmx _build/src/ctypes/ctypes_memory_stubs.cmx _build/src/ctypes/ctypes_bigarray_stubs.cmx _build/src/ctypes/ctypes_bigarray.cmi
-_build/src/ctypes/ctypes_bigarray_stubs.cmo : _build/src/ctypes/ctypes_ptr.cmo
-_build/src/ctypes/ctypes_bigarray_stubs.cmx : _build/src/ctypes/ctypes_ptr.cmx
-_build/src/ctypes/ctypes.cmi : _build/src/ctypes/ctypes_types.cmi _build/src/ctypes/ctypes_static.cmi
-_build/src/ctypes/ctypes.cmo : _build/src/ctypes/ctypes_value_printing.cmo _build/src/ctypes/ctypes_type_printing.cmi _build/src/ctypes/ctypes_structs_computed.cmi _build/src/ctypes/ctypes_std_views.cmo _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_memory.cmo _build/src/ctypes/ctypes_coerce.cmo _build/src/ctypes/ctypes.cmi
-_build/src/ctypes/ctypes.cmx : _build/src/ctypes/ctypes_value_printing.cmx _build/src/ctypes/ctypes_type_printing.cmx _build/src/ctypes/ctypes_structs_computed.cmx _build/src/ctypes/ctypes_std_views.cmx _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_memory.cmx _build/src/ctypes/ctypes_coerce.cmx _build/src/ctypes/ctypes.cmi
-_build/src/ctypes/ctypes_coerce.cmo : _build/src/ctypes/ctypes_type_printing.cmi _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitive_types.cmi
-_build/src/ctypes/ctypes_coerce.cmx : _build/src/ctypes/ctypes_type_printing.cmx _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_primitive_types.cmx
-_build/src/ctypes/ctypes_memory.cmo : _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_roots_stubs.cmo _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_memory_stubs.cmo _build/src/ctypes/ctypes_bigarray.cmi
-_build/src/ctypes/ctypes_memory.cmx : _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_roots_stubs.cmx _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_memory_stubs.cmx _build/src/ctypes/ctypes_bigarray.cmx
-_build/src/ctypes/ctypes_memory_stubs.cmo : _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitive_types.cmi
-_build/src/ctypes/ctypes_memory_stubs.cmx : _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_primitive_types.cmx
-_build/src/ctypes/ctypes_primitives.cmo : _build/src/ctypes/ctypes_primitive_types.cmi
-_build/src/ctypes/ctypes_primitives.cmx : _build/src/ctypes/ctypes_primitive_types.cmx
-_build/src/ctypes/ctypes_primitive_types.cmi : _build/src/ctypes/lDouble.cmi _build/src/ctypes/complexL.cmi
-_build/src/ctypes/ctypes_primitive_types.cmo : _build/src/ctypes/lDouble.cmi _build/src/ctypes/complexL.cmi _build/src/ctypes/ctypes_primitive_types.cmi
-_build/src/ctypes/ctypes_primitive_types.cmx : _build/src/ctypes/lDouble.cmx _build/src/ctypes/complexL.cmx _build/src/ctypes/ctypes_primitive_types.cmi
-_build/src/ctypes/ctypes_ptr.cmo :
-_build/src/ctypes/ctypes_ptr.cmx :
-_build/src/ctypes/ctypes_roots_stubs.cmo : _build/src/ctypes/ctypes_ptr.cmo
-_build/src/ctypes/ctypes_roots_stubs.cmx : _build/src/ctypes/ctypes_ptr.cmx
-_build/src/ctypes/ctypes_static.cmi : _build/src/ctypes/lDouble.cmi _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_bigarray.cmi _build/src/ctypes/complexL.cmi
-_build/src/ctypes/ctypes_static.cmo : _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitives.cmo _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_bigarray.cmi _build/src/ctypes/ctypes_static.cmi
-_build/src/ctypes/ctypes_static.cmx : _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_primitives.cmx _build/src/ctypes/ctypes_primitive_types.cmx _build/src/ctypes/ctypes_bigarray.cmx _build/src/ctypes/ctypes_static.cmi
-_build/src/ctypes/ctypes_std_views.cmo : _build/src/ctypes/ctypes_std_view_stubs.cmo _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_memory_stubs.cmo _build/src/ctypes/ctypes_memory.cmo _build/src/ctypes/ctypes_coerce.cmo
-_build/src/ctypes/ctypes_std_views.cmx : _build/src/ctypes/ctypes_std_view_stubs.cmx _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_memory_stubs.cmx _build/src/ctypes/ctypes_memory.cmx _build/src/ctypes/ctypes_coerce.cmx
-_build/src/ctypes/ctypes_std_view_stubs.cmo : _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_memory_stubs.cmo
-_build/src/ctypes/ctypes_std_view_stubs.cmx : _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_memory_stubs.cmx
-_build/src/ctypes/ctypes_structs.cmi : _build/src/ctypes/ctypes_static.cmi
-_build/src/ctypes/ctypes_structs.cmo : _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_structs.cmi
-_build/src/ctypes/ctypes_structs.cmx : _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_structs.cmi
-_build/src/ctypes/ctypes_structs_computed.cmi : _build/src/ctypes/ctypes_structs.cmi _build/src/ctypes/ctypes_static.cmi
-_build/src/ctypes/ctypes_structs_computed.cmo : _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_structs_computed.cmi
-_build/src/ctypes/ctypes_structs_computed.cmx : _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_structs_computed.cmi
-_build/src/ctypes/ctypes_type_printing.cmi : _build/src/ctypes/ctypes_static.cmi
-_build/src/ctypes/ctypes_type_printing.cmo : _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_primitives.cmo _build/src/ctypes/ctypes_bigarray.cmi _build/src/ctypes/ctypes_type_printing.cmi
-_build/src/ctypes/ctypes_type_printing.cmx : _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_primitives.cmx _build/src/ctypes/ctypes_bigarray.cmx _build/src/ctypes/ctypes_type_printing.cmi
-_build/src/ctypes/ctypes_types.cmi : _build/src/ctypes/lDouble.cmi _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/complexL.cmi
-_build/src/ctypes/ctypes_value_printing.cmo : _build/src/ctypes/ctypes_value_printing_stubs.cmo _build/src/ctypes/ctypes_type_printing.cmi _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_memory.cmo
-_build/src/ctypes/ctypes_value_printing.cmx : _build/src/ctypes/ctypes_value_printing_stubs.cmx _build/src/ctypes/ctypes_type_printing.cmx _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_memory.cmx
-_build/src/ctypes/ctypes_value_printing_stubs.cmo : _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitive_types.cmi
-_build/src/ctypes/ctypes_value_printing_stubs.cmx : _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_primitive_types.cmx
 _build/src/ctypes-foreign-base/ctypes_closure_properties.cmi :
 _build/src/ctypes-foreign-base/ctypes_closure_properties.cmo : _build/src/ctypes-foreign-base/ctypes_closure_properties.cmi
 _build/src/ctypes-foreign-base/ctypes_closure_properties.cmx : _build/src/ctypes-foreign-base/ctypes_closure_properties.cmi
@@ -145,7 +90,7 @@ _build/src/ctypes-foreign-base/ctypes_ffi.cmo : _build/src/ctypes-foreign-base/l
 _build/src/ctypes-foreign-base/ctypes_ffi.cmx : _build/src/ctypes-foreign-base/libffi_abi.cmx _build/src/ctypes-foreign-base/ctypes_weak_ref.cmx _build/src/ctypes/ctypes_type_printing.cmx _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_primitives.cmx _build/src/ctypes/ctypes_primitive_types.cmx _build/src/ctypes/ctypes_memory_stubs.cmx _build/src/ctypes/ctypes_memory.cmx _build/src/ctypes-foreign-base/ctypes_ffi_stubs.cmx _build/src/ctypes-foreign-base/ctypes_ffi.cmi
 _build/src/ctypes-foreign-base/ctypes_ffi_stubs.cmo : _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitive_types.cmi
 _build/src/ctypes-foreign-base/ctypes_ffi_stubs.cmx : _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_primitive_types.cmx
-_build/src/ctypes-foreign-base/ctypes_foreign_basis.cmo : _build/src/ctypes-foreign-base/libffi_abi.cmi _build/src/ctypes-foreign-base/dl.cmi _build/src/ctypes/ctypes_std_views.cmo _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes-foreign-base/ctypes_ffi_stubs.cmo _build/src/ctypes-foreign-base/ctypes_ffi.cmi _build/src/ctypes/ctypes_coerce.cmo _build/src/ctypes/ctypes.cmi
+_build/src/ctypes-foreign-base/ctypes_foreign_basis.cmo : _build/src/ctypes-foreign-base/libffi_abi.cmi _build/src/ctypes-foreign-base/dl.cmi _build/src/ctypes/ctypes_std_views.cmo _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes-foreign-base/ctypes_ffi_stubs.cmo _build/src/ctypes-foreign-base/ctypes_ffi.cmi _build/src/ctypes/ctypes_coerce.cmi _build/src/ctypes/ctypes.cmi
 _build/src/ctypes-foreign-base/ctypes_foreign_basis.cmx : _build/src/ctypes-foreign-base/libffi_abi.cmx _build/src/ctypes-foreign-base/dl.cmx _build/src/ctypes/ctypes_std_views.cmx _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes-foreign-base/ctypes_ffi_stubs.cmx _build/src/ctypes-foreign-base/ctypes_ffi.cmx _build/src/ctypes/ctypes_coerce.cmx _build/src/ctypes/ctypes.cmx
 _build/src/ctypes-foreign-base/ctypes_weak_ref.cmi :
 _build/src/ctypes-foreign-base/ctypes_weak_ref.cmo : _build/src/ctypes-foreign-base/ctypes_weak_ref.cmi
@@ -166,17 +111,68 @@ _build/src/ctypes-foreign-unthreaded/ctypes_gc_mutex.cmx :
 _build/src/ctypes-foreign-unthreaded/foreign.cmi : _build/src/ctypes-foreign-base/libffi_abi.cmi _build/src/ctypes-foreign-base/dl.cmi _build/src/ctypes/ctypes.cmi
 _build/src/ctypes-foreign-unthreaded/foreign.cmo : _build/src/ctypes-foreign-unthreaded/ctypes_gc_mutex.cmo _build/src/ctypes-foreign-base/ctypes_foreign_basis.cmo _build/src/ctypes-foreign-base/ctypes_closure_properties.cmi _build/src/ctypes-foreign-unthreaded/foreign.cmi
 _build/src/ctypes-foreign-unthreaded/foreign.cmx : _build/src/ctypes-foreign-unthreaded/ctypes_gc_mutex.cmx _build/src/ctypes-foreign-base/ctypes_foreign_basis.cmx _build/src/ctypes-foreign-base/ctypes_closure_properties.cmx _build/src/ctypes-foreign-unthreaded/foreign.cmi
+_build/src/ctypes-top/ctypes_printers.cmi : _build/src/ctypes/posixTypes.cmi _build/src/ctypes/lDouble.cmi _build/src/ctypes/ctypes.cmi _build/src/ctypes/complexL.cmi
+_build/src/ctypes-top/ctypes_printers.cmo : _build/src/ctypes/posixTypes.cmi _build/src/ctypes/lDouble.cmi _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes.cmi _build/src/ctypes/complexL.cmi _build/src/ctypes-top/ctypes_printers.cmi
+_build/src/ctypes-top/ctypes_printers.cmx : _build/src/ctypes/posixTypes.cmx _build/src/ctypes/lDouble.cmx _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes.cmx _build/src/ctypes/complexL.cmx _build/src/ctypes-top/ctypes_printers.cmi
+_build/src/ctypes-top/install_ctypes_printers.cmo :
+_build/src/ctypes-top/install_ctypes_printers.cmx :
+_build/src/ctypes/complexL.cmi : _build/src/ctypes/lDouble.cmi
+_build/src/ctypes/complexL.cmo : _build/src/ctypes/lDouble.cmi _build/src/ctypes/complexL.cmi
+_build/src/ctypes/complexL.cmx : _build/src/ctypes/lDouble.cmx _build/src/ctypes/complexL.cmi
+_build/src/ctypes/cstubs_internals.cmi : _build/src/ctypes/lDouble.cmi _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_memory_stubs.cmo _build/src/ctypes/ctypes_bigarray.cmi _build/src/ctypes/ctypes.cmi _build/src/ctypes/complexL.cmi
+_build/src/ctypes/cstubs_internals.cmo : _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_memory_stubs.cmo _build/src/ctypes/ctypes.cmi _build/src/ctypes/cstubs_internals.cmi
+_build/src/ctypes/cstubs_internals.cmx : _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_primitive_types.cmx _build/src/ctypes/ctypes_memory_stubs.cmx _build/src/ctypes/ctypes.cmx _build/src/ctypes/cstubs_internals.cmi
+_build/src/ctypes/ctypes.cmi : _build/src/ctypes/ctypes_types.cmi _build/src/ctypes/ctypes_static.cmi
+_build/src/ctypes/ctypes.cmo : _build/src/ctypes/ctypes_value_printing.cmo _build/src/ctypes/ctypes_types.cmi _build/src/ctypes/ctypes_type_printing.cmi _build/src/ctypes/ctypes_structs_computed.cmi _build/src/ctypes/ctypes_std_views.cmo _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_memory.cmo _build/src/ctypes/ctypes_coerce.cmi _build/src/ctypes/ctypes.cmi
+_build/src/ctypes/ctypes.cmx : _build/src/ctypes/ctypes_value_printing.cmx _build/src/ctypes/ctypes_types.cmi _build/src/ctypes/ctypes_type_printing.cmx _build/src/ctypes/ctypes_structs_computed.cmx _build/src/ctypes/ctypes_std_views.cmx _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_memory.cmx _build/src/ctypes/ctypes_coerce.cmx _build/src/ctypes/ctypes.cmi
+_build/src/ctypes/ctypes_bigarray.cmi : _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitive_types.cmi
+_build/src/ctypes/ctypes_bigarray.cmo : _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitives.cmo _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_memory_stubs.cmo _build/src/ctypes/ctypes_bigarray_stubs.cmo _build/src/ctypes/ctypes_bigarray.cmi
+_build/src/ctypes/ctypes_bigarray.cmx : _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_primitives.cmx _build/src/ctypes/ctypes_primitive_types.cmx _build/src/ctypes/ctypes_memory_stubs.cmx _build/src/ctypes/ctypes_bigarray_stubs.cmx _build/src/ctypes/ctypes_bigarray.cmi
+_build/src/ctypes/ctypes_bigarray_stubs.cmo : _build/src/ctypes/ctypes_ptr.cmo
+_build/src/ctypes/ctypes_bigarray_stubs.cmx : _build/src/ctypes/ctypes_ptr.cmx
+_build/src/ctypes/ctypes_coerce.cmi : _build/src/ctypes/ctypes_static.cmi
+_build/src/ctypes/ctypes_coerce.cmo : _build/src/ctypes/ctypes_type_printing.cmi _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_coerce.cmi
+_build/src/ctypes/ctypes_coerce.cmx : _build/src/ctypes/ctypes_type_printing.cmx _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_primitive_types.cmx _build/src/ctypes/ctypes_coerce.cmi
+_build/src/ctypes/ctypes_memory.cmo : _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_roots_stubs.cmo _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_memory_stubs.cmo _build/src/ctypes/ctypes_bigarray.cmi
+_build/src/ctypes/ctypes_memory.cmx : _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_roots_stubs.cmx _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_memory_stubs.cmx _build/src/ctypes/ctypes_bigarray.cmx
+_build/src/ctypes/ctypes_memory_stubs.cmo : _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitive_types.cmi
+_build/src/ctypes/ctypes_memory_stubs.cmx : _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_primitive_types.cmx
+_build/src/ctypes/ctypes_primitive_types.cmi : _build/src/ctypes/lDouble.cmi _build/src/ctypes/complexL.cmi
+_build/src/ctypes/ctypes_primitive_types.cmo : _build/src/ctypes/lDouble.cmi _build/src/ctypes/complexL.cmi _build/src/ctypes/ctypes_primitive_types.cmi
+_build/src/ctypes/ctypes_primitive_types.cmx : _build/src/ctypes/lDouble.cmx _build/src/ctypes/complexL.cmx _build/src/ctypes/ctypes_primitive_types.cmi
+_build/src/ctypes/ctypes_primitives.cmo : _build/src/ctypes/ctypes_primitive_types.cmi
+_build/src/ctypes/ctypes_primitives.cmx : _build/src/ctypes/ctypes_primitive_types.cmx
+_build/src/ctypes/ctypes_ptr.cmo :
+_build/src/ctypes/ctypes_ptr.cmx :
+_build/src/ctypes/ctypes_roots_stubs.cmo : _build/src/ctypes/ctypes_ptr.cmo
+_build/src/ctypes/ctypes_roots_stubs.cmx : _build/src/ctypes/ctypes_ptr.cmx
+_build/src/ctypes/ctypes_static.cmi : _build/src/ctypes/lDouble.cmi _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_bigarray.cmi _build/src/ctypes/complexL.cmi
+_build/src/ctypes/ctypes_static.cmo : _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitives.cmo _build/src/ctypes/ctypes_primitive_types.cmi _build/src/ctypes/ctypes_bigarray.cmi _build/src/ctypes/ctypes_static.cmi
+_build/src/ctypes/ctypes_static.cmx : _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_primitives.cmx _build/src/ctypes/ctypes_primitive_types.cmx _build/src/ctypes/ctypes_bigarray.cmx _build/src/ctypes/ctypes_static.cmi
+_build/src/ctypes/ctypes_std_view_stubs.cmo : _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_memory_stubs.cmo
+_build/src/ctypes/ctypes_std_view_stubs.cmx : _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_memory_stubs.cmx
+_build/src/ctypes/ctypes_std_views.cmo : _build/src/ctypes/ctypes_std_view_stubs.cmo _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_memory_stubs.cmo _build/src/ctypes/ctypes_memory.cmo _build/src/ctypes/ctypes_coerce.cmi
+_build/src/ctypes/ctypes_std_views.cmx : _build/src/ctypes/ctypes_std_view_stubs.cmx _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_memory_stubs.cmx _build/src/ctypes/ctypes_memory.cmx _build/src/ctypes/ctypes_coerce.cmx
+_build/src/ctypes/ctypes_structs.cmi : _build/src/ctypes/ctypes_static.cmi
+_build/src/ctypes/ctypes_structs.cmo : _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_structs.cmi
+_build/src/ctypes/ctypes_structs.cmx : _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_structs.cmi
+_build/src/ctypes/ctypes_structs_computed.cmi : _build/src/ctypes/ctypes_structs.cmi _build/src/ctypes/ctypes_static.cmi
+_build/src/ctypes/ctypes_structs_computed.cmo : _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_structs_computed.cmi
+_build/src/ctypes/ctypes_structs_computed.cmx : _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_structs_computed.cmi
+_build/src/ctypes/ctypes_type_printing.cmi : _build/src/ctypes/ctypes_static.cmi
+_build/src/ctypes/ctypes_type_printing.cmo : _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_primitives.cmo _build/src/ctypes/ctypes_bigarray.cmi _build/src/ctypes/ctypes_type_printing.cmi
+_build/src/ctypes/ctypes_type_printing.cmx : _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_primitives.cmx _build/src/ctypes/ctypes_bigarray.cmx _build/src/ctypes/ctypes_type_printing.cmi
+_build/src/ctypes/ctypes_types.cmi : _build/src/ctypes/lDouble.cmi _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/complexL.cmi
+_build/src/ctypes/ctypes_value_printing.cmo : _build/src/ctypes/ctypes_value_printing_stubs.cmo _build/src/ctypes/ctypes_type_printing.cmi _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_memory.cmo
+_build/src/ctypes/ctypes_value_printing.cmx : _build/src/ctypes/ctypes_value_printing_stubs.cmx _build/src/ctypes/ctypes_type_printing.cmx _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_memory.cmx
+_build/src/ctypes/ctypes_value_printing_stubs.cmo : _build/src/ctypes/ctypes_ptr.cmo _build/src/ctypes/ctypes_primitive_types.cmi
+_build/src/ctypes/ctypes_value_printing_stubs.cmx : _build/src/ctypes/ctypes_ptr.cmx _build/src/ctypes/ctypes_primitive_types.cmx
 _build/src/ctypes/lDouble.cmi :
 _build/src/ctypes/lDouble.cmo : _build/src/ctypes/lDouble.cmi
 _build/src/ctypes/lDouble.cmx : _build/src/ctypes/lDouble.cmi
 _build/src/ctypes/posixTypes.cmi : _build/src/ctypes/ctypes.cmi
 _build/src/ctypes/posixTypes.cmo : _build/src/ctypes/ctypes_std_views.cmo _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes.cmi _build/src/ctypes/posixTypes.cmi
 _build/src/ctypes/posixTypes.cmx : _build/src/ctypes/ctypes_std_views.cmx _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes.cmx _build/src/ctypes/posixTypes.cmi
-_build/src/ctypes-top/ctypes_printers.cmi : _build/src/ctypes/posixTypes.cmi _build/src/ctypes/lDouble.cmi _build/src/ctypes/ctypes.cmi _build/src/ctypes/complexL.cmi
-_build/src/ctypes-top/ctypes_printers.cmo : _build/src/ctypes/posixTypes.cmi _build/src/ctypes/lDouble.cmi _build/src/ctypes/ctypes_static.cmi _build/src/ctypes/ctypes.cmi _build/src/ctypes/complexL.cmi _build/src/ctypes-top/ctypes_printers.cmi
-_build/src/ctypes-top/ctypes_printers.cmx : _build/src/ctypes/posixTypes.cmx _build/src/ctypes/lDouble.cmx _build/src/ctypes/ctypes_static.cmx _build/src/ctypes/ctypes.cmx _build/src/ctypes/complexL.cmx _build/src/ctypes-top/ctypes_printers.cmi
-_build/src/ctypes-top/install_ctypes_printers.cmo :
-_build/src/ctypes-top/install_ctypes_printers.cmx :
 _build/src/discover/commands.cmi :
 _build/src/discover/commands.cmo : _build/src/discover/commands.cmi
 _build/src/discover/commands.cmx : _build/src/discover/commands.cmi

--- a/src/ctypes/ctypes_coerce.mli
+++ b/src/ctypes/ctypes_coerce.mli
@@ -5,7 +5,9 @@
  * See the file LICENSE for details.
  *)
 
-exception Uncoercible
+type uncoercible_info
+
+exception Uncoercible of uncoercible_info
 
 val coerce : 'a Ctypes_static.typ -> 'b Ctypes_static.typ -> 'a -> 'b
 


### PR DESCRIPTION
coerce.mli seemed unused by the build, it was probably meant for ctypes_coerce.

The other option is that this .mli shouldn't be used at all and deleted altogether I suppose.