### PR TITLE
Allow passing OCaml values directly to stubs

### DIFF
--- a/src/cstubs/cstubs_analysis.ml
+++ b/src/cstubs/cstubs_analysis.ml
@@ -21,7 +21,7 @@ let rec float : type a. a fn -> bool = function
 
 (* A value of type 'a noalloc says that reading a value of type 'a
    will not cause an OCaml allocation in C code. *)
-type _ noalloc =
+type 'a noalloc =
   Noalloc_unit : unit noalloc
 | Noalloc_int : int noalloc
 | Noalloc_uint8_t : Unsigned.uint8 noalloc
@@ -29,6 +29,7 @@ type _ noalloc =
 | Noalloc_char : char noalloc
 | Noalloc_bool : bool noalloc
 | Noalloc_view : ('a, 'b) view * 'b noalloc -> 'a noalloc
+| Noalloc_value : 'a noalloc
 
 (* A value of type 'a alloc says that reading a value of type 'a
    may cause an OCaml allocation in C code. *)
@@ -109,6 +110,7 @@ let rec allocation : type a. a typ -> a allocation = function
  | Array _ -> `Alloc Alloc_array
  | Bigarray ba -> `Alloc (Alloc_bigarray ba)
  | OCaml _ -> `Alloc Alloc_pointer
+ | OCaml_value -> `Noalloc Noalloc_value
 
 let rec may_allocate : type a. a fn -> bool = function
   | Returns t ->

