### PR TITLE
Make useconds_t a concrete, unsigned type. Add suseconds_t.

### DIFF
--- a/src/ctypes-top/ctypes_printers.ml
+++ b/src/ctypes-top/ctypes_printers.ml
@@ -65,6 +65,8 @@ let format_time_t fmt v =
   Ctypes.format PosixTypes.time_t fmt v
 let format_useconds_t fmt v =
   Ctypes.format PosixTypes.useconds_t fmt v
+let format_suseconds_t fmt v =
+  Ctypes.format PosixTypes.suseconds_t fmt v
 let format_ldouble fmt v = 
   Format.fprintf fmt "<ldouble %s>" (LDouble.to_string v)
 let format_complexld fmt v = 

--- a/src/ctypes-top/install_ctypes_printers.ml
+++ b/src/ctypes-top/install_ctypes_printers.ml
@@ -31,6 +31,7 @@ let printers = [ "Ctypes_printers.format_typ";
                  "Ctypes_printers.format_ssize_t";
                  "Ctypes_printers.format_time_t";
                  "Ctypes_printers.format_useconds_t";
+                 "Ctypes_printers.format_suseconds_t";
                  "Ctypes_printers.format_ldouble";
                  "Ctypes_printers.format_complexld";]
 

--- a/src/ctypes/posixTypes.ml
+++ b/src/ctypes/posixTypes.ml
@@ -74,6 +74,7 @@ external typeof_pid_t : unit -> Ctypes_static.arithmetic = "ctypes_typeof_pid_t"
 external typeof_ssize_t : unit -> Ctypes_static.arithmetic = "ctypes_typeof_ssize_t"
 external typeof_time_t : unit -> Ctypes_static.arithmetic = "ctypes_typeof_time_t"
 external typeof_useconds_t : unit -> Ctypes_static.arithmetic = "ctypes_typeof_useconds_t"
+external typeof_suseconds_t : unit -> Ctypes_static.arithmetic = "ctypes_typeof_suseconds_t"
 
 module Clock = (val mkArithmetic_abstract (typeof_clock_t ()) : Abstract)
 module Dev = (val mkArithmetic "dev_t" (typeof_dev_t ()))
@@ -89,7 +90,8 @@ struct
 end
 module Ssize = (val mkSigned "ssize_t" (typeof_ssize_t ()))
 module Time = (val mkArithmetic "time_t" (typeof_time_t ()))
-module Useconds = (val mkArithmetic_abstract (typeof_useconds_t ()) : Abstract)
+module Useconds = (val mkArithmetic "useconds_t" (typeof_useconds_t ()))
+module Suseconds = (val mkSigned "suseconds_t" (typeof_suseconds_t ()))
 
 type clock_t = Clock.t
 type dev_t = Dev.t
@@ -102,6 +104,7 @@ type size_t = Size.t
 type ssize_t = Ssize.t
 type time_t = Time.t
 type useconds_t = Useconds.t
+type suseconds_t = Suseconds.t
 
 let clock_t = Clock.t
 let dev_t = Dev.t
@@ -114,6 +117,7 @@ let size_t = Size.t
 let ssize_t = Ssize.t
 let time_t = Time.t
 let useconds_t = Useconds.t
+let suseconds_t = Suseconds.t
 
 (* Non-arithmetic types *)
 

--- a/src/ctypes/posixTypes.mli
+++ b/src/ctypes/posixTypes.mli
@@ -20,6 +20,8 @@ module Off : Signed.S
 module Pid : Signed.S
 module Ssize : Signed.S
 module Time : Unsigned.S
+module Useconds : Unsigned.S
+module Suseconds : Signed.S
 
 type clock_t
 type dev_t = Dev.t
@@ -31,7 +33,8 @@ type pid_t = Pid.t
 type size_t = Unsigned.size_t
 type ssize_t = Ssize.t
 type time_t = Time.t
-type useconds_t
+type useconds_t = Useconds.t
+type suseconds_t = Suseconds.t
 
 (** {3 Values representing POSIX arithmetic types} *)
 
@@ -46,6 +49,7 @@ val size_t      : size_t typ
 val ssize_t     : ssize_t typ
 val time_t      : time_t typ
 val useconds_t  : useconds_t typ
+val suseconds_t : suseconds_t typ
 
 (* non-arithmetic types from <sys/types.h> *)
 (** {2 POSIX non-arithmetic types} *)

--- a/src/ctypes/posix_types_stubs.c
+++ b/src/ctypes/posix_types_stubs.c
@@ -77,6 +77,7 @@ EXPOSE_TYPEINFO_S(pid_t)
 EXPOSE_TYPEINFO(ssize_t)
 EXPOSE_TYPEINFO(time_t)
 EXPOSE_TYPEINFO(useconds_t)
+EXPOSE_TYPEINFO(suseconds_t)
 #if !defined _WIN32 || defined __CYGWIN__
   EXPOSE_TYPEINFO(nlink_t)
 #else


### PR DESCRIPTION
I'm not sure why `useconds_t` was originally marked as abstract and not exported with concrete type. The posix specification is clear about it:
> The type useconds_t shall be an unsigned integer type capable of storing values at least in the range [0, 1000000].

I'm also adding `suseconds_t` while at it. Its specification is also clear:
> The type suseconds_t shall be a signed integer type capable of storing values at least in the range [-1, 1000000].

Source: https://pubs.opengroup.org/onlinepubs/009695399/basedefs/sys/types.h.html

I'm planning on using these for https://github.com/toots/ocaml-posix-time