### PR TITLE
Switch 'noalloc' annotations to use attributes.

### DIFF
--- a/src/ctypes/ctypes_memory_stubs.ml
+++ b/src/ctypes/ctypes_memory_stubs.ml
@@ -48,4 +48,4 @@ external string_of_array : _ Fat.t -> len:int -> string
 
 (* Do nothing, concealing from the optimizer that nothing is being done. *)
 external use_value : 'a -> unit
-  = "ctypes_use" "noalloc"
+  = "ctypes_use" [@@noalloc]

--- a/src/ctypes/lDouble.ml
+++ b/src/ctypes/lDouble.ml
@@ -77,5 +77,5 @@ let one = of_int 1
 external size_ : unit -> (int * int) = "ctypes_ldouble_size"
 let byte_sizes = size_ ()
 
-external mant_dig_ : unit -> int = "ctypes_ldouble_mant_dig" "noalloc"
+external mant_dig_ : unit -> int = "ctypes_ldouble_mant_dig" [@@noalloc]
 let mant_dig = mant_dig_ ()


### PR DESCRIPTION
Now that we've dropped support for OCaml 4.01 (#577), we can use attributes (`[@@noalloc]`) rather than old-style string annotations (`"noalloc"`).