### PR TITLE
various windows fixes

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -5,6 +5,7 @@
 package_integers_path = $(shell $(OCAMLFIND) query integers)
 ifneq (,$(filter mingw%,$(OSYSTEM)))
 lib_process=-lpsapi
+OCAMLMKLIB_EXTRA_FLAGS=-ldopt "-link -static-libgcc" # see GPR#1535
 ifeq ($(DEBUG),false)
   CFLAGS=-std=c99 -Wall -O3 $(OCAML_FFI_INCOPTS) "-I$(package_integers_path)"
 else
@@ -93,10 +94,10 @@ $(BUILDDIR)/%.cmxa: $$(NATIVE_OBJECTS)
 	$(OCAMLFIND) opt -a -linkall $(OCAMLFLAGS) $(THREAD_FLAG) $(OCAMLFIND_PACKAGE_FLAGS) $(CMXA_OPTS) -o $@ $(NATIVE_OBJECTS) $(OCAML_LINK_FLAGS)
 
 $(BUILDDIR)/dll%_stubs$(EXTDLL): $$(C_OBJECTS)
-	$(OCAMLMKLIB) -o $(BUILDDIR)/$*_stubs $^ $(OCAMLMKLIB_FLAGS)
+	$(OCAMLMKLIB) -o $(BUILDDIR)/$*_stubs $^ $(OCAMLMKLIB_FLAGS) $(OCAMLMKLIB_EXTRA_FLAGS)
 
 $(BUILDDIR)/dll%_stubs_xen$(EXTDLL): $$(XEN_OBJECTS)
-	$(OCAMLMKLIB) -o $(BUILDDIR)/$*_stubs_xen $^ $(OCAMLMKLIB_FLAGS)
+	$(OCAMLMKLIB) -o $(BUILDDIR)/$*_stubs_xen $^ $(OCAMLMKLIB_FLAGS) $(OCAMLMKLIB_EXTRA_FLAGS)
 
 $(BUILDDIR)/%.cmxs : $$(NATIVE_OBJECTS)
 	$(OCAMLFIND) opt -shared -linkall $(OCAMLFLAGS) $(THREAD_FLAG) $(OCAMLFIND_PACKAGE_FLAGS) -o $@ $(NATIVE_OBJECTS) $(C_OBJECTS) $(OCAML_LINK_FLAGS)

--- a/src/configure/extract_from_c.ml
+++ b/src/configure/extract_from_c.ml
@@ -52,6 +52,10 @@ let extract s =
   String.sub s begin_pos (end_pos - begin_pos)
 
 let headers = "\
+#if defined(__MINGW32__) || defined(__MINGW64__)
+#define __USE_MINGW_ANSI_STDIO 1
+#include <stdio.h> /* see: https://sourceforge.net/p/mingw-w64/bugs/627/ */
+#endif
 #include <stdint.h>
 #include <stdbool.h>
 #include <inttypes.h>

--- a/src/cstubs/cstubs_structs.ml
+++ b/src/cstubs/cstubs_structs.ml
@@ -28,10 +28,6 @@ let cstring s =
   in "\""^ escaped ^"\""
 
 let cprologue = [
-  "#if !__USE_MINGW_ANSI_STDIO && (defined(__MINGW32__) || defined(__MINGW64__))";
-  "#define __USE_MINGW_ANSI_STDIO 1";
-  "#endif";
-  "";
   "#include <stdio.h>";
   "#include <stddef.h>";
   "#include \"ctypes_cstubs_internals.h\"";
@@ -54,11 +50,11 @@ let puts fmt s = Format.fprintf fmt "@[puts@[(%s);@]@]@\n"
   (cstring s)
 
 (* [printf1 fmt s v] writes the call [printf(s, v);] on [fmt]. *)
-let printf1 fmt s v = Format.fprintf fmt "@[printf@[(%s,@ %t);@]@]@\n"
+let printf1 fmt s v = Format.fprintf fmt "@[ctypes_printf@[(%s,@ %t);@]@]@\n"
   (cstring s) v
 
 (* [printf2 fmt s u v] writes the call [printf(s, u, v);] on [fmt]. *)
-let printf2 fmt s u v = Format.fprintf fmt "@[printf@[(%s,@ %t,@ %t);@]@]@\n"
+let printf2 fmt s u v = Format.fprintf fmt "@[ctypes_printf@[(%s,@ %t,@ %t);@]@]@\n"
   (cstring s) u v
 
 (* [offsetof fmt t f] writes the call [offsetof(t, f)] on [fmt]. *) 

--- a/src/ctypes/ctypes_cstubs_internals.h
+++ b/src/ctypes/ctypes_cstubs_internals.h
@@ -34,4 +34,10 @@ static inline value ctypes_pair_with_errno(value p)
   CAMLreturn (v);
 }
 
