### PR TITLE
OPAM: constrain integers to < 0.3.0

### DIFF
--- a/ctypes.opam
+++ b/ctypes.opam
@@ -23,7 +23,7 @@ remove: [
 ]
 depends: [
    "base-bytes"
-   "integers"
+   "integers" { < "0.3.0" }
    "ocamlfind" {build}
    "conf-pkg-config" {build}
    "lwt" {test & < "4.0.0"}


### PR DESCRIPTION
See https://github.com/ocamllabs/ocaml-integers/issues/26