### PR TITLE
Reflect "managed" status in the types of fat pointers

### DIFF
--- a/src/cstubs/cstubs_generate_ml.ml
+++ b/src/cstubs/cstubs_generate_ml.ml
@@ -374,7 +374,8 @@ let rec pattern_and_exp_of_typ : type a. concurrency:concurrency_policy -> errno
     begin match pol with
     | In ->
       let pat = static_con "Funptr" [`Underscore] in
-      (pat, Some (`Appl (`Ident (path_of_string "CI.fptr"), e)), binds)
+      let x = fresh_var () in
+      (pat, Some (`Ident (path_of_string x)), binds @ [static_con "Static_funptr" [`Var x], e])
     | Out ->
       let x = fresh_var () in
       let pat = static_con "Funptr" [`Var x] in

--- a/src/ctypes-foreign-base/ctypes_ffi_stubs.ml
+++ b/src/ctypes-foreign-base/ctypes_ffi_stubs.ml
@@ -56,7 +56,7 @@ external prep_callspec : callspec -> int -> _ ffitype -> unit
 (* Call the function specified by `callspec' at the given address.
    The callback functions write the arguments to the buffer and read
    the return value. *)
-external call : string -> _ Ctypes_static.fn Fat.t -> callspec ->
+external call : string -> (_, _ Ctypes_static.fn) Fat.t -> callspec ->
   (voidp -> (Obj.t * int) array -> unit) -> (voidp -> 'a) -> 'a
   = "ctypes_call"
 

--- a/src/ctypes/cstubs_internals.ml
+++ b/src/ctypes/cstubs_internals.ml
@@ -25,7 +25,6 @@ include Ctypes_primitive_types
 let make_ptr reftyp raw_ptr = CPointer (Ctypes_ptr.Fat.make ~reftyp raw_ptr)
 let make_fun_ptr reftyp raw_ptr = Static_funptr (Ctypes_ptr.Fat.make ~reftyp raw_ptr)
 
-let cptr (CPointer p) = p
 let fptr (Static_funptr p) = p
 
 let mkView :

--- a/src/ctypes/cstubs_internals.ml
+++ b/src/ctypes/cstubs_internals.ml
@@ -10,20 +10,21 @@
 
 type voidp = Ctypes_ptr.voidp
 type managed_buffer = Ctypes_memory_stubs.managed_buffer
-type 'a fatptr = 'a Ctypes.typ Ctypes_ptr.Fat.t
-type 'a fatfunptr = 'a Ctypes.fn Ctypes_ptr.Fat.t
+type ('m, 'a) fatptr = ('m, 'a Ctypes.typ) Ctypes_ptr.Fat.t
+type ('m, 'a) fatfunptr = ('m, 'a Ctypes.fn) Ctypes_ptr.Fat.t
 
 let make_structured reftyp buf =
   let open Ctypes_static in
-  let managed = Obj.repr buf in
   let raw_ptr = Ctypes_memory_stubs.block_address buf in
-  { structured = CPointer (Ctypes_ptr.Fat.make ~managed ~reftyp raw_ptr) }
+  { structured = CPointer (Ctypes_ptr.Fat.make ~managed:(Some buf) ~reftyp raw_ptr) }
 
 include Ctypes_static
 include Ctypes_primitive_types
 
-let make_ptr reftyp raw_ptr = CPointer (Ctypes_ptr.Fat.make ~reftyp raw_ptr)
-let make_fun_ptr reftyp raw_ptr = Static_funptr (Ctypes_ptr.Fat.make ~reftyp raw_ptr)
+let make_ptr reftyp raw_ptr = CPointer (Ctypes_ptr.Fat.make
+                                          ~managed:None ~reftyp raw_ptr)
+let make_fun_ptr reftyp raw_ptr = Static_funptr (Ctypes_ptr.Fat.make
+                                                   ~managed:None ~reftyp raw_ptr)
 
 let mkView :
   type a b. string -> a typ -> typedef:bool -> unexpected:(a -> b) -> (b * a) list -> b typ =

--- a/src/ctypes/cstubs_internals.ml
+++ b/src/ctypes/cstubs_internals.ml
@@ -25,8 +25,6 @@ include Ctypes_primitive_types
 let make_ptr reftyp raw_ptr = CPointer (Ctypes_ptr.Fat.make ~reftyp raw_ptr)
 let make_fun_ptr reftyp raw_ptr = Static_funptr (Ctypes_ptr.Fat.make ~reftyp raw_ptr)
 
-let fptr (Static_funptr p) = p
-
 let mkView :
   type a b. string -> a typ -> typedef:bool -> unexpected:(a -> b) -> (b * a) list -> b typ =
   fun name typ ~typedef ~unexpected alist ->

--- a/src/ctypes/cstubs_internals.mli
+++ b/src/ctypes/cstubs_internals.mli
@@ -23,7 +23,6 @@ val make_structured :
 val make_ptr : 'a typ -> voidp -> 'a ptr
 val make_fun_ptr : 'a fn -> voidp -> 'a Ctypes_static.static_funptr
 
-val cptr : 'a ptr -> 'a typ Ctypes_ptr.Fat.t
 val fptr : 'a Ctypes_static.static_funptr -> 'a fn Ctypes_ptr.Fat.t
 
 type 'a ocaml_type = 'a Ctypes_static.ocaml_type =

--- a/src/ctypes/cstubs_internals.mli
+++ b/src/ctypes/cstubs_internals.mli
@@ -14,8 +14,8 @@ open Unsigned
 
 type voidp = Ctypes_ptr.voidp
 type managed_buffer = Ctypes_memory_stubs.managed_buffer
-type 'a fatptr = 'a typ Ctypes_ptr.Fat.t
-type 'a fatfunptr = 'a fn Ctypes_ptr.Fat.t
+type ('m, 'a) fatptr = ('m, 'a typ) Ctypes_ptr.Fat.t
+type ('m, 'a) fatfunptr = ('m, 'a fn) Ctypes_ptr.Fat.t
 
 val make_structured :
   ('a, 's) structured typ -> managed_buffer -> ('a, 's) structured
@@ -41,12 +41,12 @@ type 'a typ = 'a Ctypes_static.typ =
   | Bigarray        : (_, 'a, _) Ctypes_bigarray.t -> 'a typ
   | OCaml           : 'a ocaml_type             -> 'a ocaml typ
 and ('a, 'b) pointer = ('a, 'b) Ctypes_static.pointer =
-  CPointer : 'a typ Ctypes_ptr.Fat.t -> ('a, [`C]) pointer
+  CPointer : (_ option,'a typ) Ctypes_ptr.Fat.t -> ('a, [`C]) pointer
 | OCamlRef : int * 'a * 'a ocaml_type -> ('a, [`OCaml]) pointer
 and 'a ptr = ('a, [`C]) pointer
 and 'a ocaml = ('a, [`OCaml]) pointer
 and 'a static_funptr = 'a Ctypes_static.static_funptr =
