### PR TITLE
Build with -strict-sequence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,15 +156,15 @@ src/ctypes-foreign-base/dl_stubs.c: src/ctypes-foreign-base/dl_stubs.c$(OS_ALT_S
 	cp $< $@
 
 src/ctypes/ctypes_primitives.ml: src/configure/extract_from_c.ml src/configure/gen_c_primitives.ml
-	$(HOSTOCAMLFIND) ocamlc -o gen_c_primitives -package str,bytes -linkpkg $^ -I src/configure
+	$(HOSTOCAMLFIND) ocamlc -o gen_c_primitives -package str,bytes -strict-sequence -linkpkg $^ -I src/configure
 	./gen_c_primitives > $@ 2> gen_c_primitives.log || (rm $@ && cat gen_c_primitives.log || false)
 
 src/ctypes-foreign-base/libffi_abi.ml: src/configure/extract_from_c.ml src/configure/gen_libffi_abi.ml
-	$(HOSTOCAMLFIND) ocamlc -o gen_libffi_abi -package str,bytes -linkpkg $^ -I src/configure
+	$(HOSTOCAMLFIND) ocamlc -o gen_libffi_abi -package str,bytes -strict-sequence -linkpkg $^ -I src/configure
 	./gen_libffi_abi > $@ 2> gen_c_primitives.log || (rm $@ && cat gen_c_primitives.log || false)
 
 libffi.config: src/discover/commands.mli src/discover/commands.ml src/discover/discover.ml
-	$(HOSTOCAMLFIND) ocamlc -o discover -package str,bytes -linkpkg $^ -I src/discover
+	$(HOSTOCAMLFIND) ocamlc -o discover -package str,bytes -strict-sequence -linkpkg $^ -I src/discover
 	./discover -ocamlc "$(OCAMLFIND) ocamlc" > $@ || (rm $@ && false)
 
 asneeded.config:

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -20,9 +20,9 @@ endif
 endif
 
 ifeq ($(DEBUG),false)
-  OCAMLFLAGS=-principal -short-paths -ccopt "-I$(package_integers_path)"
+  OCAMLFLAGS=-principal -short-paths -strict-sequence -ccopt "-I$(package_integers_path)"
 else
-  OCAMLFLAGS=-principal -short-paths -g -ccopt "-I$(package_integers_path)"
+  OCAMLFLAGS=-principal -short-paths -strict-sequence -g -ccopt "-I$(package_integers_path)"
 endif
 ifneq ($(COVERAGE),false)
   OCAMLFIND_BISECT_FLAGS=-package bisect_ppx

--- a/src/discover/commands.mli
+++ b/src/discover/commands.mli
@@ -5,7 +5,7 @@
  * See the file LICENSE for details.
  *)
 
-val unwind_protect : cleanup:('a -> 'c) -> ('a -> 'b) -> 'a -> 'b
+val unwind_protect : cleanup:('a -> unit) -> ('a -> 'b) -> 'a -> 'b
 val with_open_output_file : filename:string -> (out_channel -> 'a) -> 'a
 
 val file_contents : filename:string -> string

--- a/tests/test-variadic/test_variadic.ml
+++ b/tests/test-variadic/test_variadic.ml
@@ -26,14 +26,14 @@ struct
     let bufsz = 128 in
     let write snprintf apply =
       let buf = allocate_n char bufsz in
-      apply (snprintf buf bufsz);
+      ignore (apply (snprintf buf bufsz));
       coerce (ptr char) string buf
     in
     begin
       assert_equal "an int: 100."
         (write snprintf_int
            (fun k -> k "an int: %d." 100));
-      
+
       assert_equal "a char A and a uint 33."
         (write snprintf_char_unsigned
            (fun k -> k "a char %c and a uint %u." 'A' (UInt.of_int 33)));


### PR DESCRIPTION
This PR enables `-strict-sequence` and allows building ctypes with it enabled.
This is related to the proposal of enabling -strict-sequence by default in ocaml/ocaml#1971, in order to make ctypes forward compatible.

(I can restrict the PR to the change in `commands.mli` if you would rather avoid modifying the build instructions themselves; although enabling the option there makes sure the issue will not come back later).