### PR TITLE
[POC] Cstubs_structs: interrogate abstract types for size and alignment

### DIFF
--- a/Makefile.tests
+++ b/Makefile.tests
@@ -516,6 +516,42 @@ $(BUILDDIR)/test-unions-ml-stub-generator.$(BEST): $(BUILDDIR)/tests/test-unions
 $(BUILDDIR)/tests/test-unions/generated_struct_stubs.c: $(BUILDDIR)/test-unions-stub-generator.$(BEST)
 	$< --c-struct-file $@
 
+test-abstract-stubs.dir  = tests/test-abstract/stubs
+test-abstract-stubs.threads = yes
+test-abstract-stubs.subproject_deps = ctypes \
+   ctypes-foreign-base ctypes-foreign-threaded tests-common
+test-abstract-stubs: PROJECT=test-abstract-stubs
+test-abstract-stubs: $$(LIB_TARGETS)
+
+test-abstract-stub-generator.dir = tests/test-abstract/stub-generator
+test-abstract-stub-generator.threads = yes
+test-abstract-stub-generator.subproject_deps = ctypes cstubs \
+     ctypes-foreign-base ctypes-foreign-threaded test-abstract-stubs tests-common
+test-abstract-stub-generator.deps = str bigarray bytes integers
+test-abstract-stub-generator: PROJECT=test-abstract-stub-generator
+test-abstract-stub-generator: $$(BEST_TARGET)
+
+test-abstract.dir = tests/test-abstract
+test-abstract.threads = yes
+test-abstract.deps = str bigarray oUnit bytes integers
+test-abstract.subproject_deps = ctypes ctypes-foreign-base \
+   ctypes-foreign-threaded cstubs test-abstract-stubs tests-common
+test-abstract.link_flags = -L$(BUILDDIR)/clib -ltest_functions
+test-abstract: PROJECT=test-abstract
+test-abstract: $$(BEST_TARGET)
+
+test-abstract-generated = \
+  tests/test-abstract/generated_struct_bindings.ml
+
+test-abstract-generated: $(test-abstract-generated)
+
+tests/test-abstract/generated_struct_bindings.ml: $(BUILDDIR)/test-abstract-ml-stub-generator.$(BEST)
+	$< > $@
+$(BUILDDIR)/test-abstract-ml-stub-generator.$(BEST): $(BUILDDIR)/tests/test-abstract/generated_struct_stubs.c
+	$(CC) -I `$(OCAMLFIND) ocamlc -where | sed 's|\r$$||'` $(CFLAGS) $(LDFLAGS) $(WINLDFLAGS) -o $@ $^
+$(BUILDDIR)/tests/test-abstract/generated_struct_stubs.c: $(BUILDDIR)/test-abstract-stub-generator.$(BEST)
+	$< --c-struct-file $@
+
 test-custom_ops.dir = tests/test-custom_ops
 test-custom_ops.threads = yes
 test-custom_ops.deps = str bigarray oUnit bytes integers
@@ -1276,7 +1312,7 @@ tests/test-closure-type-promotion/generated_bindings.ml: $(BUILDDIR)/test-closur
 test-ldouble.dir = tests/test-ldouble
 test-ldouble.threads = yes
 test-ldouble.deps = str bigarray oUnit bytes integers
-test-ldouble.subproject_deps = ctypes 
+test-ldouble.subproject_deps = ctypes
 test-ldouble: PROJECT=test-ldouble
 test-ldouble: $$(BEST_TARGET)
 
@@ -1301,6 +1337,7 @@ TESTS += test-arrays-stubs test-arrays-stub-generator test-arrays-generated test
 TESTS += test-foreign-errno
 TESTS += test-passable
 TESTS += test-alignment
+TESTS += test-abstract-stubs test-abstract-stub-generator test-abstract-generated test-abstract
 TESTS += test-views-stubs test-views-stub-generator test-views-generated test-views
 TESTS += test-oo_style-stubs test-oo_style-stub-generator test-oo_style-generated test-oo_style
 TESTS += test-marshal

--- a/src/cstubs/cstubs.ml
+++ b/src/cstubs/cstubs.ml
@@ -9,7 +9,7 @@
 
 module type FOREIGN = Ctypes.FOREIGN
 