-  Static_funptr of 'a fn Ctypes_ptr.Fat.t
+  Static_funptr : (_ option, 'a fn) Ctypes_ptr.Fat.t -> 'a static_funptr
 and ('a, 'b) view = ('a, 'b) Ctypes_static.view = {
   read : 'b -> 'a;
   write : 'a -> 'b;

--- a/src/ctypes/cstubs_internals.mli
+++ b/src/ctypes/cstubs_internals.mli
@@ -23,8 +23,6 @@ val make_structured :
 val make_ptr : 'a typ -> voidp -> 'a ptr
 val make_fun_ptr : 'a fn -> voidp -> 'a Ctypes_static.static_funptr
 
-val fptr : 'a Ctypes_static.static_funptr -> 'a fn Ctypes_ptr.Fat.t
-
 type 'a ocaml_type = 'a Ctypes_static.ocaml_type =
   String     : string ocaml_type
 | Bytes      : Bytes.t ocaml_type

--- a/src/ctypes/ctypes_bigarray.ml
+++ b/src/ctypes/ctypes_bigarray.ml
@@ -122,7 +122,7 @@ let prim_of_kind k = prim_of_kind (kind k)
 
 let unsafe_address b = Ctypes_bigarray_stubs.address b
 
-let view : type a b l. (a, b, l) t -> _ Ctypes_ptr.Fat.t -> b =
+let view : type a b l m. (a, b, l) t -> (m option, _) Ctypes_ptr.Fat.t -> b =
   let open Ctypes_bigarray_stubs in
   fun (dims, kind, layout) ptr -> let ba : b = match dims with
   | DimsGen ds -> view kind ~dims:ds ptr layout

--- a/src/ctypes/ctypes_bigarray.mli
+++ b/src/ctypes/ctypes_bigarray.mli
@@ -59,7 +59,7 @@ val unsafe_address : 'a -> Ctypes_ptr.voidp
     reference to the OCaml object then the array might be freed, invalidating
     the address. *)
 
-val view : (_, 'a, _) t -> _ Ctypes_ptr.Fat.t -> 'a
+val view : (_, 'a, _) t -> (_ option, _) Ctypes_ptr.Fat.t -> 'a
 (** [view b ptr] creates a bigarray view onto existing memory.
 
     If [ptr] references an OCaml object then [view] will ensure that

--- a/src/ctypes/ctypes_static.ml
+++ b/src/ctypes/ctypes_static.ml
@@ -51,11 +51,12 @@ and 'a union = ('a, [`Union]) structured
 and 'a structure = ('a, [`Struct]) structured
 and 'a abstract = ('a, [`Abstract]) structured
 and (_, _) pointer =
-  CPointer : 'a typ Ctypes_ptr.Fat.t -> ('a, [`C]) pointer
+  CPointer : (_ option,'a typ) Ctypes_ptr.Fat.t -> ('a, [`C]) pointer
 | OCamlRef : int * 'a * 'a ocaml_type -> ('a, [`OCaml]) pointer
 and 'a ptr = ('a, [`C]) pointer
 and 'a ocaml = ('a, [`OCaml]) pointer
-and 'a static_funptr = Static_funptr of 'a fn Ctypes_ptr.Fat.t
+and 'a static_funptr =
+  Static_funptr : (_ option, 'a fn) Ctypes_ptr.Fat.t -> 'a static_funptr
 and ('a, 'b) view = {
   read : 'b -> 'a;
   write : 'a -> 'b;

--- a/src/ctypes/ctypes_static.mli
+++ b/src/ctypes/ctypes_static.mli
@@ -45,11 +45,12 @@ and 'a union = ('a, [`Union]) structured
 and 'a structure = ('a, [`Struct]) structured
 and 'a abstract = ('a, [`Abstract]) structured
 and (_, _) pointer =
-  CPointer : 'a typ Ctypes_ptr.Fat.t -> ('a, [`C]) pointer
+  CPointer : (_ option,'a typ) Ctypes_ptr.Fat.t -> ('a, [`C]) pointer
 | OCamlRef : int * 'a * 'a ocaml_type -> ('a, [`OCaml]) pointer
 and 'a ptr = ('a, [`C]) pointer
 and 'a ocaml = ('a, [`OCaml]) pointer