+#if defined(__MINGW32__) || defined(__MINGW64__)
+#define ctypes_printf __mingw_printf
+#else
+#define ctypes_printf printf
+#endif
+
 #endif /* CTYPES_CSTUBS_INTERNALS_H */

--- a/tests/test-foreign-errno/test_errno.ml
+++ b/tests/test-foreign-errno/test_errno.ml
@@ -61,4 +61,17 @@ let suite = "foreign+errno tests" >:::
 
 
 let _ =
+  if Sys.os_type = "Win32" then
+    (*
+      Ugly workaround because oUnit raises an error, if there are
+      any changes in the environment.
+
+      There are two ways to access the environments on windows:
+       - through the native Windows API.
+       - through the crt lib. The crt uses the environment for interprocess
+         communication, but hides it from the end user.
+      Since OCaml 4.07 the native Windows API is used by Unix.environment,
+      therefore the tricks of the crt lib are visible.
+    *)
+    Sys.chdir "."; (* udpate environment *)
   run_test_tt_main suite

--- a/tests/test-value_printing/test_value_printing.ml
+++ b/tests/test-value_printing/test_value_printing.ml
@@ -210,11 +210,18 @@ struct
     let _FLT_MIN = retrieve_FLT_MIN () in
     let _FLT_MAX = retrieve_FLT_MAX () in
 
-    assert_equal (string_of float _FLT_MIN) (string_of_float _FLT_MIN);
+    let rex = Str.regexp "e\\([-+]\\)[0]+\\([1-9]+\\)" in
+    let exp_equal a b =
+      (* remove leading zeros from exponential form *)
+      let a = Str.global_replace rex "e\\1\\2" a in
+      let b = Str.global_replace rex "e\\1\\2" b in
+      assert_equal a b in
+
+    exp_equal (string_of float _FLT_MIN) (string_of_float _FLT_MIN);
     assert_equal (valid_float_lexem (string_of float 0.0)) (string_of_float 0.0);
     assert_equal (string_of float nan) (string_of_float nan);
     assert_equal (string_of float infinity) (string_of_float infinity);
-    assert_equal (string_of float _FLT_MAX) (string_of_float _FLT_MAX);
+    exp_equal (string_of float _FLT_MAX) (string_of_float _FLT_MAX);
 
     (* double *)
     let _DBL_MIN = retrieve_DBL_MIN () in
@@ -224,7 +231,7 @@ struct
     assert_equal (valid_float_lexem (string_of double 0.0)) (string_of_float 0.0);
     assert_equal (string_of double (-1.03)) (string_of_float (-1.03));
     assert_equal (string_of double (34.22)) (string_of_float (34.22));
-    assert_equal (string_of double (1.39e16)) (string_of_float (1.39e16));
+    exp_equal (string_of double (1.39e16)) (string_of_float (1.39e16));
     assert_equal (string_of double nan) (string_of_float nan);
     assert_equal (string_of double infinity) (string_of_float infinity);
     assert_equal (string_of double _DBL_MAX) (string_of_float _DBL_MAX);


### PR DESCRIPTION
This will remove `__USE_MINGW_ANSI_STDIO` from the stub generation code. `__USE_MINGW_ANSI_STDIO` must be defined before any other relevant headers are included. This is often not guaranteed because custom headers are added before calls to `Cstubs.write_c`. I've instead added the `ctypes_printf` macro for usage inside generated code, which translates to `__mingw_printf` for mingw, and `printf` otherwise. (Background: On windows one can link again various version of the c stdlib (crt). They are all not really compatible to C99. Instead of adding and testing workarounds for each version, the compatibility layer of mingw is used. This layer is normally enabled by defining `__USE_MINGW_ANSI_STDIO` or by certain compiler switches.)

The second commit removes a dll dependency introduced by OCaml 4.07 and adds further workarounds to the test suite.
