### PR TITLE
Add [Foreign.dynamic_funptr]

### DIFF
--- a/Makefile.tests
+++ b/Makefile.tests
@@ -990,6 +990,41 @@ tests/test-passing-ocaml-values/generated_stubs.c: $(BUILDDIR)/test-passing-ocam
 tests/test-passing-ocaml-values/generated_bindings.ml: $(BUILDDIR)/test-passing-ocaml-values-stub-generator.$(BEST)
 	$< --ml-file $@
 
+test-funptrs-stubs.dir = tests/test-funptrs/stubs
+test-funptrs-stubs.threads = yes
+test-funptrs-stubs.subproject_deps = ctypes \
+   ctypes-foreign-base ctypes-foreign-threaded tests-common
+test-funptrs-stubs: PROJECT=test-funptrs-stubs
+test-funptrs-stubs: $$(LIB_TARGETS)
+
+test-funptrs-stub-generator.dir = tests/test-funptrs/stub-generator
+test-funptrs-stub-generator.threads = yes
+test-funptrs-stub-generator.subproject_deps = ctypes cstubs \
+     ctypes-foreign-base ctypes-foreign-threaded test-funptrs-stubs tests-common
+test-funptrs-stub-generator.deps = str bigarray bytes integers
+test-funptrs-stub-generator: PROJECT=test-funptrs-stub-generator
+test-funptrs-stub-generator: $$(BEST_TARGET)
+
+test-funptrs.dir = tests/test-funptrs
+test-funptrs.threads = yes
+test-funptrs.deps = str bigarray oUnit bytes integers
+test-funptrs.subproject_deps = ctypes ctypes-foreign-base \
+   ctypes-foreign-threaded cstubs tests-common test-funptrs-stubs
+test-funptrs.link_flags = -L$(BUILDDIR)/clib -ltest_functions
+test-funptrs: PROJECT=test-funptrs
+test-funptrs: $$(BEST_TARGET)
+
+test-funptrs-generated= \
+  tests/test-funptrs/generated_bindings.ml \
+  tests/test-funptrs/generated_stubs.c
+
+test-funptrs-generated: $(test-funptrs-generated)
+
+tests/test-funptrs/generated_stubs.c: $(BUILDDIR)/test-funptrs-stub-generator.$(BEST)
+	$< --c-file $@
+tests/test-funptrs/generated_bindings.ml: $(BUILDDIR)/test-funptrs-stub-generator.$(BEST)
+	$< --ml-file $@
+
 test-lwt-jobs-stubs.dir  = tests/test-lwt-jobs/stubs
 test-lwt-jobs-stubs.threads = yes
 test-lwt-jobs-stubs.subproject_deps = ctypes \
@@ -1315,6 +1350,7 @@ TESTS += test-bigarrays-stubs test-bigarrays-stub-generator test-bigarrays-gener
 TESTS += test-coercions-stubs test-coercions-stub-generator test-coercions-generated test-coercions
 TESTS += test-roots
 TESTS += test-passing-ocaml-values-stubs test-passing-ocaml-values-stub-generator test-passing-ocaml-values-generated test-passing-ocaml-values
+TESTS += test-funptrs-stubs test-funptrs-stub-generator test-funptrs-generated test-funptrs
 TESTS += test-lwt-jobs-stubs test-lwt-jobs-stub-generator test-lwt-jobs-generated test-lwt-jobs
 TESTS += test-lwt-preemptive-stubs test-lwt-preemptive-stub-generator test-lwt-preemptive-generated test-lwt-preemptive
 TESTS += test-returning-errno-lwt-jobs-stubs test-returning-errno-lwt-jobs-stub-generator test-returning-errno-lwt-jobs-generated test-returning-errno-lwt-jobs

--- a/src/ctypes-foreign-base/ctypes_ffi.ml
+++ b/src/ctypes-foreign-base/ctypes_ffi.ml
@@ -225,17 +225,16 @@ struct
 
   let pointer_of_function_unsafe ~abi ~acquire_runtime_lock ~thread_registration fn =
     let make_funptr = pointer_of_function_internal ~abi ~acquire_runtime_lock ~thread_registration fn in
-    (* TODO: use a more intelligent strategy for keeping function pointers
-       associated with top-level functions alive (e.g. cache function
-       pointer creation by (function, type), or possibly even just by
-       function, since the C arity and types must be the same in each case.)
-       See the note by [kept_alive_indefinitely].
-
-       [pointer_of_function] should be considered deprecated, use [Funptr.of_fun] below
-       instead and explicitly call free when appropriate.
-    *)
     fun f ->
       let funptr = make_funptr f in
+      (* TODO: use a more intelligent strategy for keeping function pointers
+         associated with top-level functions alive (e.g. cache function
+         pointer creation by (function, type), or possibly even just by
+         function, since the C arity and types must be the same in each case.)
+         See the note by [kept_alive_indefinitely].
+
+         [dynamic_funptr_of_fun] below allows for explicit life cycle management
+         and is probably safer to use. *)
       let () = keep_alive funptr ~while_live:f in
       funptr_of_rawptr fn
         (Ctypes_ffi_stubs.raw_address_of_function_pointer funptr)

--- a/src/ctypes-foreign-base/ctypes_ffi.ml
+++ b/src/ctypes-foreign-base/ctypes_ffi.ml
@@ -282,9 +282,11 @@ struct
       )) t;
     t
 
-  let funptr_of_fun ?debug_info ~abi ~acquire_runtime_lock ~thread_registration fn f =
-    let funptr = pointer_of_function_internal ~abi ~acquire_runtime_lock ~thread_registration fn f in
-    create_funptr ?debug_info (f,funptr) (funptr_of_rawptr fn (Ctypes_ffi_stubs.raw_address_of_function_pointer funptr))
+  let funptr_of_fun ~abi ~acquire_runtime_lock ~thread_registration fn =
+    let make_funptr = pointer_of_function_internal ~abi ~acquire_runtime_lock ~thread_registration fn in
+    (fun ?debug_info f ->
+       let funptr = make_funptr f in
+       create_funptr ?debug_info (f,funptr) (funptr_of_rawptr fn (Ctypes_ffi_stubs.raw_address_of_function_pointer funptr)))
 
   let funptr_of_static_funptr fp =
       create_funptr () fp

--- a/src/ctypes-foreign-base/ctypes_ffi.ml
+++ b/src/ctypes-foreign-base/ctypes_ffi.ml
@@ -223,7 +223,7 @@ struct
       let id = Closure_properties.record (Obj.repr f) (Obj.repr boxed) in
       Ctypes_ffi_stubs.make_function_pointer cs' id
 
