### PR TITLE
fix ctypes-foreign depexts to work with opam 2

### DIFF
--- a/ctypes-foreign.opam
+++ b/ctypes-foreign.opam
@@ -1,23 +1,43 @@
 opam-version: "2.0"
 version: "dev"
 maintainer: "yallop@gmail.com"
-author: "yallop@gmail.com"
 homepage: "https://github.com/ocamllabs/ocaml-ctypes"
 dev-repo: "git+http://github.com/ocamllabs/ocaml-ctypes.git"
 bug-reports: "http://github.com/ocamllabs/ocaml-ctypes/issues"
 depexts: [
-  [ ["debian"] [ "libffi-dev"] ]   
-  [ ["ubuntu"] [ "libffi-dev" ] ]
-  [ ["osx" "homebrew"] ["libffi"] ]
-  [ ["centos"] ["libffi-devel"] ]
-  [ ["oraclelinux"] ["libffi-devel"] ]
-  [ ["fedora"] ["libffi-devel"] ]
-  [ ["alpine"] ["libffi-dev"] ]
-  [ ["opensuse"] ["libffi-devel"] ]
-  [ ["win32" "cygwinports"] ["libffi" "pkg-config"] ]
- ]
+  ["libffi-dev"] {os-family = "debian"}
+  ["libffi"] {os = "macos" & os-distribution = "homebrew"}
+  ["libffi"] {os = "macos" & os-distribution = "macports"}
+  ["libffi-devel"] {os-distribution = "centos"}
+  ["libffi-devel"] {os-distribution = "ol"}
+  ["libffi-devel"] {os-distribution = "fedora"}
+  ["libffi-dev"] {os-distribution = "alpine"}
+  ["libffi-devel"] {os-family = "suse"}
+]
 tags: ["org:ocamllabs" "org:mirage"]
 post-messages: [
   "This package requires libffi on your system" {failure}
 ]
-synopsis: "Virtual package for enabling the ctypes.foreign subpackage"
+synopsis: "Virtual package for enabling the ctypes.foreign subpackage."
+description: """
+`ctypes-foreign` is just a virtual OPAM package that determines
+whether the foreign subpackage should built as part of ctypes.
+In order to actually get the ctypes package, you should also:
+
+    opam install ctypes ctypes-foreign
+
+You can verify the existence of the ocamlfind subpackage by:
+
+    ocamlfind list | grep ctypes
+
+Which should output something like:
+
+    ctypes              (version: 0.4.1)
+    ctypes.foreign      (version: 0.4.1)
+    ctypes.foreign.base (version: 0.4.1)
+    ctypes.foreign.threaded (version: 0.4.1)
+    ctypes.foreign.unthreaded (version: 0.4.1)
+    ctypes.stubs        (version: 0.4.1)
+    ctypes.top          (version: 0.4.1)"""
+authors: "yallop@gmail.com"
+depends: ["ocaml"]


### PR DESCRIPTION
This commit syncs the ctypes-foreign.opam with the version downstream in ocaml/opam-repository, and uses the opam 2 style of specifying depexts.  This in turn makes depexts work with a pinned ctypes-foreign, which is useful for automated CI of this repository.