### PR TITLE
Drop OCaml 4.01 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ os:
   - linux
   - osx
 env:
-  - OCAML_VERSION=4.01.0
   - OCAML_VERSION=4.02.3 COVERAGE=true
   - OCAML_VERSION=4.02.3 ARM=true
   - OCAML_VERSION=4.03.0
@@ -26,8 +25,6 @@ matrix:
       env: OCAML_VERSION=4.02.3 ARM=true
     - os: osx
       env: OCAML_VERSION=4.02.3 COVERAGE=true
-    - os: osx
-      env: OCAML_VERSION=4.01.0
     - os: osx
       env: OCAML_VERSION=4.04.0+flambda
     - os: osx

--- a/ctypes.opam
+++ b/ctypes.opam
@@ -45,4 +45,4 @@ build-test: [
    ["sh" "-c" "ocveralls" "--send bisect*.out" "_build/bisect*.out" ">" "coveralls.json"] {bisect_ppx:installed}
 ]
 tags: ["org:ocamllabs" "org:mirage"]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.02.3" ]

--- a/src/cstubs/cstubs_generate_c.ml
+++ b/src/cstubs/cstubs_generate_c.ml
@@ -370,10 +370,10 @@ struct
   let structure (type r) ~errno ~stub_name fmt fn args (result : r typ) =
     let open Ctypes in
     let s = structure_type stub_name in
-    let (_ : (_,_) field) = field s "job" lwt_unix_job in
+    let _ : (_,_) field = field s "job" lwt_unix_job in
     let () = match result with
-        Void -> let (_ : (_,_) field) = field s "result" int in ()
-      | result -> let (_ : (_,_) field) = field s "result" result in ()
+        Void -> let _ : (_,_) field = field s "result" int in ()
+      | result -> let _ : (_,_) field = field s "result" result in ()
     in
     let () = match errno with
         `Ignore_errno -> ()

--- a/src/ctypes-foreign-threaded/foreign.ml
+++ b/src/ctypes-foreign-threaded/foreign.ml
@@ -10,6 +10,6 @@ include Ctypes_foreign_basis.Make(Ctypes_closure_properties.Make(Mutex))
 let () = begin
   (* Initialize the Thread library and set up the hook for registering C
      threads with the OCaml runtime *)
-  let (_ : Thread.t) = Thread.self () in
+  let _ : Thread.t = Thread.self () in
   Ctypes_foreign_threaded_stubs.setup_thread_registration ()
 end

--- a/src/ctypes/ctypes_bigarray.ml
+++ b/src/ctypes/ctypes_bigarray.ml
@@ -105,14 +105,10 @@ let kind_type_names : type a. a kind -> _ = function
     (`Ident ["char"],
      `Ident ["Bigarray"; "int8_unsigned_elt"])
 
-(** OCaml-4.01-compatible comparison.  This can be replaced with
-    pattern matching once ctypes requires OCaml 4.02 *)
-type boxed_layout = Boxed_layout : _ Bigarray.layout -> boxed_layout
 let layout_path : type a. a Bigarray.layout -> string list =
-  fun layout ->
-    if Boxed_layout layout = Boxed_layout Bigarray.c_layout
-    then ["Bigarray"; "c_layout"]
-    else ["Bigarray"; "fortran_layout"]
+  function
+  | Bigarray.C_layout -> ["Bigarray"; "c_layout"]
+  | Bigarray.Fortran_layout -> ["Bigarray"; "fortran_layout"]
 
 let type_expression : type a b l. (a, b, l) t -> _ =
   fun (t, ck, l) ->

--- a/src/ctypes/ctypes_bigarray_stubs.ml
+++ b/src/ctypes/ctypes_bigarray_stubs.ml
@@ -20,15 +20,20 @@ type _ kind =
   | Kind_complex64 : Complex.t kind
   | Kind_char : char kind
 
-external kind : ('a, 'b) Bigarray.kind -> 'a kind
-  (* Bigarray.kind is simply an int whose values are consecutively numbered
-     starting from zero, so we can directly transform its values to a variant
-     with appropriately-ordered constructors.
-
-     In OCaml <= 4.01.0, Bigarray.char and Bigarray.int8_unsigned are
-     indistinguishable, so the 'kind' function will never return Kind_char.
-     OCaml 4.02.0 gives the types distinct representations. *)
-  = "%identity"
+let kind : type a b. (a, b) Bigarray.kind -> a kind = function
+  | Bigarray.Float32 -> Kind_float32
+  | Bigarray.Float64 -> Kind_float64
+  | Bigarray.Int8_signed -> Kind_int8_signed
+  | Bigarray.Int8_unsigned -> Kind_int8_unsigned
+  | Bigarray.Int16_signed -> Kind_int16_signed
+  | Bigarray.Int16_unsigned -> Kind_int16_unsigned
+  | Bigarray.Int32 -> Kind_int32
+  | Bigarray.Int64 -> Kind_int64
+  | Bigarray.Int -> Kind_int
+  | Bigarray.Nativeint -> Kind_nativeint
+  | Bigarray.Complex32 -> Kind_complex32
+  | Bigarray.Complex64 -> Kind_complex64
+  | Bigarray.Char -> Kind_char
 
 external address : 'b -> Ctypes_ptr.voidp
   = "ctypes_bigarray_address"

--- a/tests/test-coercions/test_coercions.ml
+++ b/tests/test-coercions/test_coercions.ml
@@ -270,7 +270,7 @@ let test_unsupported_coercions _ =
       ListLabels.iter types ~f:(fun (T t1, ts) ->
       ListLabels.iter ts ~f:(fun (T t2) ->
               try 
-                let (_ : _ -> _) = coerce t1 t2 in
+                let _ : _ -> _ = coerce t1 t2 in
                 assert_failure "coercion unexpectedly succeeded"
               with Uncoercible _ -> ()))
   end in ()


### PR DESCRIPTION
Restrict OPAM and Travis to require OCaml versions from 4.02 onwards.

Also take advantage of a couple of new features:
   * new syntax `let pat : type = expression` (previously `pat` was restricted to variables)
  * GADT representations for bigarray element types and layouts

Closes #576