### PR TITLE
use CMPLX[FL]? macros instead of I

### DIFF
--- a/src/ctypes/ctypes_complex_compatibility.h
+++ b/src/ctypes/ctypes_complex_compatibility.h
@@ -8,12 +8,6 @@
 #ifndef CTYPES_COMPLEX_COMPATIBILITY_H
 #define CTYPES_COMPLEX_COMPATIBILITY_H
 
-#if defined(__ANDROID__)
-
-#include <math.h>
-
-#include <caml/fail.h>
-
 /* "Each complex type has the same representation and alignment
     requirements as an array type containing exactly two elements of
     the corresponding real type; the first element is equal to the real
@@ -26,14 +20,28 @@ union ctypes_complex_long_double_union {
   long double parts[2];
 };
 
+union ctypes_complex_double_union {
+  double _Complex z;
+  double parts[2];
+};
+
+union ctypes_complex_float_union {
+  float _Complex z;
+  float parts[2];
+};
+
+#if defined(__ANDROID__)
+#define CTYPES_USE_STRUCT_BUILDER 1
+
+#include <math.h>
+
+#include <caml/fail.h>
+
 static inline long double ctypes_compat_creall(long double _Complex z)
 { union ctypes_complex_long_double_union u; u.z = z; return u.parts[0]; }
 
 static inline long double ctypes_compat_cimagl(long double _Complex z)
 { union ctypes_complex_long_double_union u; u.z = z; return u.parts[1]; }
-
-static inline long double _Complex ctypes_compat_make_complexl(long double re, long double im)
-{ union ctypes_complex_long_double_union u; u.parts[0] = re; u.parts[1] = im; return u.z; }
 
 static inline long double _Complex ctypes_compat_conjl(long double _Complex z)
 { union ctypes_complex_long_double_union u; u.z = z; u.parts[1] = -u.parts[1]; return u.z; }
@@ -44,36 +52,20 @@ static inline long double _Complex ctypes_compat_csqrtl(long double _Complex z)
 static inline long double ctypes_compat_cargl(long double _Complex z)
 { return atan2(ctypes_compat_cimagl(z), ctypes_compat_creall(z)); }
 
-union ctypes_complex_double_union {
-  double _Complex z;
-  double parts[2];
-};
-
 static inline double ctypes_compat_creal(double _Complex z)
 { union ctypes_complex_double_union u; u.z = z; return u.parts[0]; }
 
 static inline double ctypes_compat_cimag(double _Complex z)
 { union ctypes_complex_double_union u; u.z = z; return u.parts[1]; }
 
-static inline double _Complex ctypes_compat_make_complex(double re, double im)
-{ union ctypes_complex_double_union u; u.parts[0] = re; u.parts[1] = im; return u.z; }
-
 static inline double _Complex ctypes_compat_conj(double _Complex z)
 { union ctypes_complex_double_union u; u.z = z; u.parts[1] = -u.parts[1]; return u.z; }
-
-union ctypes_complex_float_union {
-  float _Complex z;
-  float parts[2];
-};
 
 static inline float ctypes_compat_crealf(float _Complex z)
 { union ctypes_complex_float_union u; u.z = z; return u.parts[0]; }
 
 static inline float ctypes_compat_cimagf(float _Complex z)
 { union ctypes_complex_float_union u; u.z = z; return u.parts[1]; }
-
-static inline float _Complex ctypes_compat_make_complexf(float re, float im)
-{ union ctypes_complex_float_union u; u.parts[0] = re; u.parts[1] = im; return u.z; }
 
 static inline float _Complex ctypes_compat_conjf(float _Complex z)
 { union ctypes_complex_float_union u; u.z = z; u.parts[1] = -u.parts[1]; return u.z; }
@@ -86,8 +78,6 @@ static inline long double ctypes_compat_creall(long double _Complex z)
 { return creall(z); }
 static inline long double ctypes_compat_cimagl(long double _Complex z)
 { return cimagl(z); }
-static inline long double _Complex ctypes_compat_make_complexl(long double re, long double im)
-{ return re + im * I; }
 static inline long double _Complex ctypes_compat_conjl(long double _Complex z)
 { return conjl(z); }
 static inline long double _Complex ctypes_compat_cexpl(long double _Complex z)
@@ -105,8 +95,6 @@ static inline double ctypes_compat_creal(double _Complex z)
 { return creal(z); }
 static inline double ctypes_compat_cimag(double _Complex z)
 { return cimag(z); }
-static inline double _Complex ctypes_compat_make_complex(double re, double im)
-{ return re + im * I; }
 static inline double _Complex ctypes_compat_conj(double _Complex z)
 { return conj(z); }
 
@@ -114,10 +102,19 @@ static inline float ctypes_compat_crealf(float _Complex z)
 { return crealf(z); }
 static inline float ctypes_compat_cimagf(float _Complex z)
 { return cimagf(z); }
-static inline float _Complex ctypes_compat_make_complexf(float re, float im)
-{ return re + im * I; }
 static inline float _Complex ctypes_compat_conjf(float _Complex z)
 { return conjf(z); }
+
+#if !defined(CMPLXF) || !defined(CMPLX) || !defined(CMPLXL)
+#define CTYPES_USE_STRUCT_BUILDER 1
+#else
+static inline double _Complex ctypes_compat_make_complex(double re, double im)
+{ return (CMPLX(re,im)); }
+static inline long double _Complex ctypes_compat_make_complexl(long double re, long double im)
+{ return (CMPLXL(re,im)); }
+static inline float _Complex ctypes_compat_make_complexf(float re, float im)
+{ return (CMPLXF(re,im)); }
+#endif
 
 #endif
 
@@ -134,6 +131,17 @@ static inline long double _Complex ctypes_compat_clogl(long double _Complex z)
 
 static inline long double _Complex ctypes_compat_cpowl(long double _Complex x, long double _Complex z)
 { caml_failwith("ctypes: cpowl does not exist on current platform"); }
+#endif
+
+
+#ifdef CTYPES_USE_STRUCT_BUILDER
+static inline double _Complex ctypes_compat_make_complex(double re, double im)
+{ union ctypes_complex_double_union u; u.parts[0] = re; u.parts[1] = im; return u.z; }
+static inline float _Complex ctypes_compat_make_complexf(float re, float im)
+{ union ctypes_complex_float_union u; u.parts[0] = re; u.parts[1] = im; return u.z; }
+static inline long double _Complex ctypes_compat_make_complexl(long double re, long double im)
+{ union ctypes_complex_long_double_union u; u.parts[0] = re; u.parts[1] = im; return u.z; }
+#undef CTYPES_USE_STRUCT_BUILDER
 #endif
 
 #endif /* CTYPES_COMPLEX_COMPATIBILITY_H */

