### PR TITLE
Introduce `CArray.of_string` and expand the `string` view documentation

### DIFF
--- a/src/ctypes/ctypes.mli
+++ b/src/ctypes/ctypes.mli
@@ -275,6 +275,10 @@ sig
   (** [unsafe_set a n v] behaves like [set a n v] except that the check that
       [n] between [0] and [(CArray.length a - 1)] is not performed. *)
 
+  val of_string : string -> char t
+  (** [of_string s] builds an array of the same length as [s], and writes
+      the elements of [s] to the corresponding elements of the array. *)
+
   val of_list : 'a typ -> 'a list -> 'a t
   (** [of_list t l] builds an array of type [t] of the same length as [l], and
       writes the elements of [l] to the corresponding elements of the array. *)

--- a/src/ctypes/ctypes_memory.ml
+++ b/src/ctypes/ctypes_memory.ml
@@ -214,6 +214,11 @@ struct
 
   let element_type { astart } = reference_type astart
 
+  let of_string string =
+    let arr = make char (String.length string) in
+    String.iteri (set arr) string;
+    arr
+
   let of_list typ list =
     let arr = make typ (List.length list) in
     List.iteri (set arr) list;

--- a/src/ctypes/ctypes_types.mli
+++ b/src/ctypes/ctypes_types.mli
@@ -192,6 +192,11 @@ sig
       To avoid problems with the garbage collector, values passed using
       {!string} are copied into immovable C-managed storage before being passed
       to C.
+
+      When the memory is not owned by the C code, -- i.e. when creating or
+      initializing a struct in OCaml before passing it to C -- then the
+      {!string} view isn't a good choice, because there's no way to manage the
+      lifetime of the C copy of the generated OCaml string.
   *)
 
   val string_opt : string option typ

--- a/tests/test-arrays/test_array.ml
+++ b/tests/test-arrays/test_array.ml
@@ -92,7 +92,6 @@ let test_multidimensional_arrays _ =
     done
   done
 
-
 (*
   Test the CArray.iter function
  *)
@@ -209,6 +208,21 @@ let test_sub _ =
     assert_equal [1; 2; 3] (CArray.to_list a);
     assert_equal [10; 3] (CArray.to_list r);
   end
+
+
+(*
+  Test the CArray.of_string function
+*)
+let test_of_string _ =
+  let s = "abcdefghiABCDEFGHI" in
+  let a = CArray.of_string s in
+  let s' = coerce (ptr char) string (CArray.start a) in
+  assert_equal s s';
+
+  let s = "" in
+  let a = CArray.of_string s in
+  let s' = coerce (ptr char) string (CArray.start a) in
+  assert_equal s s'
 
 
 (*
@@ -374,6 +388,9 @@ let suite = "Array tests" >:::
 
    "CArray.sub"
     >:: test_sub;
+
+   "CArray.of_string"
+   >:: test_of_string;
 
    "array initialization"
     >:: test_array_initialiation;


### PR DESCRIPTION
I have already expanded a bit the comments on the FAQ. Feel free to close this PR if you think it's superfluous, but I thought that passing strings in C structure fields and similar type of bindings are probably not that uncommon, and it may be useful to be hinted that `string` views are not the right thing both by the documentation and by the presence of a function like `CArray.of_string`.