-  let pointer_of_function_unsafe ~abi ~acquire_runtime_lock ~thread_registration fn =
+  let pointer_of_function ~abi ~acquire_runtime_lock ~thread_registration fn =
     let make_funptr = pointer_of_function_internal ~abi ~acquire_runtime_lock ~thread_registration fn in
     fun f ->
       let funptr = make_funptr f in

--- a/src/ctypes-foreign-base/ctypes_ffi.mli
+++ b/src/ctypes-foreign-base/ctypes_ffi.mli
@@ -30,11 +30,22 @@ sig
   (** Build an OCaml function from a type specification and a pointer to a C
       function. *)
 
-  val pointer_of_function : abi:abi -> acquire_runtime_lock:bool ->
+  val pointer_of_function_unsafe : abi:abi -> acquire_runtime_lock:bool ->
     thread_registration:bool ->
     ('a -> 'b) fn -> ('a -> 'b) -> ('a -> 'b) static_funptr
   (** Build an C function from a type specification and an OCaml function.
 
       The C function pointer returned is callable as long as the OCaml function
       value is live. *)
+
+  type 'a funptr
+
+  val free_funptr : _ funptr -> unit
+
+  val funptr_of_fun : ?debug_info:string -> abi:abi -> acquire_runtime_lock:bool -> thread_registration:bool
+    -> ('a -> 'b) fn -> ('a -> 'b) -> ('a -> 'b) funptr
+
+  val funptr_of_static_funptr : ('a -> 'b) static_funptr -> ('a -> 'b) funptr
+
+  val funptr_to_static_funptr : ('a -> 'b) funptr -> ('a -> 'b) static_funptr
 end

--- a/src/ctypes-foreign-base/ctypes_ffi.mli
+++ b/src/ctypes-foreign-base/ctypes_ffi.mli
@@ -30,7 +30,7 @@ sig
   (** Build an OCaml function from a type specification and a pointer to a C
       function. *)
 