-module type FOREIGN' = FOREIGN with type 'a result = unit
+module type FOREIGN' = Ctypes.FOREIGN with type 'a result = unit
 
 module type BINDINGS = functor (F : FOREIGN') -> sig end
 

--- a/src/cstubs/cstubs.mli
+++ b/src/cstubs/cstubs.mli
@@ -10,16 +10,18 @@
 module Types :
 sig
   module type TYPE = Ctypes.TYPE
+    [@@deprecated "Cstubs.Types.TYPE is deprecated. Use Ctypes.TYPE instead"]
 
-  module type BINDINGS = functor (F : TYPE) -> sig end
+  module type BINDINGS = functor (F : Ctypes.TYPE) -> sig end
 
   val write_c : Format.formatter -> (module BINDINGS) -> unit
 end
 
 
 module type FOREIGN = Ctypes.FOREIGN
+  [@@deprecated "Cstubs.FOREIGN is deprecated. Use Ctypes.FOREIGN instead"]
 
-module type BINDINGS = functor (F : FOREIGN with type 'a result = unit) -> sig end
+module type BINDINGS = functor (F : Ctypes.FOREIGN with type 'a result = unit) -> sig end
 
 type errno_policy
 (** Values of the [errno_policy] type specify the errno support provided by
@@ -35,7 +37,7 @@ val return_errno : errno_policy
     Passing [return_errno] as the [errno] argument to {!Cstubs.write_c} and
     {!Cstubs.write_ml} changes the return type of bound functions from a
     single value to a pair of values.  For example, the binding
-    specification 
+    specification
 
        [let realpath = foreign "reaplath" (string @-> string @-> returning string)]
 

--- a/src/cstubs/cstubs_structs.ml
+++ b/src/cstubs/cstubs_structs.ml
@@ -9,7 +9,7 @@ open Ctypes
 
 module type TYPE = Ctypes.TYPE
 
-module type BINDINGS = functor (F : TYPE) -> sig end
+module type BINDINGS = functor (F : Ctypes.TYPE) -> sig end
 
 let cstring s =
   (* Format a string for output as a C string literal. *)

--- a/src/cstubs/cstubs_structs.ml
+++ b/src/cstubs/cstubs_structs.ml
@@ -7,17 +7,7 @@
 
 open Ctypes
 
-module type TYPE =
-sig
-  include Ctypes_types.TYPE
-
-  type 'a const
-  val constant : string -> 'a typ -> 'a const
-
-  val enum : string -> ?typedef:bool -> ?unexpected:(int64 -> 'a) -> ('a * int64 const) list -> 'a typ
-
-  val interrogated_abstract : name:string -> 'a abstract typ
-end
+module type TYPE = Ctypes.TYPE
 
 module type BINDINGS = functor (F : TYPE) -> sig end
 

--- a/src/cstubs/cstubs_structs.mli
+++ b/src/cstubs/cstubs_structs.mli
@@ -13,6 +13,8 @@ sig
   val constant : string -> 'a typ -> 'a const
 
   val enum : string -> ?typedef:bool -> ?unexpected:(int64 -> 'a) -> ('a * int64 const) list -> 'a typ
+
+  val interrogated_abstract : name:string -> 'a Ctypes.abstract typ
 end
 
 module type BINDINGS = functor (F : TYPE) -> sig end

--- a/src/cstubs/cstubs_structs.mli
+++ b/src/cstubs/cstubs_structs.mli
@@ -5,17 +5,7 @@
  * See the file LICENSE for details.
  *)
 
-module type TYPE =
-sig
-  include Ctypes_types.TYPE
-
-  type 'a const
-  val constant : string -> 'a typ -> 'a const
-
-  val enum : string -> ?typedef:bool -> ?unexpected:(int64 -> 'a) -> ('a * int64 const) list -> 'a typ
-
-  val interrogated_abstract : name:string -> 'a Ctypes.abstract typ
-end
+module type TYPE = Ctypes.TYPE
 
 module type BINDINGS = functor (F : TYPE) -> sig end
 

--- a/src/cstubs/cstubs_structs.mli
+++ b/src/cstubs/cstubs_structs.mli
@@ -6,7 +6,8 @@
  *)
 
 module type TYPE = Ctypes.TYPE
+  [@@deprecated "Cstubs_structs.TYPE is deprecated. Use Ctypes.TYPE instead"]
 
-module type BINDINGS = functor (F : TYPE) -> sig end
+module type BINDINGS = functor (F : Ctypes.TYPE) -> sig end
 
 val write_c : Format.formatter -> (module BINDINGS) -> unit

--- a/src/ctypes/ctypes.ml
+++ b/src/ctypes/ctypes.ml
@@ -41,5 +41,4 @@ sig
   val constant : string -> 'a typ -> 'a const
   val enum : string -> ?typedef:bool ->
     ?unexpected:(int64 -> 'a) -> ('a * int64 const) list -> 'a typ
-  val interrogated_abstract : name:string -> 'a abstract typ
 end

--- a/src/ctypes/ctypes.ml
+++ b/src/ctypes/ctypes.ml
@@ -41,4 +41,5 @@ sig
   val constant : string -> 'a typ -> 'a const
   val enum : string -> ?typedef:bool ->
     ?unexpected:(int64 -> 'a) -> ('a * int64 const) list -> 'a typ
+  val interrogated_abstract : name:string -> 'a abstract typ
 end

--- a/src/ctypes/ctypes.mli
+++ b/src/ctypes/ctypes.mli
@@ -303,7 +303,7 @@ sig
       itself as the second argument. *)
 
   val fold_left : ('a -> 'b -> 'a) -> 'a -> 'b t -> 'a
-  (** [CArray.fold_left (@) x a] computes 
+  (** [CArray.fold_left (@) x a] computes
          [(((x @ a.(0)) @ a.(1)) ...) @ a.(n-1)]
        where [n] is the length of the array [a]. *)
 
@@ -528,7 +528,7 @@ sig
       The value [alist] is an association list of OCaml values and values
       retrieved by the [constant] function.  For example, to expose the enum
 
-        enum letters \{ A, B, C = 10, D \}; 
+        enum letters \{ A, B, C = 10, D \};
 
       you might first retrieve the values of the enumeration constants:
 
@@ -564,6 +564,8 @@ sig
       If [typedef] is [true] then [name] is instead treated as an alias:
 
         [typedef enum { ... } letters] *)
+
+  val interrogated_abstract : name:string -> 'a abstract typ
 end
 
 (** {2:roots Registration of OCaml values as roots} *)

--- a/src/ctypes/ctypes.mli
+++ b/src/ctypes/ctypes.mli
@@ -564,8 +564,6 @@ sig
       If [typedef] is [true] then [name] is instead treated as an alias:
 
         [typedef enum { ... } letters] *)
-
-  val interrogated_abstract : name:string -> 'a abstract typ
 end
 
 (** {2:roots Registration of OCaml values as roots} *)

--- a/src/ctypes/ctypes_memory.ml
+++ b/src/ctypes/ctypes_memory.ml
@@ -57,7 +57,8 @@ let rec write : type a b. a typ -> a -> b Fat.t -> unit
     | Struct { spec = Complete _ } as s -> write_aggregate (sizeof s)
     | Union { uspec = None } -> raise IncompleteType
     | Union { uspec = Some { size } } -> write_aggregate size
-    | Abstract { asize } -> write_aggregate asize
+    | Abstract { asize = None } -> raise IncompleteType
+    | Abstract { asize = Some size } -> write_aggregate size
     | Array _ as a ->
       let size = sizeof a in
       (fun { astart = CPointer src } dst ->
@@ -415,7 +416,7 @@ struct
 
   let set : 'a. unit ptr -> 'a -> unit =
     fun p v -> Stubs.set (raw_addr p) v
-  
+
   let release : 'a. unit ptr -> unit =
     fun p -> Stubs.release (raw_addr p)
 end

--- a/src/ctypes/ctypes_static.mli
+++ b/src/ctypes/ctypes_static.mli
@@ -9,8 +9,8 @@
 
 type abstract_type = {
   aname : string;
-  asize : int;
-  aalignment : int;
+  asize : int option;
+  aalignment : int option;
 }
 
 type _ ocaml_type =
@@ -152,7 +152,7 @@ val ocaml_bytes : Bytes.t ocaml typ
 val ocaml_float_array : float array ocaml typ
 val ptr : 'a typ -> 'a ptr typ
 val ( @-> ) : 'a typ -> 'b fn -> ('a -> 'b) fn
-val abstract : name:string -> size:int -> alignment:int -> 'a abstract typ
+val abstract : name:string -> ?size:int -> ?alignment:int -> 'a abstract typ
 val view : ?format_typ:((Format.formatter -> unit) ->
                         Format.formatter -> unit) ->
            ?format: (Format.formatter -> 'b -> unit) ->

--- a/src/ctypes/ctypes_types.mli
+++ b/src/ctypes/ctypes_types.mli
@@ -327,9 +327,17 @@ sig
 
   (** {3 Abstract types} *)
 
-  val abstract : name:string -> size:int -> alignment:int -> 'a Ctypes_static.abstract typ
-  (** Create an abstract type specification from the size and alignment
-      requirements for the type. *)
+  val abstract : name:string -> ?size:int -> ?alignment:int -> 'a Ctypes_static.abstract typ
+  (** Create an abstract type specification.
+
+      If [abstract] is used with [Cstubs_structs], [Cstubs_structs] generates
+      code for automatically discovering the size and alignment from C. [~size]
+      and [~alignment] can still be specified to override the discovered values.
+
+      When not using [Cstubs_structs], not specifying [~size] and [~alignment]
+      results in an incomplete type, which cannot be used in structs, unions, or
+      arrays, and cannot have [Ctypes.sizeof] and/or [Ctypes.alignment] applied
+      to it. *)
 
   (** {3 Injection of concrete types} *)
 

--- a/src/ctypes/ctypes_types.mli
+++ b/src/ctypes/ctypes_types.mli
@@ -331,8 +331,10 @@ sig
   (** Create an abstract type specification.
 
       If [abstract] is used with [Cstubs_structs], [Cstubs_structs] generates
-      code for automatically discovering the size and alignment from C. [~size]
-      and [~alignment] can still be specified to override the discovered values.
+      code for automatically discovering the size and alignment from C. It is
+      recommended to pass [?size:None] and [?alignment:None] in this case. If
+      specific values are passed (e.g. [~size:4]), they are checked against the
+      discovered values. It is an error if the values don't match.
 
       When not using [Cstubs_structs], not specifying [~size] and [~alignment]
       results in an incomplete type, which cannot be used in structs, unions, or

--- a/tests/test-abstract/stub-generator/driver.ml
+++ b/tests/test-abstract/stub-generator/driver.ml
@@ -1,0 +1,5 @@
+module No_functions (F : Ctypes.FOREIGN) = struct end
+
+let () = Tests_common.run Sys.argv
+   ~structs:(module Types.Struct_stubs)
+   (module No_functions)

--- a/tests/test-abstract/stubs/types.ml
+++ b/tests/test-abstract/stubs/types.ml
@@ -1,0 +1,9 @@
+open Ctypes
+
+module Struct_stubs (S : Ctypes.TYPE) =
+struct
+  open S
+
+  let abstract_int : [`abstract_char] abstract typ =
+    abstract ~name:"int" ?size:None ?alignment:None
+end

--- a/tests/test-abstract/test_abstract.ml
+++ b/tests/test-abstract/test_abstract.ml
@@ -1,0 +1,49 @@
+open OUnit2
+open Ctypes
+
+module Generated = Generated_struct_bindings
+
+let suite = "Abstract type tests" >::: [
+  "inferred" >:: begin fun _ ->
+    let t = Generated.abstract ~name:"int" ?size:None ?alignment:None in
+    assert_equal (sizeof t) (sizeof int);
+    assert_equal (alignment t) (alignment int)
+  end;
+
+  "guessed" >:: begin fun _ ->
+    let size = sizeof int in
+    let alignment = alignment int in
+    let t = Generated.abstract ~name:"int" ~size ~alignment in
+    assert_equal (sizeof t) size;
+    assert_equal (Ctypes.alignment t) alignment
+  end;
+
+  "wrong size" >:: begin fun _ ->
+    let size = sizeof int in
+    let expected_message =
+      Printf.sprintf
+        "Inferred size for int is %i, but ~size:%i was passed to Ctypes.abstract"
+        size (size + 1)
+    in
+    assert_raises
+      (Failure expected_message)
+      (fun () ->
+        Generated.abstract ~name:"int" ~size:(size + 1) ?alignment:None)
+  end;
+
+  "wrong alignment" >:: begin fun _ ->
+    let alignment = alignment int in
+    let expected_message =
+      Printf.sprintf
+        "Inferred alignment for int is %i, but ~alignment:%i was passed to Ctypes.abstract"
+        alignment (alignment + 1)
+    in
+    assert_raises
+      (Failure expected_message)
+      (fun () ->
+        Generated.abstract ~name:"int" ?size:None ~alignment:(alignment + 1))
+  end;
+]
+
+let _ =
+  run_test_tt_main suite


### PR DESCRIPTION
This adds a new function to `Cstubs_structs`,

```ocaml
val interrogated_abstract : name:string -> 'a abstract typ
```

Usage is like:

```ocaml
type os_fd
type t = os_fd abstract
let t : t typ = interrogated_abstract ~name:"uv_os_fd_t"
```

<br/>

It works like the existing

```ocaml
val abstract : name:string -> size:int -> alignment:int -> 'a abstract typ
```

and is based on it, but it generates some C code to figure out `~size` and `~alignment`. The interesting part of that generated C code looks like this:

```c
  printf("  | \"uv_os_fd_t\" ->\n    abstract ~name ~size:%lu ~alignment:%lu\n",
        sizeof(uv_os_fd_t), offsetof(struct { char c; uv_os_fd_t x; }, x));
```

...which eventually generates the OCaml code:

```ocaml
let interrogated_abstract ~name =
  match name with
  | "uv_os_fd_t" ->
    abstract ~name ~size:4 ~alignment:4
  | _ ->
    failwith ("unmatched abstract type: " ^ name)
```

<br/>

I marked this PR as POC because I don't know what to call this new function, or where it properly belongs. My original idea was to shadow `abstract` in `Cstubs_structs` with this new version, but this is a breaking change, unless I add `?size` and `?alignment` as optional arguments. I'm also not sure what the counterpart to `interrogated_abstract` should be in `Foreign`. I'm not sure how one would get this kind of interrogation with libffi, or if it's possible. I'd assume it's at least very difficult.

I'll be happy to adjust the PR, with comments on the previous paragraph. And I can write docs in `ctypes.mli` :)