--- a/tests/test-complex/test_complex.ml
+++ b/tests/test-complex/test_complex.ml
@@ -129,6 +129,10 @@ struct
       assert_equal ~cmp:complex32_eq (Complex.add l r) (add_complexf_val l r);
       assert_equal ~cmp:complex32_eq (Complex.mul l r) (mul_complexf_val l r);
 
+      let zinf = { re = 0.; im = infinity } in
+      assert_equal 0. (add_complexd_val zinf zinf).re;
+      assert_equal 0. (add_complexf_val zinf zinf).re;
+
       (* test long double complex *)
       let re x = LDouble.(to_float (ComplexL.re x)) in
       let im x = LDouble.(to_float (ComplexL.im x)) in
@@ -138,6 +142,8 @@ struct
       let l', r' = to_complexld l, to_complexld r in
       assert_equal ~cmp:complex64_eq (Complex.add l r) (of_complexld @@ add_complexld_val l' r');
       assert_equal ~cmp:complex64_eq (Complex.mul l r) (of_complexld @@ mul_complexld_val l' r');
+
+      assert_equal 0. (re (to_complexld zinf));
 
       (* rot-dist test *)
       let rot x a = 


### PR DESCRIPTION
The usage of `I` provided by "complex.h" is error-prone, e.g `double complex z = Double_val(x) + I*(Double_val(y))` might give `NaN` as `creal(z)` for `x = 0.0` and `y = infinity`. 

The macros were introduced by C11, therefore I didn't make any assumptions, if they are available or not.