### PR TITLE
Add support for unsafe ocaml arguments.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@
 * Eliminate uses of <complex.h> on Android  
   https://github.com/ocamllabs/ocaml-ctypes/pull/579
 
+* Allow unsafe ocaml values in callbacks
+
 Thanks to Anton Bachin (@aantron), Andreas Hauptmann (@fdopen) and
 @ygrek for contributions to this release.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
   https://github.com/ocamllabs/ocaml-ctypes/pull/579
 
 * Allow unsafe ocaml values in callbacks
+  https://github.com/ocamllabs/ocaml-ctypes/pull/607
 
 Thanks to Anton Bachin (@aantron), Andreas Hauptmann (@fdopen) and
 @ygrek for contributions to this release.

--- a/src/cstubs/cstubs_analysis.ml
+++ b/src/cstubs/cstubs_analysis.ml
@@ -109,6 +109,7 @@ let rec allocation : type a. a typ -> a allocation = function
  | Array _ -> `Alloc Alloc_array
  | Bigarray ba -> `Alloc (Alloc_bigarray ba)
  | OCaml _ -> `Alloc Alloc_pointer
+ | OCamlUnsafe _ -> `Alloc Alloc_pointer
 
 let rec may_allocate : type a. a fn -> bool = function
   | Returns t ->

--- a/src/cstubs/cstubs_generate_c.ml
+++ b/src/cstubs/cstubs_generate_c.ml
@@ -142,8 +142,11 @@ struct
     | View { ty } -> prj ty ~orig x
     | Array _ -> report_unpassable "arrays"
     | Bigarray _ -> report_unpassable "bigarrays"
+    | OCamlUnsafe String
     | OCaml String -> Some (string_to_ptr x)
+    | OCamlUnsafe Bytes
     | OCaml Bytes -> Some (string_to_ptr x)
+    | OCamlUnsafe FloatArray
     | OCaml FloatArray -> Some (float_array_to_ptr x)
 
   let prj ty x = prj ty ~orig:ty x
@@ -160,6 +163,7 @@ struct
     | View { ty } -> inj ty x
     | Array _ -> report_unpassable "arrays"
     | Bigarray _ -> report_unpassable "bigarrays"
+    | OCamlUnsafe _
     | OCaml _ -> report_unpassable "ocaml references as return values"
 
   type _ fn =

--- a/src/cstubs/cstubs_generate_c.ml
+++ b/src/cstubs/cstubs_generate_c.ml
@@ -143,10 +143,13 @@ struct
     | Array _ -> report_unpassable "arrays"
     | Bigarray _ -> report_unpassable "bigarrays"
     | OCamlUnsafe String
+                   -> Some (string_to_ptr x)
     | OCaml String -> Some (string_to_ptr x)
     | OCamlUnsafe Bytes
+                  -> Some (string_to_ptr x)
     | OCaml Bytes -> Some (string_to_ptr x)
     | OCamlUnsafe FloatArray
+                       -> Some (float_array_to_ptr x)
     | OCaml FloatArray -> Some (float_array_to_ptr x)
 
   let prj ty x = prj ty ~orig:ty x
@@ -163,7 +166,7 @@ struct
     | View { ty } -> inj ty x
     | Array _ -> report_unpassable "arrays"
     | Bigarray _ -> report_unpassable "bigarrays"
-    | OCamlUnsafe _
+    | OCamlUnsafe _ -> report_unpassable "ocaml references as return values"
     | OCaml _ -> report_unpassable "ocaml references as return values"
 
   type _ fn =

--- a/src/cstubs/cstubs_generate_ml.ml
+++ b/src/cstubs/cstubs_generate_ml.ml
@@ -245,12 +245,18 @@ let rec ml_typ_of_return_typ : type a. a typ -> ml_type =
   | Bigarray _ as a -> internal_error
     "Unexpected bigarray type in the return type: %s" (Ctypes.string_of_typ a)
   | OCamlUnsafe String
+                 -> Ctypes_static.unsupported
+    "cstubs does not support OCaml strings as return values"
   | OCaml String -> Ctypes_static.unsupported
     "cstubs does not support OCaml strings as return values"
   | OCamlUnsafe Bytes
+                -> Ctypes_static.unsupported
+    "cstubs does not support OCaml bytes values as return values"
   | OCaml Bytes -> Ctypes_static.unsupported
     "cstubs does not support OCaml bytes values as return values"
   | OCamlUnsafe FloatArray
+                     -> Ctypes_static.unsupported
+    "cstubs does not support OCaml float arrays as return values"
   | OCaml FloatArray -> Ctypes_static.unsupported
     "cstubs does not support OCaml float arrays as return values"
 
