### PR TITLE
CArray: add the null terminator in of_string

### DIFF
--- a/src/ctypes/ctypes_memory.ml
+++ b/src/ctypes/ctypes_memory.ml
@@ -215,8 +215,10 @@ struct
   let element_type { astart } = reference_type astart
 
   let of_string string =
-    let arr = make char (String.length string) in
+    let len = String.length string in
+    let arr = make char (len + 1) in
     String.iteri (set arr) string;
+    set arr len '\x00';
     arr
 
   let of_list typ list =


### PR DESCRIPTION
This could also be done by using `~initial:'\x00'`, but in this case it may not be worth
as we are replacing almost all the elements anyways.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>