### PR TITLE
Fix LDouble.to_int

### DIFF
--- a/src/ctypes/lDouble.ml
+++ b/src/ctypes/lDouble.ml
@@ -77,3 +77,5 @@ let one = of_int 1
 external size_ : unit -> (int * int) = "ctypes_ldouble_size"
 let byte_sizes = size_ ()
 
+external mant_dig_ : unit -> int = "ctypes_ldouble_mant_dig" "noalloc"
+let mant_dig = mant_dig_ ()

--- a/src/ctypes/lDouble.mli
+++ b/src/ctypes/lDouble.mli
@@ -178,3 +178,5 @@ val byte_sizes : int * int
     and the actual number of bytes used by the value.
     (unused bytes may contain undefined values) *)
 
+val mant_dig : int
+(** size of mantissa *)

--- a/src/ctypes/ldouble_stubs.c
+++ b/src/ctypes/ldouble_stubs.c
@@ -213,7 +213,9 @@ CAMLprim value ctypes_ldouble_of_int(value a) {
 }
 CAMLprim value ctypes_ldouble_to_int(value a) {
   CAMLparam1(a);
-  CAMLreturn(Val_long(ldouble_custom_val(a)));
+  long double b = ldouble_custom_val(a);
+  intnat c = b;
+  CAMLreturn(Val_long(c));
 }
 
 #define OP2(OPNAME, OP)                                                               \
@@ -563,3 +565,7 @@ value ldouble_init(value unit) {
   return Val_unit;
 }
 
+CAMLprim value ctypes_ldouble_mant_dig(value unit) {
+  intnat r = LDBL_MANT_DIG;
+  return Val_long(r);
+}


### PR DESCRIPTION
`long double` must be casted to `intnat` first, not to `uintnat` directly. Otherwise the conversion is undefined behavior for nearly all negative values, see: http://c0x.coding-guidelines.com/6.3.1.4.html , Note 50. 

The code was correct until https://github.com/ocaml/ocaml/commit/24c118d7b63cdab58ed9bad28e2d337e9d1d30ba
. It seems to work as intended on x86 platforms and the CI for ARM still uses OCaml 4.02.3.