@@ -267,15 +273,22 @@ let rec ml_typ_of_arg_typ : type a. a typ -> ml_type = function
     "Unexpected array in an argument type: %s" (Ctypes.string_of_typ a)
   | Bigarray _ as a -> internal_error
     "Unexpected bigarray in an argument type: %s" (Ctypes.string_of_typ a)
-  | OCamlUnsafe String
+  | OCamlUnsafe String ->
+    `Appl (path_of_string "CI.ocaml",
+           [`Ident (path_of_string "string")])
   | OCaml String ->
     `Appl (path_of_string "CI.ocaml",
            [`Ident (path_of_string "string")])
-  | OCamlUnsafe Bytes
+  | OCamlUnsafe Bytes ->
+    `Appl (path_of_string "CI.ocaml",
+           [`Ident (path_of_string "Bytes.t")])
   | OCaml Bytes ->
     `Appl (path_of_string "CI.ocaml",
            [`Ident (path_of_string "Bytes.t")])
-  | OCamlUnsafe FloatArray
+  | OCamlUnsafe FloatArray ->
+    `Appl (path_of_string "CI.ocaml",
+           [`Appl (path_of_string "array",
+                   [`Ident (path_of_string "float")])])
   | OCaml FloatArray ->
     `Appl (path_of_string "CI.ocaml",
            [`Appl (path_of_string "array",
@@ -482,15 +495,21 @@ let rec pattern_of_typ : type a. a typ -> ml_pat = function
      static_con "Array" [`Underscore; `Underscore]
   | Bigarray _ ->
      static_con "Bigarray" [`Underscore]
-  | OCamlUnsafe String
+  | OCamlUnsafe String ->
+    Ctypes_static.unsupported
+      "cstubs does not support OCaml strings as global values"
   | OCaml String ->
     Ctypes_static.unsupported
       "cstubs does not support OCaml strings as global values"
-  | OCamlUnsafe Bytes
+  | OCamlUnsafe Bytes ->
+    Ctypes_static.unsupported
+      "cstubs does not support OCaml bytes values as global values"
   | OCaml Bytes ->
     Ctypes_static.unsupported
       "cstubs does not support OCaml bytes values as global values"
-  | OCamlUnsafe FloatArray
+  | OCamlUnsafe FloatArray ->
+    Ctypes_static.unsupported
+      "cstubs does not support OCaml float arrays as global values"
   | OCaml FloatArray ->
     Ctypes_static.unsupported
       "cstubs does not support OCaml float arrays as global values"

--- a/src/ctypes-foreign-base/ctypes_ffi.ml
+++ b/src/ctypes-foreign-base/ctypes_ffi.ml
@@ -63,6 +63,7 @@ struct
                                              else ArgType ffitype
     | Pointer _                           -> ArgType (Ctypes_ffi_stubs.pointer_ffitype ())
     | Funptr _                            -> ArgType (Ctypes_ffi_stubs.pointer_ffitype ())
+    | OCamlUnsafe _
     | OCaml _                             -> ArgType (Ctypes_ffi_stubs.pointer_ffitype ())
     | Union _                             -> report_unpassable "unions"
     | Struct ({ spec = Complete _ } as s) -> struct_arg_type s
@@ -160,9 +161,14 @@ struct
         mov.(idx) <- (Obj.repr obj, disp * elt_size);
         Obj.repr obj
     in function
-    | OCaml String     -> ocaml_arg 1
-    | OCaml Bytes      -> ocaml_arg 1
-    | OCaml FloatArray -> ocaml_arg (Ctypes_primitives.sizeof Ctypes_primitive_types.Double)
+    | OCamlUnsafe String -> ocaml_arg 1
+    | OCaml String       -> ocaml_arg 1
+    | OCamlUnsafe Bytes  -> ocaml_arg 1
+    | OCaml Bytes        -> ocaml_arg 1
+    | OCamlUnsafe FloatArray ->
+       ocaml_arg (Ctypes_primitives.sizeof Ctypes_primitive_types.Double)
+    | OCaml FloatArray ->
+       ocaml_arg (Ctypes_primitives.sizeof Ctypes_primitive_types.Double)
     | View { write = w; ty } ->
       (fun ~offset ~idx v dst mov -> 
          let wv = w v in

--- a/src/ctypes-foreign-base/ctypes_ffi.ml
+++ b/src/ctypes-foreign-base/ctypes_ffi.ml
@@ -63,7 +63,7 @@ struct
                                              else ArgType ffitype
     | Pointer _                           -> ArgType (Ctypes_ffi_stubs.pointer_ffitype ())
     | Funptr _                            -> ArgType (Ctypes_ffi_stubs.pointer_ffitype ())
-    | OCamlUnsafe _
+    | OCamlUnsafe _                       -> ArgType (Ctypes_ffi_stubs.pointer_ffitype ())
     | OCaml _                             -> ArgType (Ctypes_ffi_stubs.pointer_ffitype ())
     | Union _                             -> report_unpassable "unions"
     | Struct ({ spec = Complete _ } as s) -> struct_arg_type s

--- a/src/ctypes/cstubs_internals.mli
+++ b/src/ctypes/cstubs_internals.mli
@@ -42,6 +42,7 @@ type 'a typ = 'a Ctypes_static.typ =
   | View            : ('a, 'b) view             -> 'a typ
   | Array           : 'a typ * int              -> 'a Ctypes_static.carray typ
   | Bigarray        : (_, 'a, _) Ctypes_bigarray.t -> 'a typ
+  | OCamlUnsafe     : 'a ocaml_type             -> 'a ocaml typ
   | OCaml           : 'a ocaml_type             -> 'a ocaml typ
 and ('a, 'b) pointer = ('a, 'b) Ctypes_static.pointer =
   CPointer : 'a typ Ctypes_ptr.Fat.t -> ('a, [`C]) pointer

--- a/src/ctypes/ctypes_memory.ml
+++ b/src/ctypes/ctypes_memory.ml
@@ -35,6 +35,7 @@ let rec build : type a b. a typ -> b typ Fat.t -> a
       let buildty = build ty in
       (fun buf -> read (buildty buf))
     | OCamlUnsafe _
+              -> (fun buf -> assert false)
     | OCaml _ -> (fun buf -> assert false)
     (* The following cases should never happen; non-struct aggregate
        types are excluded during type construction. *)

--- a/src/ctypes/ctypes_static.ml
+++ b/src/ctypes/ctypes_static.ml
@@ -132,7 +132,7 @@ let rec sizeof : type a. a typ -> int = function
   | Abstract { asize }             -> asize
   | Pointer _                      -> Ctypes_primitives.pointer_size
   | Funptr _                       -> Ctypes_primitives.pointer_size
-  | OCamlUnsafe _
+  | OCamlUnsafe _                  -> raise IncompleteType
   | OCaml _                        -> raise IncompleteType
   | View { ty }                    -> sizeof ty
 
@@ -165,7 +165,7 @@ let rec passable : type a. a typ -> bool = function
   | Pointer _                      -> true
   | Funptr _                       -> true
   | Abstract _                     -> false
-  | OCamlUnsafe _
+  | OCamlUnsafe _                  -> true
   | OCaml _                        -> true
   | View { ty }                    -> passable ty
 

--- a/src/ctypes/ctypes_static.ml
+++ b/src/ctypes/ctypes_static.ml
@@ -149,7 +149,7 @@ let rec alignment : type a. a typ -> int = function
   | Abstract { aalignment }          -> aalignment
   | Pointer _                        -> Ctypes_primitives.pointer_alignment
   | Funptr _                         -> Ctypes_primitives.pointer_alignment
-  | OCamlUnsafe _
+  | OCamlUnsafe _                    -> raise IncompleteType
   | OCaml _                          -> raise IncompleteType
   | View { ty }                      -> alignment ty
 

--- a/src/ctypes/ctypes_static.mli
+++ b/src/ctypes/ctypes_static.mli
@@ -38,6 +38,7 @@ type _ typ =
   | Array           : 'a typ * int       -> 'a carray typ
   | Bigarray        : (_, 'a, _) Ctypes_bigarray.t
                                          -> 'a typ
+  | OCamlUnsafe     : 'a ocaml_type      -> 'a ocaml typ
   | OCaml           : 'a ocaml_type      -> 'a ocaml typ
 and 'a carray = { astart : 'a ptr; alength : int }
 and ('a, 'kind) structured = { structured : ('a, 'kind) structured ptr }
@@ -148,8 +149,11 @@ val ulong : Unsigned.ulong typ
 val ullong : Unsigned.ullong typ
 val array : int -> 'a typ -> 'a carray typ
 val ocaml_string : string ocaml typ
+val ocaml_unsafe_string : string ocaml typ
 val ocaml_bytes : Bytes.t ocaml typ
+val ocaml_unsafe_bytes : bytes ocaml typ
 val ocaml_float_array : float array ocaml typ
+val ocaml_unsafe_float_array : float array ocaml typ
 val ptr : 'a typ -> 'a ptr typ
 val ( @-> ) : 'a typ -> 'b fn -> ('a -> 'b) fn
 val abstract : name:string -> size:int -> alignment:int -> 'a abstract typ

--- a/src/ctypes/ctypes_type_printing.ml
+++ b/src/ctypes/ctypes_type_printing.ml
@@ -73,8 +73,11 @@ let rec format_typ' : type a. a typ ->
       let name = Ctypes_primitives.name elem in
       fprintf fmt "%s%t%t" name (k `array)
         (fun fmt -> (Array.iter (Format.fprintf fmt "[%d]") dims))
+    | OCamlUnsafe String
     | OCaml String -> format_typ' (ptr char) k context fmt
+    | OCamlUnsafe Bytes
     | OCaml Bytes -> format_typ' (ptr char) k context fmt
+    | OCamlUnsafe FloatArray
     | OCaml FloatArray -> format_typ' (ptr double) k context fmt
 
 and format_fields : type a. a boxed_field list -> Format.formatter -> unit =

--- a/src/ctypes/ctypes_type_printing.ml
+++ b/src/ctypes/ctypes_type_printing.ml
@@ -74,10 +74,13 @@ let rec format_typ' : type a. a typ ->
       fprintf fmt "%s%t%t" name (k `array)
         (fun fmt -> (Array.iter (Format.fprintf fmt "[%d]") dims))
     | OCamlUnsafe String
+                   -> format_typ' (ptr char) k context fmt
     | OCaml String -> format_typ' (ptr char) k context fmt
     | OCamlUnsafe Bytes
+                  -> format_typ' (ptr char) k context fmt
     | OCaml Bytes -> format_typ' (ptr char) k context fmt
     | OCamlUnsafe FloatArray
+                       -> format_typ' (ptr double) k context fmt
     | OCaml FloatArray -> format_typ' (ptr double) k context fmt
 
 and format_fields : type a. a boxed_field list -> Format.formatter -> unit =

--- a/src/ctypes/ctypes_types.mli
+++ b/src/ctypes/ctypes_types.mli
@@ -212,7 +212,8 @@ sig
   val ocaml_unsafe_string : string Ctypes_static.ocaml typ
   (** [ocaml_unsafe_string str] is the same as [ocaml_string str] except that 
       the compiler will not check if it passed in a C function with [Cstubs.unlocked]
-      concurrency. [str] should be registered as a global root via the [Root] module. *)
+      concurrency. In this case, [str] should be registered as a global root via the 
+      [Root] module. *)
 
   val ocaml_bytes : Bytes.t Ctypes_static.ocaml typ
   (** Value representing the directly mapped storage of an OCaml byte array. *)
@@ -220,7 +221,8 @@ sig
   val ocaml_unsafe_bytes : bytes Ctypes_static.ocaml typ
   (** [ocaml_unsafe_bytes buf] is the same as [ocaml_bytes buf] except that
       the compiler will not check if it passed in a C function with [Cstubs.unlocked]
-      concurrency. [buf] should be registered as a global root via the [Root] module. *)
+      concurrency. In this case [buf] should be registered as a global root via the 
+      [Root] module. *)
 
   (** {3 Array types} *)
 

--- a/src/ctypes/ctypes_types.mli
+++ b/src/ctypes/ctypes_types.mli
@@ -209,8 +209,18 @@ sig
   val ocaml_string : string Ctypes_static.ocaml typ
   (** Value representing the directly mapped storage of an OCaml string. *)
 
+  val ocaml_unsafe_string : string Ctypes_static.ocaml typ
+  (** [ocaml_unsafe_string str] is the same as [ocaml_string str] except that 
+      the compiler will not check if it passed in a C function with [Cstubs.unlocked]
+      concurrency. [str] should be registered as a global root via the [Root] module. *)
+
   val ocaml_bytes : Bytes.t Ctypes_static.ocaml typ
   (** Value representing the directly mapped storage of an OCaml byte array. *)
+
+  val ocaml_unsafe_bytes : bytes Ctypes_static.ocaml typ
+  (** [ocaml_unsafe_bytes buf] is the same as [ocaml_bytes buf] except that
+      the compiler will not check if it passed in a C function with [Cstubs.unlocked]
+      concurrency. [buf] should be registered as a global root via the [Root] module. *)
 
   (** {3 Array types} *)
 

--- a/src/ctypes/ctypes_value_printing.ml
+++ b/src/ctypes/ctypes_value_printing.ml
@@ -21,6 +21,7 @@ let rec format : type a. a typ -> Format.formatter -> a -> unit
   | Bigarray ba -> Format.fprintf fmt "<bigarray %a>"
     (fun fmt -> Ctypes_type_printing.format_typ fmt) typ
   | Abstract _ -> format_structured fmt v
+  | OCamlUnsafe _ -> format_ocaml fmt v
   | OCaml _ -> format_ocaml fmt v
   | View {write; ty; format=f} ->
     begin match f with


### PR DESCRIPTION
If I'm not mistaken, it should be possible to:
* Register a string or bytes buffer via `Root.register`
* Pass this value to a C callback via `ocaml_{string,bytes}_start`
* Once the callback has returned, release the root via `Root.release`

This PR adds this possibility by introducing `ocaml_unsafe_{string,bytes}` (and the yet unexposed `ocaml_unsafe_float_array`).

Let me know what you think!