### PR TITLE
Distinguish bytes and string in generated stub code

### DIFF
--- a/src/cstubs/cstubs_generate_c.ml
+++ b/src/cstubs/cstubs_generate_c.ml
@@ -77,6 +77,11 @@ struct
                           (value @-> returning (ptr void)),
                    [x])
 
+  let bytes_to_ptr : cexp -> ccomp =
+    fun x -> `App (reader "CTYPES_PTR_OF_OCAML_BYTES"
+                          (value @-> returning (ptr void)),
+                   [x])
+
   let float_array_to_ptr : cexp -> ccomp =
     fun x -> `App (reader "CTYPES_PTR_OF_FLOAT_ARRAY"
                           (value @-> returning (ptr void)),
@@ -143,7 +148,7 @@ struct
     | Array _ -> report_unpassable "arrays"
     | Bigarray _ -> report_unpassable "bigarrays"
     | OCaml String -> Some (string_to_ptr x)
-    | OCaml Bytes -> Some (string_to_ptr x)
+    | OCaml Bytes -> Some (bytes_to_ptr x)
     | OCaml FloatArray -> Some (float_array_to_ptr x)
 
   let prj ty x = prj ty ~orig:ty x

--- a/src/ctypes/ctypes_cstubs_internals.h
+++ b/src/ctypes/ctypes_cstubs_internals.h
@@ -18,6 +18,14 @@
 #include <caml/threads.h>
 #define CTYPES_PTR_OF_OCAML_STRING(s) \
   (String_val(Field(s, 1)) + Long_val(Field(s, 0)))
+
+#ifdef Bytes_val
+#define CTYPES_PTR_OF_OCAML_BYTES(s) \
+  (Bytes_val(Field(s, 1)) + Long_val(Field(s, 0)))
+#else
+#define CTYPES_PTR_OF_OCAML_BYTES(s) CTYPES_PTR_OF_OCAML_STRING(s)
+#endif
+
 #define Ctypes_val_char(c) \
   (Val_int((c + 256) % 256))
 #define CTYPES_PAIR_WITH_ERRNO(v)


### PR DESCRIPTION
OCaml 4.10 [defaults to the `force-safe-string` mode](https://github.com/ocaml/ocaml/blob/4e6e9123287405a08b349c3e0e12d53000e8534d/Changes#L149-L157), so that the `String_val` macro returns `const char *`.

This PR updates ctypes to generate calls to `Bytes_val` rather than `String_val` for uses of [`ocaml_bytes`](https://github.com/ocamllabs/ocaml-ctypes/blob/ab70b38f1848e8c2ecb726b603f860abf52b146b/src/ctypes/ctypes_types.mli#L212-L213), ensuring `const`-correctness and fixing problems such as the one reported [here](https://github.com/ocamllabs/ocaml-ctypes/issues/134#issuecomment-568168667).