### PR TITLE
use_value updates

### DIFF
--- a/src/ctypes/ctypes_memory_stubs.ml
+++ b/src/ctypes/ctypes_memory_stubs.ml
@@ -48,4 +48,4 @@ external string_of_array : _ Fat.t -> len:int -> string
 
 (* Do nothing, concealing from the optimizer that nothing is being done. *)
 external use_value : 'a -> unit
-  = "ctypes_use"
+  = "ctypes_use" "noalloc"

--- a/src/ctypes/ctypes_roots.c
+++ b/src/ctypes/ctypes_roots.c
@@ -38,5 +38,5 @@ value ctypes_caml_roots_release(value p_)
 /* 'a -> unit */
 value ctypes_use(value v)
 {
-  return v;
+  return Val_unit;
 }


### PR DESCRIPTION
The trivial `use_value` function is used internally in ctypes to manage object lifetimes.  This PR makes two improvements

* Mark `use_value` `noalloc` to reduce overhead
* Return `Val_unit`, as the type signature promises. (Thanks, @lindig.)