-and 'a static_funptr = Static_funptr of 'a fn Ctypes_ptr.Fat.t
+and 'a static_funptr =
+  Static_funptr : (_ option, 'a fn) Ctypes_ptr.Fat.t -> 'a static_funptr
 and ('a, 'b) view = {
   read : 'b -> 'a;
   write : 'a -> 'b;

--- a/src/ctypes/ctypes_std_view_stubs.ml
+++ b/src/ctypes/ctypes_std_view_stubs.ml
@@ -8,7 +8,7 @@
 (* Stubs for standard views. *)
 
 (* Convert a C string to an OCaml string *)
-external string_of_cstring : char Ctypes_static.typ Ctypes_ptr.Fat.t -> string
+external string_of_cstring : (_, char Ctypes_static.typ) Ctypes_ptr.Fat.t -> string
   = "ctypes_string_of_cstring"
 
 (* Convert an OCaml string to a C string *)

--- a/src/ctypes/ctypes_std_views.ml
+++ b/src/ctypes/ctypes_std_views.ml
@@ -9,9 +9,10 @@ let string_of_char_ptr (Ctypes_static.CPointer p) =
   Ctypes_std_view_stubs.string_of_cstring p
 
 let char_ptr_of_string s =
-  let managed = Ctypes_std_view_stubs.cstring_of_string s in
-  Ctypes_static.CPointer (Ctypes_ptr.Fat.make ~managed ~reftyp:Ctypes_static.char
-                     (Ctypes_memory_stubs.block_address managed))
+  let p = Ctypes_std_view_stubs.cstring_of_string s in
+  Ctypes_static.CPointer (Ctypes_ptr.Fat.make
+                            ~managed:(Some p) ~reftyp:Ctypes_static.char
+                     (Ctypes_memory_stubs.block_address p))
 
 let string = Ctypes_static.(view (ptr char))
   ~read:string_of_char_ptr ~write:char_ptr_of_string
@@ -39,7 +40,7 @@ let read_nullable_funptr t reftyp =
 let write_nullable_funptr t reftyp =
   let coerce = Ctypes_coerce.coerce t Ctypes_static.(static_funptr reftyp) in
   function None -> Ctypes_static.Static_funptr
-                     (Ctypes_ptr.Fat.make ~reftyp Ctypes_ptr.Raw.null)
+                     (Ctypes_ptr.Fat.make ~managed:None ~reftyp Ctypes_ptr.Raw.null)
          | Some f -> coerce f
 
 let nullable_funptr_view ?format_typ ?format t reftyp =

--- a/tests/test-raw/test_raw.ml
+++ b/tests/test-raw/test_raw.ml
@@ -14,6 +14,9 @@ open Ctypes_std_view_stubs
 *)
 
 
+let make_unmanaged ~reftyp p = Ctypes_ptr.Fat.make ~managed:None ~reftyp p
+
+
 (* Call the C function
 
         double fabs(double)
@@ -31,15 +34,15 @@ let test_fabs _ =
       double_ffitype in
     
     let dlfabs = Ctypes_ptr.Raw.of_nativeint (Dl.dlsym "fabs") in
-    let dlfabs_fat = Ctypes_ptr.Fat.make dlfabs
+    let dlfabs_fat = make_unmanaged dlfabs
         ~reftyp:Ctypes.(double @-> returning double) in
 
     let fabs x =
       call "fabs" dlfabs_fat callspec
         (fun p _values ->
           write Ctypes_primitive_types.Double x
-            Ctypes_ptr.(Fat.make ~reftyp:Ctypes_static.Void (Raw.(add p (of_int arg_1_offset)))))
-        (fun p -> read Ctypes_primitive_types.Double (Ctypes_ptr.Fat.make ~reftyp:Ctypes_static.Void p))
+            Ctypes_ptr.(make_unmanaged ~reftyp:Ctypes_static.Void (Raw.(add p (of_int arg_1_offset)))))
+        (fun p -> read Ctypes_primitive_types.Double (make_unmanaged ~reftyp:Ctypes_static.Void p))
     in
 
     assert_equal 2.0 (fabs (-2.0)) ~printer:string_of_float;
@@ -66,17 +69,17 @@ let test_pow _ =
       double_ffitype in
     
     let dlpow = Ctypes_ptr.Raw.of_nativeint (Dl.dlsym "pow") in
-    let dlpow_fat = Ctypes_ptr.Fat.make dlpow
+    let dlpow_fat = make_unmanaged dlpow
         ~reftyp:Ctypes.(double @-> double @-> returning double) in
 
     let pow x y =
       call "pow" dlpow_fat callspec
         (fun buffer _values ->
           write Ctypes_primitive_types.Double x
-            Ctypes_ptr.(Fat.make ~reftyp:Ctypes_static.Void (Raw.(add buffer (of_int arg_1_offset))));
+            Ctypes_ptr.(make_unmanaged ~reftyp:Ctypes_static.Void (Raw.(add buffer (of_int arg_1_offset))));
           write Ctypes_primitive_types.Double y
-            Ctypes_ptr.(Fat.make ~reftyp:Ctypes_static.Void (Raw.(add buffer (of_int arg_2_offset)))))
-        (fun p -> read Ctypes_primitive_types.Double (Ctypes_ptr.Fat.make ~reftyp:Ctypes_static.Void p))
+            Ctypes_ptr.(make_unmanaged ~reftyp:Ctypes_static.Void (Raw.(add buffer (of_int arg_2_offset)))))
+        (fun p -> read Ctypes_primitive_types.Double (make_unmanaged ~reftyp:Ctypes_static.Void p))
     in
 
     assert_equal 8.0 (pow 2.0 3.0);


### PR DESCRIPTION
This internal-only change eliminates the use of `Obj.t` in `Ctypes_ptr.Fat.t`, instead reflecting the type of the `managed` field in the type and using existential types in clients (such as `Ctypes.pointer` and `Ctypes.static_funptr`) to hide the additional type parameter.

This change should eventually make it possible to give a more compact representation to `Foreign.dynamic_funptr` (https://github.com/ocamllabs/ocaml-ctypes/pull/595).