--- a/src/cstubs/cstubs_generate_ml.ml
+++ b/src/cstubs/cstubs_generate_ml.ml
@@ -30,7 +30,7 @@ type ml_pat = [ `Var of string
               | `Underscore
               | `Con of path * ml_pat list ]
 
-type ml_exp = [ `Ident of path 
+type ml_exp = [ `Ident of path
               | `Project of ml_exp * path
               | `MakePtr of ml_exp * ml_exp
               | `MakeFunPtr of ml_exp * ml_exp
@@ -52,7 +52,7 @@ type extern = {
   attributes: attributes;
 }
 
-module Emit_ML : sig 
+module Emit_ML : sig
   type appl_parens = ApplParens | NoApplParens
   val ml_exp : appl_parens -> Format.formatter -> ml_exp -> unit
   val ml_pat : appl_parens -> Format.formatter -> ml_pat -> unit
@@ -62,13 +62,13 @@ end =
 struct
   let fprintf = Format.fprintf
 
-  (* We (only) need to parenthesize function types in certain contexts 
+  (* We (only) need to parenthesize function types in certain contexts
         * on the lhs of a function type: - -> t
         * as the argument to a single-argument type constructor: - t
   *)
   type arrow_parens = ArrowParens | NoArrowParens
 
-  (* We (only) need to parenthesize application expressions in certain contexts 
+  (* We (only) need to parenthesize application expressions in certain contexts
         * in a projection expression: -.l
         * in a dereference expression: !@ -
         * as an argument in an application: e -
@@ -108,7 +108,7 @@ struct
     | Some primname -> fprintf fmt "%S@ " primname
 
   let attrs fmt { float; noalloc } =
-    begin 
+    begin
     (* TODO: float support not yet implemented *)
     (* if float then pp_print_string fmt "\"float\""; *)
 
@@ -250,6 +250,7 @@ let rec ml_typ_of_return_typ : type a. a typ -> ml_type =
     "cstubs does not support OCaml bytes values as return values"
   | OCaml FloatArray -> Ctypes_static.unsupported
     "cstubs does not support OCaml float arrays as return values"
+  | OCaml_value -> `Ident (literal_path "'a")
 
 let rec ml_typ_of_arg_typ : type a. a typ -> ml_type = function
   | Void -> `Ident (path_of_string "unit")
@@ -274,6 +275,8 @@ let rec ml_typ_of_arg_typ : type a. a typ -> ml_type = function
     `Appl (path_of_string "CI.ocaml",
            [`Appl (path_of_string "array",
                    [`Ident (path_of_string "float")])])
+  | OCaml_value ->
+    `Ident (literal_path "'a")
 
 type polarity = In | Out
 
@@ -348,7 +351,7 @@ let map_result ~concurrency ~errno f e =
   | _, _, `MakeStructured x ->
     map_result (`Appl (`Ident make_structured, `Ident (path_of_string x))) e
   | _, _, `Appl x ->
-    map_result (`Ident (path_of_string x)) e 
+    map_result (`Ident (path_of_string x)) e
 
 let rec pattern_and_exp_of_typ : type a. concurrency:concurrency_policy -> errno:errno_policy ->
   a typ -> ml_exp -> polarity -> (lident * ml_exp) list -> ml_pat * ml_exp option * (lident * ml_exp) list =
@@ -433,6 +436,7 @@ let rec pattern_and_exp_of_typ : type a. concurrency:concurrency_policy -> errno
     | Out, FloatArray -> Ctypes_static.unsupported
       "cstubs does not support OCaml float arrays as return values"
     end
+  | OCaml_value -> (static_con "OCaml_value" [], None, binds)
   | Abstract _ as ty -> internal_error
     "Unexpected abstract type encountered during ML code generation: %s"
     (Ctypes.string_of_typ ty)
@@ -473,6 +477,9 @@ let rec pattern_of_typ : type a. a typ -> ml_pat = function
   | OCaml FloatArray ->
     Ctypes_static.unsupported
       "cstubs does not support OCaml float arrays as global values"
+  | OCaml_value ->
+    Ctypes_static.unsupported
+      "cstubs does not support generic OCaml values as global values"
   | Abstract _ as ty ->
     internal_error
       "Unexpected abstract type encountered during ML code generation: %s"
@@ -600,5 +607,5 @@ let inverse_case ~register_name ~constructor name fmt fn : unit =
       (path_of_string "f") fn "f" Out in
   Format.fprintf fmt "|@[ @[%a, %S@] -> %s %s (%a)@]@\n"
     Emit_ML.(ml_pat NoApplParens) p name register_name constructor
-    Emit_ML.(ml_exp ApplParens) 
+    Emit_ML.(ml_exp ApplParens)
     e

--- a/src/cstubs/ctypes_path.ml
+++ b/src/cstubs/ctypes_path.ml
@@ -20,10 +20,13 @@ let rec is_valid_path = function
   | [l] -> is_ident l
   | u :: p -> is_uident u && is_valid_path p
 
-let path_of_string s = 
+let path_of_string s =
   let p = Str.(split (regexp_string ".") s) in
   if is_valid_path p then p
   else invalid_arg "Ctypes_ident.path_of_string"
 
 let format_path fmt p =
   Format.pp_print_string fmt (String.concat "." p)
+
+let literal_path s =
+  [s]

--- a/src/cstubs/ctypes_path.mli
+++ b/src/cstubs/ctypes_path.mli
@@ -10,4 +10,5 @@
 type path
 
 val path_of_string : string -> path
+val literal_path : string -> path
 val format_path : Format.formatter -> path -> unit

--- a/src/ctypes-foreign-base/ctypes_ffi.ml
+++ b/src/ctypes-foreign-base/ctypes_ffi.ml
@@ -64,6 +64,7 @@ struct
     | Pointer _                           -> ArgType (Ctypes_ffi_stubs.pointer_ffitype ())
     | Funptr _                            -> ArgType (Ctypes_ffi_stubs.pointer_ffitype ())
     | OCaml _                             -> ArgType (Ctypes_ffi_stubs.pointer_ffitype ())
+    | OCaml_value                         -> ArgType (Ctypes_ffi_stubs.pointer_ffitype ())
     | Union _                             -> report_unpassable "unions"
     | Struct ({ spec = Complete _ } as s) -> struct_arg_type s
     | View { ty }                         -> arg_type ty
@@ -111,7 +112,7 @@ struct
           let v = Ctypes_ffi_stubs.call name addr callspec
               (fun buf arr -> List.iter (fun w -> r := w buf arr :: !r) writers)
               read_return_value
-          in 
+          in
           Ctypes_memory_stubs.use_value r;
           v
       | WriteArg (write, ccallspec) ->
@@ -164,11 +165,11 @@ struct
     | OCaml Bytes      -> ocaml_arg 1
     | OCaml FloatArray -> ocaml_arg (Ctypes_primitives.sizeof Ctypes_primitive_types.Double)
     | View { write = w; ty } ->
-      (fun ~offset ~idx v dst mov -> 
+      (fun ~offset ~idx v dst mov ->
          let wv = w v in
          let wa = write_arg ty ~offset ~idx wv dst mov in
          Obj.repr (wv, wa))
-    | ty -> (fun ~offset ~idx v dst mov -> 
+    | ty -> (fun ~offset ~idx v dst mov ->
         Ctypes_memory.write ty v
           (Ctypes_ptr.Fat.(add_bytes (make ~reftyp:Void dst) offset));
         Obj.repr v)

--- a/src/ctypes/cstubs_internals.mli
+++ b/src/ctypes/cstubs_internals.mli
@@ -43,6 +43,7 @@ type 'a typ = 'a Ctypes_static.typ =
   | Array           : 'a typ * int              -> 'a Ctypes_static.carray typ
   | Bigarray        : (_, 'a, _) Ctypes_bigarray.t -> 'a typ
   | OCaml           : 'a ocaml_type             -> 'a ocaml typ
+  | OCaml_value     :                              'a typ
 and ('a, 'b) pointer = ('a, 'b) Ctypes_static.pointer =
   CPointer : 'a typ Ctypes_ptr.Fat.t -> ('a, [`C]) pointer
 | OCamlRef : int * 'a * 'a ocaml_type -> ('a, [`OCaml]) pointer

--- a/src/ctypes/ctypes_memory.ml
+++ b/src/ctypes/ctypes_memory.ml
@@ -35,6 +35,7 @@ let rec build : type a b. a typ -> b typ Fat.t -> a
       let buildty = build ty in
       (fun buf -> read (buildty buf))
     | OCaml _ -> (fun buf -> assert false)
+    | OCaml_value -> (fun buf -> assert false)
     (* The following cases should never happen; non-struct aggregate
        types are excluded during type construction. *)
     | Union _ -> assert false
@@ -73,6 +74,7 @@ let rec write : type a b. a typ -> a -> b Fat.t -> unit
       let writety = write ty in
       (fun v -> writety (w v))
     | OCaml _ -> raise IncompleteType
+    | OCaml_value -> raise IncompleteType
 
 let null : unit ptr = CPointer (Fat.make ~reftyp:Void Raw.null)
 
@@ -415,7 +417,7 @@ struct
 
   let set : 'a. unit ptr -> 'a -> unit =
     fun p v -> Stubs.set (raw_addr p) v
-  
+
   let release : 'a. unit ptr -> unit =
     fun p -> Stubs.release (raw_addr p)
 end

--- a/src/ctypes/ctypes_static.mli
+++ b/src/ctypes/ctypes_static.mli
@@ -13,7 +13,7 @@ type abstract_type = {
   aalignment : int;
 }
 
-type _ ocaml_type =
+type 'a ocaml_type =
   String     : string ocaml_type
 | Bytes      : Bytes.t ocaml_type
 | FloatArray : float array ocaml_type
@@ -39,6 +39,7 @@ type _ typ =
   | Bigarray        : (_, 'a, _) Ctypes_bigarray.t
                                          -> 'a typ
   | OCaml           : 'a ocaml_type      -> 'a ocaml typ
+  | OCaml_value     :                       'a typ
 and 'a carray = { astart : 'a ptr; alength : int }
 and ('a, 'kind) structured = { structured : ('a, 'kind) structured ptr }
 and 'a union = ('a, [`Union]) structured
@@ -149,6 +150,7 @@ val ullong : Unsigned.ullong typ
 val array : int -> 'a typ -> 'a carray typ
 val ocaml_string : string ocaml typ
 val ocaml_bytes : Bytes.t ocaml typ
+val ocaml_any_value : 'a typ
 val ocaml_float_array : float array ocaml typ
 val ptr : 'a typ -> 'a ptr typ
 val ( @-> ) : 'a typ -> 'b fn -> ('a -> 'b) fn

--- a/src/ctypes/ctypes_type_printing.ml
+++ b/src/ctypes/ctypes_type_printing.ml
@@ -76,6 +76,8 @@ let rec format_typ' : type a. a typ ->
     | OCaml String -> format_typ' (ptr char) k context fmt
     | OCaml Bytes -> format_typ' (ptr char) k context fmt
     | OCaml FloatArray -> format_typ' (ptr double) k context fmt
+    | OCaml_value ->
+      fprintf fmt "value%t" (k `nonarray)
 
 and format_fields : type a. a boxed_field list -> Format.formatter -> unit =
   fun fields fmt ->

--- a/src/ctypes/ctypes_types.mli
+++ b/src/ctypes/ctypes_types.mli
@@ -212,6 +212,10 @@ sig
   val ocaml_bytes : Bytes.t Ctypes_static.ocaml typ
   (** Value representing the directly mapped storage of an OCaml byte array. *)
 
+  val ocaml_any_value : 'a typ
+  (** Value representing any OCaml value, to be accessed from C directly. This
+      corresponds to the C type [value] from [caml/mlvalues.h]. *)
+
   (** {3 Array types} *)
 
   (** {4 C array types} *)

--- a/src/ctypes/ctypes_value_printing.ml
+++ b/src/ctypes/ctypes_value_printing.ml
@@ -22,6 +22,7 @@ let rec format : type a. a typ -> Format.formatter -> a -> unit
     (fun fmt -> Ctypes_type_printing.format_typ fmt) typ
   | Abstract _ -> format_structured fmt v
   | OCaml _ -> format_ocaml fmt v
+  | OCaml_value -> Format.pp_print_string fmt "(value)"
   | View {write; ty; format=f} ->
     begin match f with
       | None -> format ty fmt (write v)


### PR DESCRIPTION
I want to call

```c
void get_sockaddr(value mladr,
                  union sock_addr_union * adr /*out*/,
                  socklen_param_type * adr_len /*out*/);
```

...but I found no way to pass the `value` argument in current ctypes.

So, this PR adds:

```ocaml
val ocaml_any_value : 'a typ
(** Value representing any OCaml value, to be accessed from C directly. This
    corresponds to the C type [value] from [caml/mlvalues.h]. *)
```

...which is used like this:

```ocaml
(* type t defined elsewhere *)
let unix_sockaddr : Unix.sockaddr typ = ocaml_any_value

let get =
  foreign "get_sockaddr"
    (unix_sockaddr @-> ptr t @-> ptr int @-> returning void)
```

The ML code generated for `get` is:

```ocaml
external luv_stub_63_get_sockaddr : 'a -> _ CI.fatptr -> _ CI.fatptr -> unit
  = "luv_stub_63_get_sockaddr"

(* ... *)

| Function
    (CI.OCaml_value,
     Function (CI.Pointer _, Function (CI.Pointer _, Returns CI.Void))),
  "get_sockaddr" ->
  (fun x13 x14 x15 ->
    luv_stub_63_get_sockaddr x13 (CI.cptr x14) (CI.cptr x15))
```

...and the C stub is:

```c
value luv_stub_63_get_sockaddr(value x270, value x269, value x268)
{
   union sock_addr_union* x272 = CTYPES_ADDR_OF_FATPTR(x269);
   int* x273 = CTYPES_ADDR_OF_FATPTR(x268);
   get_sockaddr(x270, x272, x273);
   return Val_unit;
}
```

These look right to me, and seem to work. I'm not sure about some of the other code this PR touches, like in `cstubs_analysis.ml`.
