### PR TITLE
Constrain lwt to versions below 4.0.0

### DIFF
--- a/ctypes.opam
+++ b/ctypes.opam
@@ -26,7 +26,7 @@ depends: [
    "integers"
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test}
+   "lwt" {test & < "4.0.0"}
    "ctypes-foreign" {test}
    "ounit" {test}
    "conf-ncurses" {test}


### PR DESCRIPTION
See https://github.com/ocaml/opam-repository/pull/11754