-  val pointer_of_function_unsafe : abi:abi -> acquire_runtime_lock:bool ->
+  val pointer_of_function : abi:abi -> acquire_runtime_lock:bool ->
     thread_registration:bool ->
     ('a -> 'b) fn -> ('a -> 'b) -> ('a -> 'b) static_funptr
   (** Build an C function from a type specification and an OCaml function.

--- a/src/ctypes-foreign-base/ctypes_ffi.mli
+++ b/src/ctypes-foreign-base/ctypes_ffi.mli
@@ -42,8 +42,8 @@ sig
 
   val free_funptr : _ funptr -> unit
 
-  val funptr_of_fun : ?debug_info:string -> abi:abi -> acquire_runtime_lock:bool -> thread_registration:bool
-    -> ('a -> 'b) fn -> ('a -> 'b) -> ('a -> 'b) funptr
+  val funptr_of_fun : abi:abi -> acquire_runtime_lock:bool -> thread_registration:bool
+    -> ('a -> 'b) fn -> ?debug_info:string -> ('a -> 'b) -> ('a -> 'b) funptr
 
   val funptr_of_static_funptr : ('a -> 'b) static_funptr -> ('a -> 'b) funptr
 

--- a/src/ctypes-foreign-base/ctypes_ffi.mli
+++ b/src/ctypes-foreign-base/ctypes_ffi.mli
@@ -43,9 +43,11 @@ sig
   val free_funptr : _ funptr -> unit
 
   val funptr_of_fun : abi:abi -> acquire_runtime_lock:bool -> thread_registration:bool
-    -> ('a -> 'b) fn -> ?debug_info:string -> ('a -> 'b) -> ('a -> 'b) funptr
+    -> ('a -> 'b) fn -> ('a -> 'b) -> ('a -> 'b) funptr
 
   val funptr_of_static_funptr : ('a -> 'b) static_funptr -> ('a -> 'b) funptr
 
   val funptr_to_static_funptr : ('a -> 'b) funptr -> ('a -> 'b) static_funptr
+
+  val report_leaked_funptr : (string -> unit) ref 
 end

--- a/src/ctypes-foreign-base/ctypes_foreign_basis.ml
+++ b/src/ctypes-foreign-base/ctypes_foreign_basis.ml
@@ -14,21 +14,18 @@ struct
 
   exception CallToExpiredClosure = Ctypes_ffi_stubs.CallToExpiredClosure
 
-  let funptr_unsafe ?(abi=Libffi_abi.default_abi) ?name ?(check_errno=false)
+  let funptr ?(abi=Libffi_abi.default_abi) ?name ?(check_errno=false)
       ?(runtime_lock=false) ?(thread_registration=false) fn =
     let open Ffi in
     let read = function_of_pointer
       ~abi ~check_errno ~release_runtime_lock:runtime_lock ?name fn
-    and write = pointer_of_function_unsafe fn
+    and write = pointer_of_function fn
       ~abi ~acquire_runtime_lock:runtime_lock ~thread_registration in
     Ctypes_static.(view ~read ~write (static_funptr fn))
 
-  let funptr_unsafe_opt ?abi ?name ?check_errno ?runtime_lock ?thread_registration fn =
+  let funptr_opt ?abi ?name ?check_errno ?runtime_lock ?thread_registration fn =
     Ctypes_std_views.nullable_funptr_view
-      (funptr_unsafe ?abi ?name ?check_errno ?runtime_lock ?thread_registration fn) fn
-
-  let funptr = funptr_unsafe
-  let funptr_opt = funptr_unsafe_opt
+      (funptr ?abi ?name ?check_errno ?runtime_lock ?thread_registration fn) fn
 
   let funptr_of_raw_ptr p = 
     Ctypes.funptr_of_raw_address (Ctypes_ptr.Raw.to_nativeint p)

--- a/src/ctypes-foreign-base/ctypes_foreign_basis.ml
+++ b/src/ctypes-foreign-base/ctypes_foreign_basis.ml
@@ -89,7 +89,7 @@ struct
       | exception exn -> free f; raise exn
   end
 
-  let funptr_spec (type a b) ?(abi=Libffi_abi.default_abi) ?(runtime_lock=false) ?(thread_registration=false) fn : (module Funptr_spec with type fn_first_arg = a and type fn_rest = b) =
+  let funptr_spec (type a) (type b) ?(abi=Libffi_abi.default_abi) ?(runtime_lock=false) ?(thread_registration=false) fn : (module Funptr_spec with type fn_first_arg = a and type fn_rest = b) =
     (module struct
          type fn_first_arg = a
          type fn_rest = b

--- a/src/ctypes-foreign-base/ctypes_foreign_basis.ml
+++ b/src/ctypes-foreign-base/ctypes_foreign_basis.ml
@@ -58,19 +58,9 @@ struct
     val with_fun : ?debug_info:string -> fn -> (t -> 'c) -> 'c
   end
 
-  module type Funptr_spec = sig
-    type fn_first_arg
-    type fn_rest
-    val fn : (fn_first_arg -> fn_rest) Ctypes.fn
-    val abi : Libffi_abi.abi
-    val acquire_runtime_lock : bool
-    val thread_registration : bool
-  end
-
-  module Make_funptr(Fn : Funptr_spec) :
-    Funptr with type fn=(Fn.fn_first_arg -> Fn.fn_rest) = struct
-    open Fn
-    type fn = fn_first_arg -> fn_rest
+  let dynamic_funptr (type a b) ?(abi=Libffi_abi.default_abi) ?(runtime_lock=false) ?(thread_registration=false) fn : (module Funptr with type fn = a -> b) =
+    (module struct
+    type fn = a -> b
     type t = fn Ffi.funptr
 
     let t =
@@ -78,26 +68,16 @@ struct
       let read = Ffi.funptr_of_static_funptr in
       Ctypes_static.(view ~read ~write (static_funptr fn))
 
-    let t_opt = Ctypes_std_views.nullable_funptr_view t Fn.fn
+    let t_opt = Ctypes_std_views.nullable_funptr_view t fn
     let free = Ffi.free_funptr
-    let of_fun = Ffi.funptr_of_fun ~abi ~acquire_runtime_lock ~thread_registration fn
+    let of_fun = Ffi.funptr_of_fun ~abi ~acquire_runtime_lock:runtime_lock ~thread_registration fn
 
     let with_fun ?debug_info f do_it =
       let f = of_fun ?debug_info f in
       match do_it f with
       | res -> free f; res
       | exception exn -> free f; raise exn
-  end
-
-  let funptr_spec (type a) (type b) ?(abi=Libffi_abi.default_abi) ?(runtime_lock=false) ?(thread_registration=false) fn : (module Funptr_spec with type fn_first_arg = a and type fn_rest = b) =
-    (module struct
-         type fn_first_arg = a
-         type fn_rest = b
-         let fn = fn
-         let abi = abi
-         let acquire_runtime_lock = runtime_lock
-         let thread_registration = thread_registration
-       end)
+  end)
 
   let call_static_funptr ?name ?(abi=Libffi_abi.default_abi) ?(check_errno=false) ?(release_runtime_lock=false) fn fp =
     Ffi.function_of_pointer

--- a/src/ctypes-foreign-base/ctypes_foreign_basis.ml
+++ b/src/ctypes-foreign-base/ctypes_foreign_basis.ml
@@ -40,13 +40,11 @@ struct
   let foreign ?(abi=Libffi_abi.default_abi) ?from ?(stub=false)
       ?(check_errno=false) ?(release_runtime_lock=false) symbol typ =
     try
-      Ffi.function_of_pointer ~name:symbol ~abi ~check_errno ~release_runtime_lock typ
-        (Ctypes.coerce
-           (static_funptr (void @-> returning void))
-           (static_funptr typ)
-           (funptr_of_raw_ptr
-              (Ctypes_ptr.Raw.of_nativeint
-                 (dlsym ?handle:from ~symbol))))
+      let coerce = Ctypes_coerce.coerce (static_funptr (void @-> returning void))
+        (funptr ~abi ~name:symbol ~check_errno ~runtime_lock:release_runtime_lock typ) in
+      coerce (funptr_of_raw_ptr
+                (Ctypes_ptr.Raw.of_nativeint
+                   (dlsym ?handle:from ~symbol)))
     with
     | exn -> if stub then fun _ -> raise exn else raise exn
 

--- a/src/ctypes-foreign-base/ctypes_foreign_basis.ml
+++ b/src/ctypes-foreign-base/ctypes_foreign_basis.ml
@@ -48,7 +48,7 @@ struct
     with
     | exn -> if stub then fun _ -> raise exn else raise exn
 
-  module type Dynamic_funptr = sig
+  module type Funptr = sig
     type fn
     type t
     val t : t Ctypes.typ
@@ -62,15 +62,14 @@ struct
     type fn_first_arg
     type fn_rest
     val fn : (fn_first_arg -> fn_rest) Ctypes.fn
-    val debug_info : string option
     val abi : Libffi_abi.abi
     val acquire_runtime_lock : bool
     val thread_registration : bool
   end
 
   module Make_funptr(Fn : Funptr_spec) :
-    Dynamic_funptr with type fn=(Fn.fn_first_arg -> Fn.fn_rest) = struct
-    include Fn
+    Funptr with type fn=(Fn.fn_first_arg -> Fn.fn_rest) = struct
+    open Fn
     type fn = fn_first_arg -> fn_rest
     type t = fn Ffi.funptr
 
@@ -81,13 +80,7 @@ struct
 
     let t_opt = Ctypes_std_views.nullable_funptr_view t Fn.fn
     let free = Ffi.free_funptr
-    let of_fun_ = Ffi.funptr_of_fun ~abi ~acquire_runtime_lock ~thread_registration fn
-    let of_fun ?debug_info f =
-      let debug_info = match debug_info with
-        | None -> Fn.debug_info
-        | Some _ -> debug_info
-      in
-      of_fun_ ?debug_info f
+    let of_fun = Ffi.funptr_of_fun ~abi ~acquire_runtime_lock ~thread_registration fn
 
     let with_fun ?debug_info f do_it =
       let f = of_fun ?debug_info f in
@@ -96,12 +89,11 @@ struct
       | exception exn -> free f; raise exn
   end
 
-  let dynamic_funptr (type a b) ?debug_info ?(abi=Libffi_abi.default_abi) ?(runtime_lock=false) ?(thread_registration=false) fn : (module Funptr_spec with type fn_first_arg = a and type fn_rest = b) =
+  let funptr_spec (type a b) ?(abi=Libffi_abi.default_abi) ?(runtime_lock=false) ?(thread_registration=false) fn : (module Funptr_spec with type fn_first_arg = a and type fn_rest = b) =
     (module struct
          type fn_first_arg = a
          type fn_rest = b
          let fn = fn
-         let debug_info = debug_info
          let abi = abi
          let acquire_runtime_lock = runtime_lock
          let thread_registration = thread_registration

--- a/src/ctypes-foreign-threaded/foreign.mli
+++ b/src/ctypes-foreign-threaded/foreign.mli
@@ -133,8 +133,7 @@ module type Funptr = sig
       Failure to call {!free} and not holding a reference this this pointer
       is an error.
 
-      For many use cases it may be simpler to use {!with_fun} instead as this will
-      do the free for you.
+      Alternatively {!with_fun} encapsulates both allocation and deallocation.
 
       Implementation detail: To avoid hard to debug crashes the implementation
       will leak the OCaml closure in this event that {!free} was not used and

--- a/src/ctypes-foreign-threaded/foreign.mli
+++ b/src/ctypes-foreign-threaded/foreign.mli
@@ -60,10 +60,11 @@ val funptr :
     This function hides hard to reason about details of the life-time of the ocaml closure
     and C function pointer. Getting this wrong will cause hard to debug segmentation faults.
 
-    For passing ocaml functions into C (for use in callbacks) consider using [Foreign.Make_funptr].
+    For passing ocaml functions into C (for use in callbacks) consider using
+    [Foreign.Make_funptr(val (funptr_spec ...))].
 
-    If passing function pointers from C [Ctypes.static_funptr] and [Foreign.call_static_funptr]
-    can be used.
+    If passing function pointers from C consider using [Ctypes.static_funptr] and
+    [Foreign.call_static_funptr].
     ----
 
     The ctypes library, like C itself, distinguishes functions and function
@@ -103,6 +104,7 @@ val funptr_opt :
 exception CallToExpiredClosure
 (** A closure passed to C was collected by the OCaml garbage collector before
     it was called. *)
+
 module type Funptr = sig
   type fn
   (** [fn] is the signature of the underlying ocaml function. *)
@@ -173,7 +175,7 @@ module Make_funptr(Fn:Funptr_spec) : Funptr with type fn=Fn.fn_first_arg -> Fn.f
     Example:
     {[
       module Progress_callback = Foreign.Make_funptr(val (
-        Foreign.dynamic_funptr (int @-> int @-> ptr void @-> returning void))
+        Foreign.funptr_spec (int @-> int @-> ptr void @-> returning void))
       let keygen =
         foreign "RSA_generate_key" (int @-> int @-> Progress_callback.t @-> ptr void @-> returning rsa_key)
       let secret_key =

--- a/src/ctypes-foreign-threaded/foreign.mli
+++ b/src/ctypes-foreign-threaded/foreign.mli
@@ -103,58 +103,94 @@ val funptr_opt :
 exception CallToExpiredClosure
 (** A closure passed to C was collected by the OCaml garbage collector before
     it was called. *)
+module type Dynamic_funptr = sig
+  type fn
+  (** [fn] is the signature of the underlying ocaml function. *)
 
-type 'a dynamic_funptr
-(** [dynamic_funptr] allows safer passing of ocaml functions for use as C callbacks.
+  type t
+  (** [Dynamic_funptr.t] Handle to an ocaml function that can be passed to C for
+      use in callbacks.
 
     Unfortunately it is not possible to track if a fuction pointer is still used in C,
     so you must use the appropriate life cycle functions below for this.
 
-    See [dynamic_funptr], [dynamic_funptr_of_fun], [free_dynamic_funptr]
-    and [with_dynamic_funptr_of_fun].
-*)
+    See [t], [of_fun], [with_fun] and [free] *)
 
-val dynamic_funptr : ('a -> 'b) Ctypes.fn -> ('a -> 'b) dynamic_funptr Ctypes.typ
+  val t : t Ctypes.typ
+  (** ctype for that can be used in type signatures of external functions *)
+
+  val t_opt : t option Ctypes.typ
+  (** Like [t] but optional. *)
+
+  val free : t -> unit
+  (** [free fptr] - Indicate that the [fptr] is no longer needed.
+
+      Once [free] has been called any C calls to this [Dynamic_funptr.t] are 
+      unsafe and may result in a segmentation fault. Only call [free] once the
+      callback is no longer used from C.
+  *)
+
+  val of_fun : ?debug_info:string -> fn -> t
+  (** [of_fun fn] - Turn an ocaml closure into a function pointer
+      that can be passed to C.
+
+      You MUST call [free] to the function pointer is no longer needed.
+      Failure to do so will result in a memory leak.
+      Failure to call [free] and not holding a reference this this pointer
+      is an error. To avoid unexpected crashes we log this and ensure that
+      potentially still needed ocaml values are retained.
+
+      For many use cases it may be simpler to use [with_fun] instead as this will
+      do the free for you. *)
+
+  val with_fun : ?debug_info:string -> fn -> (t -> 'c) -> 'c
+  (** [with_fun fn (fun fptr -> DO_STUFF)] - Turn an ocaml closure into a
+      function pointer and do simple life cycle management.
+
+      This will automatically call [free fptr] after [DO_STUFF] completes.
+
+      It is not safe to use if the C function ptr [fptr] may still be used
+      after [DO_STUFF] completed.
+  *)
+end
+
+
+module type Funptr_spec = sig
+  type fn_first_arg
+  type fn_rest
+  val fn : (fn_first_arg -> fn_rest) Ctypes.fn
+  val debug_info : string option
+  val abi : Libffi_abi.abi
+  val acquire_runtime_lock : bool
+  val thread_registration : bool
+end
+
+module Make_funptr(Fn:Funptr_spec) : Dynamic_funptr with type fn=Fn.fn_first_arg -> Fn.fn_rest
+
+val dynamic_funptr
+  : ?debug_info:string
+  -> ?abi:Libffi_abi.abi
+  -> ?runtime_lock:bool
+  -> ?thread_registration:bool
+  -> ('a -> 'b) Ctypes.fn
+  -> (module Funptr_spec with type fn_first_arg = 'a and type fn_rest = 'b)
 (** [dynamic_funptr fn] - define a Ctype for more safely passing ocaml functions to C.
 
     [dynamic_funptr (FOO @-> returning BAR)] is roughly equivalent to [BAR( * )(FOO)] in C.
-*)
 
-val dynamic_funptr_opt : ('a -> 'b) Ctypes.fn -> ('a -> 'b) dynamic_funptr option Ctypes.typ
-(** Like [dynamic_funptr] but optional. *)
-
-val free_dynamic_funptr : _ dynamic_funptr -> unit
-(** [free_dynamic_funptr fptr] - Indicate that the [fptr] is no longer needed.
-
-    Once [free_dynamic_funptr] has been called any C calls to this [dynamic_funptr] are
-    unsafe and may result in a segmentation fault. Only call [free_dynamic_funptr] once
-    the callback is no longer used from C.
-*)
-
-val dynamic_funptr_of_fun : ?debug_info:string -> ?abi:Libffi_abi.abi -> ?runtime_lock:bool -> ?thread_registration:bool
-  -> ('a -> 'b) Ctypes.fn -> ('a -> 'b) -> ('a -> 'b) dynamic_funptr
-(** [dynamic_funptr_of_fun fn] - Turn an ocaml closure into a function pointer
-    that can be passed to C.
-
-    You MUST call [free_dynamic_funptr] to the function pointer is no longer needed.
-    Failure to do so will result in a memory leak.
-    Failure to call [free_dynamic_funptr] and not holding a reference this this pointer
-    is an error. To avoid unexpected crashes we log this and ensure that potentially still
-    needed ocaml values are retained.
-
-    For many use cases it may be simpler to use [with_dynamic_funptr_of_fun] instead as
-    this will do the free for you. *)
-
-val with_dynamic_funptr_of_fun : ?debug_info:string -> ?abi:Libffi_abi.abi -> ?runtime_lock:bool -> ?thread_registration:bool
-  -> ('a -> 'b) Ctypes.fn -> ('a -> 'b) -> (('a -> 'b) dynamic_funptr -> 'c) -> 'c
-(** [with_dynamic_funptr_of_fun fn (fun fptr -> DO_STUFF)] - Turn an ocaml closure into a
-    function pointer and do simple life cycle management.
-
-    This will automatically call [free_dynamic_funptr fptr] after [DO_STUFF] completes.
-
-    It is not safe to use if the C function ptr [fptr] may still be used after this
-    has been released.
-*)
+    Example:
+    {[
+      module Progress_callback = Foreign.Make_funptr(val (
+        Foreign.dynamic_funptr (int @-> int @-> ptr void @-> returning void))
+      let keygen =
+        foreign "RSA_generate_key" (int @-> int @-> Progress_callback.t @-> ptr void @-> returning rsa_key)
+      let secret_key =
+        Progress_callback.with_fun
+          (fun a b _ -> printf "progress: a:%d, b:%d\n" a b) 
+          (fun progress ->
+             keygen 2048 65537 progress null)
+    ]}
+    *)
 
 val call_static_funptr :
   ?name:string ->

--- a/src/ctypes-foreign-threaded/foreign.mli
+++ b/src/ctypes-foreign-threaded/foreign.mli
@@ -137,7 +137,7 @@ module type Funptr = sig
       do the free for you.
 
       Implementation detail: To avoid hard to debug crashes the implementation
-      will leak the ocaml closure in this event that {!free} was not used and
+      will leak the OCaml closure in this event that {!free} was not used and
       report a warning, see {!on_leaked_funptr}. *)
 
   val with_fun : fn -> (t -> 'c) -> 'c

--- a/src/ctypes-foreign-threaded/foreign.mli
+++ b/src/ctypes-foreign-threaded/foreign.mli
@@ -113,7 +113,7 @@ module type Funptr = sig
       Alternatively {!with_fun} encapsulates both allocation and deallocation. *)
 
   val t : t Ctypes.typ
-  (** ctype that can be used in type signatures of external functions *)
+  (** A type representation for a function pointer type with explicit lifetime management. *)
 
   val t_opt : t option Ctypes.typ
   (** This behaves like {!t}, except that null pointers appear in OCaml as [None]. *)

--- a/src/ctypes-foreign-threaded/foreign.mli
+++ b/src/ctypes-foreign-threaded/foreign.mli
@@ -121,7 +121,7 @@ module type Funptr = sig
   val free : t -> unit
   (** Indicate that the [fptr] is no longer needed.
 
-      Once [free] has been called any C calls to this [Dynamic_funptr.t] are
+      Once [free] has been called any C calls to this [Funptr.t] are
       unsafe. Only call [free] once the callback is no longer used from C. *)
 
   val of_fun : fn -> t

--- a/src/ctypes-foreign-unthreaded/foreign.ml
+++ b/src/ctypes-foreign-unthreaded/foreign.ml
@@ -5,11 +5,4 @@
  * See the file LICENSE for details.
  *)
 
-include Ctypes_foreign_basis.Make(Ctypes_closure_properties.Make(Mutex))
-
-let () = begin
-  (* Initialize the Thread library and set up the hook for registering C
-     threads with the OCaml runtime *)
-  let _ : Thread.t = Thread.self () in
-  Ctypes_foreign_threaded_stubs.setup_thread_registration ()
-end
+include Ctypes_foreign_basis.Make(Ctypes_closure_properties.Make(Ctypes_gc_mutex))

--- a/src/ctypes-foreign-unthreaded/foreign.ml
+++ b/src/ctypes-foreign-unthreaded/foreign.ml
@@ -5,4 +5,11 @@
  * See the file LICENSE for details.
  *)
 
-include Ctypes_foreign_basis.Make(Ctypes_closure_properties.Make(Ctypes_gc_mutex))
+include Ctypes_foreign_basis.Make(Ctypes_closure_properties.Make(Mutex))
+
+let () = begin
+  (* Initialize the Thread library and set up the hook for registering C
+     threads with the OCaml runtime *)
+  let _ : Thread.t = Thread.self () in
+  Ctypes_foreign_threaded_stubs.setup_thread_registration ()
+end

--- a/src/ctypes-foreign-unthreaded/foreign.mli
+++ b/src/ctypes-foreign-unthreaded/foreign.mli
@@ -60,10 +60,11 @@ val funptr :
     This function hides hard to reason about details of the life-time of the ocaml closure
     and C function pointer. Getting this wrong will cause hard to debug segmentation faults.
 
-    For passing ocaml functions into C (for use in callbacks) consider using [Foreign.Make_funptr].
+    For passing ocaml functions into C (for use in callbacks) consider using
+    [Foreign.Make_funptr(val (funptr_spec ...))].
 
-    If passing function pointers from C [Ctypes.static_funptr] and [Foreign.call_static_funptr]
-    can be used.
+    If passing function pointers from C consider using [Ctypes.static_funptr] and
+    [Foreign.call_static_funptr].
     ----
 
     The ctypes library, like C itself, distinguishes functions and function
@@ -103,6 +104,7 @@ val funptr_opt :
 exception CallToExpiredClosure
 (** A closure passed to C was collected by the OCaml garbage collector before
     it was called. *)
+
 module type Funptr = sig
   type fn
   (** [fn] is the signature of the underlying ocaml function. *)
@@ -173,7 +175,7 @@ module Make_funptr(Fn:Funptr_spec) : Funptr with type fn=Fn.fn_first_arg -> Fn.f
     Example:
     {[
       module Progress_callback = Foreign.Make_funptr(val (
-        Foreign.dynamic_funptr (int @-> int @-> ptr void @-> returning void))
+        Foreign.funptr_spec (int @-> int @-> ptr void @-> returning void))
       let keygen =
         foreign "RSA_generate_key" (int @-> int @-> Progress_callback.t @-> ptr void @-> returning rsa_key)
       let secret_key =

--- a/src/ctypes-foreign-unthreaded/foreign.mli
+++ b/src/ctypes-foreign-unthreaded/foreign.mli
@@ -103,58 +103,94 @@ val funptr_opt :
 exception CallToExpiredClosure
 (** A closure passed to C was collected by the OCaml garbage collector before
     it was called. *)
+module type Dynamic_funptr = sig
+  type fn
+  (** [fn] is the signature of the underlying ocaml function. *)
 
-type 'a dynamic_funptr
-(** [dynamic_funptr] allows safer passing of ocaml functions for use as C callbacks.
+  type t
+  (** [Dynamic_funptr.t] Handle to an ocaml function that can be passed to C for
+      use in callbacks.
 
     Unfortunately it is not possible to track if a fuction pointer is still used in C,
     so you must use the appropriate life cycle functions below for this.
 
-    See [dynamic_funptr], [dynamic_funptr_of_fun], [free_dynamic_funptr]
-    and [with_dynamic_funptr_of_fun].
-*)
+    See [t], [of_fun], [with_fun] and [free] *)
 
-val dynamic_funptr : ('a -> 'b) Ctypes.fn -> ('a -> 'b) dynamic_funptr Ctypes.typ
+  val t : t Ctypes.typ
+  (** ctype for that can be used in type signatures of external functions *)
+
+  val t_opt : t option Ctypes.typ
+  (** Like [t] but optional. *)
+
+  val free : t -> unit
+  (** [free fptr] - Indicate that the [fptr] is no longer needed.
+
+      Once [free] has been called any C calls to this [Dynamic_funptr.t] are 
+      unsafe and may result in a segmentation fault. Only call [free] once the
+      callback is no longer used from C.
+  *)
+
+  val of_fun : ?debug_info:string -> fn -> t
+  (** [of_fun fn] - Turn an ocaml closure into a function pointer
+      that can be passed to C.
+
+      You MUST call [free] to the function pointer is no longer needed.
+      Failure to do so will result in a memory leak.
+      Failure to call [free] and not holding a reference this this pointer
+      is an error. To avoid unexpected crashes we log this and ensure that
+      potentially still needed ocaml values are retained.
+
+      For many use cases it may be simpler to use [with_fun] instead as this will
+      do the free for you. *)
+
+  val with_fun : ?debug_info:string -> fn -> (t -> 'c) -> 'c
+  (** [with_fun fn (fun fptr -> DO_STUFF)] - Turn an ocaml closure into a
+      function pointer and do simple life cycle management.
+
+      This will automatically call [free fptr] after [DO_STUFF] completes.
+
+      It is not safe to use if the C function ptr [fptr] may still be used
+      after [DO_STUFF] completed.
+  *)
+end
+
+
+module type Funptr_spec = sig
+  type fn_first_arg
+  type fn_rest
+  val fn : (fn_first_arg -> fn_rest) Ctypes.fn
+  val debug_info : string option
+  val abi : Libffi_abi.abi
+  val acquire_runtime_lock : bool
+  val thread_registration : bool
+end
+
+module Make_funptr(Fn:Funptr_spec) : Dynamic_funptr with type fn=Fn.fn_first_arg -> Fn.fn_rest
+
+val dynamic_funptr
+  : ?debug_info:string
+  -> ?abi:Libffi_abi.abi
+  -> ?runtime_lock:bool
+  -> ?thread_registration:bool
+  -> ('a -> 'b) Ctypes.fn
+  -> (module Funptr_spec with type fn_first_arg = 'a and type fn_rest = 'b)
 (** [dynamic_funptr fn] - define a Ctype for more safely passing ocaml functions to C.
 
     [dynamic_funptr (FOO @-> returning BAR)] is roughly equivalent to [BAR( * )(FOO)] in C.
-*)
 
-val dynamic_funptr_opt : ('a -> 'b) Ctypes.fn -> ('a -> 'b) dynamic_funptr option Ctypes.typ
-(** Like [dynamic_funptr] but optional. *)
-
-val free_dynamic_funptr : _ dynamic_funptr -> unit
-(** [free_dynamic_funptr fptr] - Indicate that the [fptr] is no longer needed.
-
-    Once [free_dynamic_funptr] has been called any C calls to this [dynamic_funptr] are
-    unsafe and may result in a segmentation fault. Only call [free_dynamic_funptr] once
-    the callback is no longer used from C.
-*)
-
-val dynamic_funptr_of_fun : ?debug_info:string -> ?abi:Libffi_abi.abi -> ?runtime_lock:bool -> ?thread_registration:bool
-  -> ('a -> 'b) Ctypes.fn -> ('a -> 'b) -> ('a -> 'b) dynamic_funptr
-(** [dynamic_funptr_of_fun fn] - Turn an ocaml closure into a function pointer
-    that can be passed to C.
-
-    You MUST call [free_dynamic_funptr] to the function pointer is no longer needed.
-    Failure to do so will result in a memory leak.
-    Failure to call [free_dynamic_funptr] and not holding a reference this this pointer
-    is an error. To avoid unexpected crashes we log this and ensure that potentially still
-    needed ocaml values are retained.
-
-    For many use cases it may be simpler to use [with_dynamic_funptr_of_fun] instead as
-    this will do the free for you. *)
-
-val with_dynamic_funptr_of_fun : ?debug_info:string -> ?abi:Libffi_abi.abi -> ?runtime_lock:bool -> ?thread_registration:bool
-  -> ('a -> 'b) Ctypes.fn -> ('a -> 'b) -> (('a -> 'b) dynamic_funptr -> 'c) -> 'c
-(** [with_dynamic_funptr_of_fun fn (fun fptr -> DO_STUFF)] - Turn an ocaml closure into a
-    function pointer and do simple life cycle management.
-
-    This will automatically call [free_dynamic_funptr fptr] after [DO_STUFF] completes.
-
-    It is not safe to use if the C function ptr [fptr] may still be used after this
-    has been released.
-*)
+    Example:
+    {[
+      module Progress_callback = Foreign.Make_funptr(val (
+        Foreign.dynamic_funptr (int @-> int @-> ptr void @-> returning void))
+      let keygen =
+        foreign "RSA_generate_key" (int @-> int @-> Progress_callback.t @-> ptr void @-> returning rsa_key)
+      let secret_key =
+        Progress_callback.with_fun
+          (fun a b _ -> printf "progress: a:%d, b:%d\n" a b) 
+          (fun progress ->
+             keygen 2048 65537 progress null)
+    ]}
+    *)
 
 val call_static_funptr :
   ?name:string ->

--- a/src/ctypes-foreign-unthreaded/foreign.mli
+++ b/src/ctypes-foreign-unthreaded/foreign.mli
@@ -113,7 +113,7 @@ module type Funptr = sig
       Alternatively {!with_fun} encapsulates both allocation and deallocation. *)
 
   val t : t Ctypes.typ
-  (** ctype that can be used in type signatures of external functions *)
+  (** A type representation for a function pointer type with explicit lifetime management. *)
 
   val t_opt : t option Ctypes.typ
   (** This behaves like {!t}, except that null pointers appear in OCaml as [None]. *)

--- a/tests/clib/test_functions.c
+++ b/tests/clib/test_functions.c
@@ -893,3 +893,21 @@ int foreign_thread_registration_test(void (*test_f)(uint64_t),
   free(h_thread);
   return ret_code;
 }
+
+int call_dynamic_funptr(int (*f)(int),int n) {
+  if(f == NULL) return 0;
+  else return f(n);
+}
+
+int(*saved_dynamic_funptr)(int) = NULL;
+
+void save_dynamic_funptr(int (*f)(int)) {
+  saved_dynamic_funptr = f;
+}
+
+int call_saved_dynamic_funptr(int n) {
+  return call_dynamic_funptr(saved_dynamic_funptr, n);
+}
+
+int call_dynamic_funptr_struct(struct simple_closure x) { return (x.f(x.n)); }
+int call_dynamic_funptr_struct_ptr(struct simple_closure *x) { return (x->f(x->n)); }

--- a/tests/clib/test_functions.h
+++ b/tests/clib/test_functions.h
@@ -272,4 +272,14 @@ void check_ones(const int *, size_t);
 intnat max_caml_int(void);
 
 int foreign_thread_registration_test(void (*)(uint64_t),unsigned,unsigned);
+
+int call_dynamic_funptr(int (*)(int),int);
+
+void save_dynamic_funptr(int (*)(int));
+int call_saved_dynamic_funptr(int);
+
+struct simple_closure { int (*f)(int); int n; };
+int call_dynamic_funptr_struct(struct simple_closure);
+int call_dynamic_funptr_struct_ptr(struct simple_closure*);
+
 #endif /* TEST_FUNCTIONS_H */

--- a/tests/test-funptrs/stub-generator/driver.ml
+++ b/tests/test-funptrs/stub-generator/driver.ml
@@ -1,0 +1,12 @@
+(*
+ * Copyright (c) 2014 Jeremy Yallop.
+ *
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+(* Stub generation driver for the foreign value tests. *)
+
+let cheader = "extern char **environ;"
+
+let () = Tests_common.run ~cheader Sys.argv (module Functions.Stubs)

--- a/tests/test-funptrs/stubs/functions.ml
+++ b/tests/test-funptrs/stubs/functions.ml
@@ -1,0 +1,24 @@
+open Ctypes
+
+module Callback = (val Foreign.dynamic_funptr (int @-> returning int))
+
+module Stubs (F: Ctypes.FOREIGN) =
+struct
+  open F
+
+  let call_dynamic_funptr = foreign "call_dynamic_funptr" (Callback.t @-> int @-> returning int)
+  let save_dynamic_funptr = foreign "save_dynamic_funptr" (Callback.t @-> returning void)
+  let call_saved_dynamic_funptr  = foreign "call_saved_dynamic_funptr" (int @-> returning int)
+
+  let call_dynamic_funptr_opt  = foreign "call_dynamic_funptr" (Callback.t_opt @-> int @-> returning int)
+  let save_dynamic_funptr_opt  = foreign "save_dynamic_funptr" (Callback.t_opt @-> returning void)
+
+  type simple_closure 
+  let simple_closure : simple_closure structure typ = structure "simple_closure"
+  let simple_closure_f = field simple_closure "f" Callback.t
+  let simple_closure_n = field simple_closure "n" int
+  let () = seal simple_closure
+
+  let call_dynamic_funptr_struct = foreign "call_dynamic_funptr_struct" (simple_closure @-> returning int)
+  let call_dynamic_funptr_struct_ptr = foreign "call_dynamic_funptr_struct_ptr" (ptr simple_closure @-> returning int)
+end

--- a/tests/test-funptrs/test_funptrs.ml
+++ b/tests/test-funptrs/test_funptrs.ml
@@ -1,0 +1,216 @@
+(*
+ * Copyright (c) 2013 Jeremy Yallop.
+ *
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+open OUnit2
+open Ctypes
+open Foreign
+
+(* Explicitly raise on leaked funptrs. *)
+
+let detect_funptr_leaks ?(expected_number_of_leaked_funptrs=0) f =
+  let number_of_leaked_funptrs = ref 0 in
+  Foreign.report_leaked_funptr := (fun _msg ->
+    number_of_leaked_funptrs := !number_of_leaked_funptrs + 1);
+  Gc.full_major ();
+  Gc.full_major ();
+  assert_equal 0 !number_of_leaked_funptrs;
+  let res = f () in
+  Gc.full_major ();
+  Gc.full_major ();
+  assert_equal expected_number_of_leaked_funptrs !number_of_leaked_funptrs;
+  res
+;;
+
+
+module Callback = Functions.Callback
+module Common_tests(S : Cstubs.FOREIGN with type 'a result = 'a
+                                        and type 'a return = 'a) =
+struct
+  module M = Functions.Stubs(S)
+
+  let make_f () : (int -> int) * ([`Live|`Released] -> unit) =
+    let closure_status = ref `Live in
+    let f = (+) 1 in
+    Gc.finalise_last (fun () -> closure_status := `Released) f;
+    f, (fun status -> 
+      Gc.full_major ();
+      Gc.full_major ();
+      assert_equal status !closure_status)
+  ;;
+
+  let test_of_fun_and_free _ =
+    detect_funptr_leaks (fun () ->
+      let f, assert_closure =
+        let f, assert_closure = make_f () in
+        Callback.of_fun f, assert_closure
+      in
+      assert_closure `Live;
+      assert_equal 3 (M.call_dynamic_funptr f 2);
+      Callback.free f;
+      assert_closure `Released)
+  ;;
+
+  let test_of_fun_and_leak _ =
+    let assert_closure = 
+      detect_funptr_leaks ~expected_number_of_leaked_funptrs:1 (fun () ->
+        let f, assert_closure =
+          let f, assert_closure = make_f () in
+          Callback.of_fun f, assert_closure
+        in
+        assert_closure `Live;
+        assert_equal 3 (M.call_dynamic_funptr f 2);
+        assert_closure)
+    in
+    assert_closure `Live
+  ;;
+
+  let test_with_fun _ =
+    detect_funptr_leaks (fun () ->
+      let assert_closure = 
+        let f, assert_closure = make_f () in
+        assert_equal 3 (Callback.with_fun f (fun f -> M.call_dynamic_funptr f 2));
+        assert_closure
+      in
+      assert_closure `Released)
+  ;;
+
+  let test_opt_none _ =
+    detect_funptr_leaks (fun () ->
+      assert_equal 0 (M.call_dynamic_funptr_opt None 2))
+  ;;
+
+  let test_opt_some _ =
+    detect_funptr_leaks (fun () ->
+      assert_equal 3 (Callback.with_fun ((+) 1) (fun f -> M.call_dynamic_funptr_opt (Some f) 2)))
+  ;;
+
+  let test_save_and_free _ =
+    detect_funptr_leaks (fun () ->
+      M.save_dynamic_funptr_opt (None);
+      assert_equal 0 (M.call_saved_dynamic_funptr 2);
+      let f, assert_closure =
+        let f, assert_closure = make_f () in
+        Callback.of_fun f, assert_closure
+      in
+      assert_closure `Live;
+      M.save_dynamic_funptr_opt (Some f);
+      assert_closure `Live;
+      assert_equal 3 (M.call_saved_dynamic_funptr 2);
+      assert_closure `Live;
+      Callback.free f;
+      assert_closure `Released;
+    );
+    M.save_dynamic_funptr_opt (None)
+  ;;
+
+  let test_save_and_leak _ =
+    let assert_closure = 
+      detect_funptr_leaks ~expected_number_of_leaked_funptrs:1 (fun () ->
+      M.save_dynamic_funptr_opt (None);
+      assert_equal 0 (M.call_saved_dynamic_funptr 2);
+      let f, assert_closure =
+        let f, assert_closure = make_f () in
+        Callback.of_fun f, assert_closure
+      in
+      assert_closure `Live;
+      M.save_dynamic_funptr_opt (Some f);
+      assert_closure)
+    in
+    (* Technically this is undefined behaviour, but the library should handle this in
+       the least surprising way possible (leaking but not crashing). *)
+    assert_closure `Live;
+    assert_equal 3 (M.call_saved_dynamic_funptr 2);
+    M.save_dynamic_funptr_opt (None);
+    assert_equal 0 (M.call_saved_dynamic_funptr 2);
+    assert_closure `Live;
+  ;;
+
+  let test_struct _ =
+    detect_funptr_leaks (fun () ->
+      let t = make M.simple_closure in
+      let f = Callback.of_fun ((+)1) in
+      setf t M.simple_closure_f f;
+      setf t M.simple_closure_n 2;
+      assert_equal 3 (M.call_dynamic_funptr_struct t);
+      Callback.free f
+    )
+
+  let test_struct_ptr _ =
+    detect_funptr_leaks (fun () ->
+      let t = make M.simple_closure in
+      let p = addr t in
+      let f = Callback.of_fun ((+)1) in
+      p |-> M.simple_closure_f <-@ f;
+      p |-> M.simple_closure_n <-@ 2;
+      assert_equal 3 (M.call_dynamic_funptr_struct_ptr p);
+      Callback.free f
+    )
+
+end
+
+module Foreign_tests = Common_tests(Tests_common.Foreign_binder)
+module Stub_tests = Common_tests(Generated_bindings)
+
+let suite = "Dynamic-Funptr tests" >:::
+  ["test_of_fun_and_free (foreign)"
+   >:: Foreign_tests.test_of_fun_and_free;
+
+   "test_of_fun_and_free (stubs)"
+   >:: Stub_tests.test_of_fun_and_free;
+
+   "test_of_fun_and_leak (foreign)"
+   >:: Foreign_tests.test_of_fun_and_leak;
+
+   "test_of_fun_and_leak (stubs)"
+   >:: Stub_tests.test_of_fun_and_leak;
+
+   "test_with_fun (foreign)"
+   >:: Foreign_tests.test_with_fun;
+
+   "test_with_fun (stubs)"
+   >:: Stub_tests.test_with_fun;
+
+   "test_opt_none (foreign)"
+   >:: Foreign_tests.test_opt_none;
+
+   "test_opt_none (stubs)"
+   >:: Stub_tests.test_opt_none;
+
+   "test_opt_some (foreign)"
+   >:: Foreign_tests.test_opt_some;
+
+   "test_opt_some (stubs)"
+   >:: Stub_tests.test_opt_some;
+
+   "test_save_and_free (foreign)"
+   >:: Foreign_tests.test_save_and_free;
+
+   "test_save_and_free (stubs)"
+   >:: Stub_tests.test_save_and_free;
+
+   "test_save_and_leak (foreign)"
+   >:: Foreign_tests.test_save_and_leak;
+
+   "test_save_and_leak (stubs)"
+   >:: Stub_tests.test_save_and_leak;
+
+   "test_struct (foreign)"
+   >:: Foreign_tests.test_struct;
+
+   "test_struct (stubs)"
+   >:: Stub_tests.test_struct;
+
+   "test_struct_ptr (foreign)"
+   >:: Foreign_tests.test_struct_ptr;
+
+   "test_struct_ptr (stubs)"
+   >:: Stub_tests.test_struct_ptr;
+  ]
+
+let _ =
+  run_test_tt_main suite
+

--- a/tests/test-funptrs/test_funptrs.ml
+++ b/tests/test-funptrs/test_funptrs.ml
@@ -34,7 +34,7 @@ struct
 
   let make_f () : (int -> int) * ([`Live|`Released] -> unit) =
     let closure_status = ref `Live in
-    let f = (+) 1 in
+    let f = !(ref (+)) 1 in
     Gc.finalise (fun _ -> closure_status := `Released) f;
     f, (fun status -> 
       Gc.full_major ();


### PR DESCRIPTION
[Foreign.dynamic_funptr] is a safer alternative for [Foreign.funptr], in
particular this new version requires explicit life cycle management making it
easier to avoid difficult to debug segmentation faults where the ocaml
closure is released before it is used from C.

We discovered one of these in Async_ssl which motivated us to propose this addition.