### PR TITLE
update lwt test constrain

### DIFF
--- a/Makefile.tests
+++ b/Makefile.tests
@@ -1050,7 +1050,7 @@ test-lwt-preemptive-stub-generator: $$(BEST_TARGET)
 
 test-lwt-preemptive.dir = tests/test-lwt-preemptive
 test-lwt-preemptive.threads = yes
-test-lwt-preemptive.deps = str bigarray oUnit bytes integers lwt.preemptive
+test-lwt-preemptive.deps = str bigarray oUnit bytes integers lwt.unix
 test-lwt-preemptive.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs tests-common test-lwt-preemptive-stubs
 test-lwt-preemptive.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -1135,7 +1135,7 @@ test-returning-errno-lwt-preemptive-stub-generator: $$(BEST_TARGET)
 
 test-returning-errno-lwt-preemptive.dir = tests/test-returning-errno-lwt-preemptive
 test-returning-errno-lwt-preemptive.threads = yes
-test-returning-errno-lwt-preemptive.deps = str bigarray oUnit bytes integers lwt.preemptive
+test-returning-errno-lwt-preemptive.deps = str bigarray oUnit bytes integers lwt.unix
 test-returning-errno-lwt-preemptive.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs tests-common test-returning-errno-lwt-preemptive-stubs
 test-returning-errno-lwt-preemptive.link_flags = -L$(BUILDDIR)/clib -ltest_functions

--- a/ctypes.opam
+++ b/ctypes.opam
@@ -26,7 +26,7 @@ depends: [
    "integers" { >= "0.3.0" }
    "ocamlfind" {build}
    "conf-pkg-config" {build}
-   "lwt" {test & < "4.0.0"}
+   "lwt" {test & >= "3.2.0"}
    "ctypes-foreign" {test}
    "ounit" {test}
    "conf-ncurses" {test}


### PR DESCRIPTION
OCaml 4.01.0 support was dropped in 3243c8974b726cbd67fa1bf044f3cf7137961f12, so it's  now possible to depend on a newer lwt version without ifdefs inside the Makefile.
See https://github.com/ocsigen/lwt/blob/5c2f2d90f898a5bc9889c01b96a2de547c31482f/CHANGES#L96
This should make #601 possible

