### PR TITLE
Remove uses of bytes library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ ctypes.cmi_only = ctypes_static ctypes_primitive_types ctypes_structs cstubs_int
 ctypes.public = lDouble complexL ctypes posixTypes ctypes_types
 ctypes.dir = src/ctypes
 ctypes.extra_mls = ctypes_primitives.ml
-ctypes.deps = bigarray bytes integers
+ctypes.deps = bigarray integers
 ctypes.linkdeps = integers_stubs
 ctypes.install = yes
 ctypes.install_native_objects = yes
@@ -81,7 +81,7 @@ ctypes: $(ctypes.dir)/$(ctypes.extra_mls) $$(LIB_TARGETS)
 cstubs.public = cstubs_structs cstubs cstubs_inverted
 cstubs.dir = src/cstubs
 cstubs.subproject_deps = ctypes
-cstubs.deps = str bytes integers
+cstubs.deps = str integers
 cstubs.install = yes
 cstubs.install_native_objects = yes
 cstubs.extra_hs = $(package_integers_path)/ocaml_integers.h
@@ -95,7 +95,7 @@ ctypes-foreign-base.install = yes
 ctypes-foreign-base.install_native_objects = yes
 ctypes-foreign-base.threads = no
 ctypes-foreign-base.dir = src/ctypes-foreign-base
-ctypes-foreign-base.deps = bytes integers
+ctypes-foreign-base.deps = integers
 ctypes-foreign-base.subproject_deps = ctypes
 ctypes-foreign-base.extra_mls = libffi_abi.ml dl.ml
 ctypes-foreign-base.extra_cs = dl_stubs.c
@@ -156,15 +156,15 @@ src/ctypes-foreign-base/dl_stubs.c: src/ctypes-foreign-base/dl_stubs.c$(OS_ALT_S
 	cp $< $@
 
 src/ctypes/ctypes_primitives.ml: src/configure/extract_from_c.ml src/configure/gen_c_primitives.ml
-	$(HOSTOCAMLFIND) ocamlc -o gen_c_primitives -package str,bytes -strict-sequence -linkpkg $^ -I src/configure
+	$(HOSTOCAMLFIND) ocamlc -o gen_c_primitives -package str -strict-sequence -linkpkg $^ -I src/configure
 	./gen_c_primitives > $@ 2> gen_c_primitives.log || (rm $@ && cat gen_c_primitives.log || false)
 
 src/ctypes-foreign-base/libffi_abi.ml: src/configure/extract_from_c.ml src/configure/gen_libffi_abi.ml
-	$(HOSTOCAMLFIND) ocamlc -o gen_libffi_abi -package str,bytes -strict-sequence -linkpkg $^ -I src/configure
+	$(HOSTOCAMLFIND) ocamlc -o gen_libffi_abi -package str -strict-sequence -linkpkg $^ -I src/configure
 	./gen_libffi_abi > $@ 2> gen_c_primitives.log || (rm $@ && cat gen_c_primitives.log || false)
 
 libffi.config: src/discover/commands.mli src/discover/commands.ml src/discover/discover.ml
-	$(HOSTOCAMLFIND) ocamlc -o discover -package str,bytes -strict-sequence -linkpkg $^ -I src/discover
+	$(HOSTOCAMLFIND) ocamlc -o discover -package str -strict-sequence -linkpkg $^ -I src/discover
 	./discover -ocamlc "$(OCAMLFIND) ocamlc" > $@ || (rm $@ && false)
 
 asneeded.config:

--- a/Makefile.examples
+++ b/Makefile.examples
@@ -14,7 +14,7 @@ fts-stub-generator.dir = examples/fts/stub-generation/stub-generator
 fts-stub-generator.deps = integers
 fts-stub-generator.subproject_deps = ctypes cstubs \
   ctypes-foreign-base ctypes-foreign-unthreaded fts-stubs
-fts-stub-generator.deps = bytes str unix bigarray integers
+fts-stub-generator.deps = str unix bigarray integers
 fts-stub-generator: PROJECT=fts-stub-generator
 fts-stub-generator: $$(NATIVE_TARGET)
 
@@ -22,7 +22,7 @@ fts-cmd.install = no
 fts-cmd.dir = examples/fts/stub-generation
 fts-cmd.subproject_deps = ctypes \
   ctypes-foreign-base ctypes-foreign-unthreaded fts-stubs
-fts-cmd.deps = bytes str unix bigarray integers
+fts-cmd.deps = str unix bigarray integers
 fts-cmd.extra_mls = fts_generated.ml
 fts-cmd.extra_cs = fts_stubs.c
 fts-cmd: CFLAGS+=-D_FILE_OFFSET_BITS=32
@@ -36,7 +36,7 @@ examples/fts/stub-generation/fts_generated.ml: fts-stub-generator
 # subproject: fts using dynamic linking (foreign)
 fts.install = no
 fts.dir = examples/fts/foreign
-fts.deps = bytes unix bigarray str integers
+fts.deps = unix bigarray str integers
 fts.subproject_deps = ctypes ctypes-foreign-base ctypes-foreign-unthreaded
 fts: PROJECT=fts
 fts: $$(NATIVE_TARGET)
@@ -51,14 +51,14 @@ date-stubs: $$(LIB_TARGETS)
 date-stub-generator.install = no
 date-stub-generator.dir = examples/date/stub-generation/stub-generator
 date-stub-generator.subproject_deps = ctypes cstubs date-stubs
-date-stub-generator.deps = bytes str unix bigarray integers
+date-stub-generator.deps = str unix bigarray integers
 date-stub-generator: PROJECT=date-stub-generator
 date-stub-generator: $$(NATIVE_TARGET)
 
 date-cmd.install = no
 date-cmd.dir = examples/date/stub-generation
 date-cmd.subproject_deps = ctypes date-stubs
-date-cmd.deps = bytes str unix bigarray integers
+date-cmd.deps = str unix bigarray integers
 date-cmd.extra_mls = date_generated.ml
 date-cmd.extra_cs = date_stubs.c
 date-cmd: PROJECT=date-cmd
@@ -72,7 +72,7 @@ examples/date/stub-generation/date_generated.ml:
 date.install = no
 date.dir = examples/date/foreign
 date.subproject_deps = ctypes ctypes-foreign-base ctypes-foreign-unthreaded
-date.deps = bytes unix bigarray str integers
+date.deps = unix bigarray str integers
 date: PROJECT=date
 date: $$(NATIVE_TARGET)
 
@@ -80,7 +80,7 @@ date: $$(NATIVE_TARGET)
 ncurses-stubs.install = no
 ncurses-stubs.dir = examples/ncurses/stub-generation/bindings
 ncurses-stubs.subproject_deps = ctypes
-ncurses-stubs.deps = bytes str unix bigarray integers
+ncurses-stubs.deps = str unix bigarray integers
 ncurses-stubs: PROJECT=ncurses-stubs
 ncurses-stubs: $$(NATIVE_TARGET) $$(LIB_TARGETS)
 
@@ -89,14 +89,14 @@ ncurses-stub-generator.dir = examples/ncurses/stub-generation/stub-generator
 ncurses-stub-generator.deps = integers
 ncurses-stub-generator.subproject_deps = ctypes cstubs \
   ctypes-foreign-base ctypes-foreign-unthreaded ncurses-stubs
-ncurses-stub-generator.deps = bytes str unix bigarray integers
+ncurses-stub-generator.deps = str unix bigarray integers
 ncurses-stub-generator: PROJECT=ncurses-stub-generator
 ncurses-stub-generator: $$(NATIVE_TARGET)
 
 ncurses-cmd.install = no
 ncurses-cmd.dir = examples/ncurses/stub-generation
 ncurses-cmd.subproject_deps = ctypes ncurses-stubs
-ncurses-cmd.deps = bytes str unix bigarray integers
+ncurses-cmd.deps = str unix bigarray integers
 ncurses-cmd.extra_mls = ncurses_generated.ml
 ncurses-cmd.extra_cs = ncurses_stubs.c
 ncurses-cmd.link_flags = -lncurses
@@ -111,7 +111,7 @@ examples/ncurses/stub-generation/ncurses_generated.ml: ncurses-stubs
 ncurses.install = no
 ncurses.dir = examples/ncurses/foreign
 ncurses.subproject_deps = ctypes ctypes-foreign-base ctypes-foreign-unthreaded
-ncurses.deps = bytes unix bigarray str integers
+ncurses.deps = unix bigarray str integers
 ncurses.link_flags = -lncurses
 ncurses: PROJECT=ncurses
 ncurses: $$(NATIVE_TARGET)

--- a/Makefile.tests
+++ b/Makefile.tests
@@ -19,7 +19,7 @@ tests-common: $$(LIB_TARGETS)
 
 test-raw.dir = tests/test-raw
 test-raw.threads = yes
-test-raw.deps = bigarray oUnit str bytes integers
+test-raw.deps = bigarray oUnit str integers
 test-raw.subproject_deps = ctypes ctypes-foreign-base ctypes-foreign-threaded
 test-raw: PROJECT=test-raw
 test-raw: $$(BEST_TARGET)
@@ -35,13 +35,13 @@ test-pointers-stub-generator.dir = tests/test-pointers/stub-generator
 test-pointers-stub-generator.threads = yes
 test-pointers-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-pointers-stubs tests-common
-test-pointers-stub-generator.deps = str bigarray bytes integers
+test-pointers-stub-generator.deps = str bigarray integers
 test-pointers-stub-generator: PROJECT=test-pointers-stub-generator
 test-pointers-stub-generator: $$(BEST_TARGET)
 
 test-pointers.dir = tests/test-pointers
 test-pointers.threads = yes
-test-pointers.deps = str bigarray oUnit bytes integers
+test-pointers.deps = str bigarray oUnit integers
 test-pointers.subproject_deps = ctypes ctypes-foreign-base \
   ctypes-foreign-threaded cstubs tests-common test-pointers-stubs
 test-pointers.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -70,13 +70,13 @@ test-integers-stub-generator.dir = tests/test-integers/stub-generator
 test-integers-stub-generator.threads = yes
 test-integers-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-integers-stubs tests-common
-test-integers-stub-generator.deps = str bigarray bytes integers
+test-integers-stub-generator.deps = str bigarray integers
 test-integers-stub-generator: PROJECT=test-integers-stub-generator
 test-integers-stub-generator: $$(BEST_TARGET)
 
 test-integers.dir = tests/test-integers
 test-integers.threads = yes
-test-integers.deps = str bigarray oUnit bytes integers
+test-integers.deps = str bigarray oUnit integers
 test-integers.subproject_deps = ctypes ctypes-foreign-base \
   ctypes-foreign-threaded cstubs tests-common test-integers-stubs
 test-integers.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -106,13 +106,13 @@ test-variadic-stub-generator.dir = tests/test-variadic/stub-generator
 test-variadic-stub-generator.threads = yes
 test-variadic-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-variadic-stubs tests-common
-test-variadic-stub-generator.deps = str bigarray bytes integers
+test-variadic-stub-generator.deps = str bigarray integers
 test-variadic-stub-generator: PROJECT=test-variadic-stub-generator
 test-variadic-stub-generator: $$(BEST_TARGET)
 
 test-variadic.dir = tests/test-variadic
 test-variadic.threads = yes
-test-variadic.deps = str bigarray oUnit bytes integers
+test-variadic.deps = str bigarray oUnit integers
 test-variadic.subproject_deps = ctypes ctypes-foreign-base \
   ctypes-foreign-threaded cstubs tests-common test-variadic-stubs
 test-variadic.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -141,13 +141,13 @@ test-builtins-stub-generator.dir = tests/test-builtins/stub-generator
 test-builtins-stub-generator.threads = yes
 test-builtins-stub-generator.subproject_deps = ctypes cstubs \
   test-builtins-stubs ctypes-foreign-base ctypes-foreign-threaded tests-common
-test-builtins-stub-generator.deps = str bigarray bytes integers
+test-builtins-stub-generator.deps = str bigarray integers
 test-builtins-stub-generator: PROJECT=test-builtins-stub-generator
 test-builtins-stub-generator: $$(BEST_TARGET)
 
 test-builtins.dir = tests/test-builtins
 test-builtins.threads = yes
-test-builtins.deps = str bigarray oUnit bytes integers
+test-builtins.deps = str bigarray oUnit integers
 test-builtins.subproject_deps = ctypes cstubs test-builtins-stubs \
   ctypes-foreign-base ctypes-foreign-threaded tests-common
 test-builtins.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -176,13 +176,13 @@ test-macros-stub-generator.dir = tests/test-macros/stub-generator
 test-macros-stub-generator.threads = yes
 test-macros-stub-generator.subproject_deps = ctypes cstubs \
   test-macros-stubs ctypes-foreign-base ctypes-foreign-threaded tests-common
-test-macros-stub-generator.deps = str bigarray bytes integers
+test-macros-stub-generator.deps = str bigarray integers
 test-macros-stub-generator: PROJECT=test-macros-stub-generator
 test-macros-stub-generator: $$(BEST_TARGET)
 
 test-macros.dir = tests/test-macros
 test-macros.threads = yes
-test-macros.deps = str bigarray oUnit bytes integers
+test-macros.deps = str bigarray oUnit integers
 test-macros.subproject_deps = ctypes cstubs test-macros-stubs \
   ctypes-foreign-base ctypes-foreign-threaded tests-common
 test-macros.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -212,13 +212,13 @@ test-higher_order-stub-generator.dir = tests/test-higher_order/stub-generator
 test-higher_order-stub-generator.threads = yes
 test-higher_order-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-higher_order-stubs tests-common
-test-higher_order-stub-generator.deps = str bigarray bytes integers
+test-higher_order-stub-generator.deps = str bigarray integers
 test-higher_order-stub-generator: PROJECT=test-higher_order-stub-generator
 test-higher_order-stub-generator: $$(BEST_TARGET)
 
 test-higher_order.dir = tests/test-higher_order
 test-higher_order.threads = yes
-test-higher_order.deps = str bigarray oUnit bytes integers
+test-higher_order.deps = str bigarray oUnit integers
 test-higher_order.subproject_deps = ctypes ctypes-foreign-base \
   ctypes-foreign-threaded cstubs test-higher_order-stubs tests-common
 test-higher_order.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -258,7 +258,7 @@ test-enums-stub-generator.threads = yes
 test-enums-stub-generator.subproject_deps = ctypes cstubs \
      test-enums-struct-stubs \
      ctypes-foreign-base ctypes-foreign-threaded test-enums-stubs tests-common
-test-enums-stub-generator.deps = str bigarray bytes integers
+test-enums-stub-generator.deps = str bigarray integers
 test-enums-stub-generator: PROJECT=test-enums-stub-generator
 test-enums-stub-generator: $$(BEST_TARGET)
 
@@ -266,13 +266,13 @@ test-enums-struct-stub-generator.dir = tests/test-enums/struct-stub-generator
 test-enums-struct-stub-generator.threads = yes
 test-enums-struct-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-enums-struct-stubs tests-common
-test-enums-struct-stub-generator.deps = str bigarray bytes integers
+test-enums-struct-stub-generator.deps = str bigarray integers
 test-enums-struct-stub-generator: PROJECT=test-enums-struct-stub-generator
 test-enums-struct-stub-generator: $$(BEST_TARGET)
 
 test-enums.dir = tests/test-enums
 test-enums.threads = yes
-test-enums.deps = str bigarray oUnit bytes integers
+test-enums.deps = str bigarray oUnit integers
 test-enums.subproject_deps = ctypes ctypes-foreign-base \
   ctypes-foreign-threaded cstubs test-enums-struct-stubs test-enums-stubs tests-common
 test-enums.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -313,13 +313,13 @@ test-structs-stub-generator.dir = tests/test-structs/stub-generator
 test-structs-stub-generator.threads = yes
 test-structs-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-structs-stubs tests-common
-test-structs-stub-generator.deps = str bigarray bytes integers
+test-structs-stub-generator.deps = str bigarray integers
 test-structs-stub-generator: PROJECT=test-structs-stub-generator
 test-structs-stub-generator: $$(BEST_TARGET)
 
 test-structs.dir = tests/test-structs
 test-structs.threads = yes
-test-structs.deps = str bigarray oUnit bytes integers
+test-structs.deps = str bigarray oUnit integers
 test-structs.subproject_deps = ctypes ctypes-foreign-base \
   ctypes-foreign-threaded cstubs test-structs-stubs tests-common
 test-structs.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -356,13 +356,13 @@ test-constants-stub-generator.dir = tests/test-constants/stub-generator
 test-constants-stub-generator.threads = yes
 test-constants-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-constants-stubs tests-common
-test-constants-stub-generator.deps = str bigarray bytes integers
+test-constants-stub-generator.deps = str bigarray integers
 test-constants-stub-generator: PROJECT=test-constants-stub-generator
 test-constants-stub-generator: $$(BEST_TARGET)
 
 test-constants.dir = tests/test-constants
 test-constants.threads = yes
-test-constants.deps = str bigarray oUnit bytes integers
+test-constants.deps = str bigarray oUnit integers
 test-constants.subproject_deps = ctypes ctypes-foreign-base \
   ctypes-foreign-threaded cstubs test-constants-stubs tests-common
 test-constants.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -391,7 +391,7 @@ $(BUILDDIR)/tests/test-constants/generated_struct_stubs.c: $(BUILDDIR)/test-cons
 
 test-finalisers.dir = tests/test-finalisers
 test-finalisers.threads = yes
-test-finalisers.deps = str bigarray oUnit bytes integers
+test-finalisers.deps = str bigarray oUnit integers
 test-finalisers.subproject_deps = ctypes ctypes-foreign-base ctypes-foreign-threaded
 test-finalisers: PROJECT=test-finalisers
 test-finalisers: $$(BEST_TARGET)
@@ -407,13 +407,13 @@ test-cstdlib-stub-generator.dir = tests/test-cstdlib/stub-generator
 test-cstdlib-stub-generator.threads = yes
 test-cstdlib-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-cstdlib-stubs tests-common
-test-cstdlib-stub-generator.deps = str bigarray bytes integers
+test-cstdlib-stub-generator.deps = str bigarray integers
 test-cstdlib-stub-generator: PROJECT=test-cstdlib-stub-generator
 test-cstdlib-stub-generator: $$(BEST_TARGET)
 
 test-cstdlib.dir = tests/test-cstdlib
 test-cstdlib.threads = yes
-test-cstdlib.deps = str bigarray oUnit bytes integers
+test-cstdlib.deps = str bigarray oUnit integers
 test-cstdlib.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs test-cstdlib-stubs tests-common
 test-cstdlib.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -433,7 +433,7 @@ tests/test-cstdlib/generated_bindings.ml: $(BUILDDIR)/test-cstdlib-stub-generato
 
 test-sizeof.dir = tests/test-sizeof
 test-sizeof.threads = yes
-test-sizeof.deps = str bigarray oUnit bytes integers
+test-sizeof.deps = str bigarray oUnit integers
 test-sizeof.subproject_deps = ctypes ctypes-foreign-base ctypes-foreign-threaded
 test-sizeof: PROJECT=test-sizeof
 test-sizeof: $$(BEST_TARGET)
@@ -449,13 +449,13 @@ test-foreign_values-stub-generator.dir = tests/test-foreign_values/stub-generato
 test-foreign_values-stub-generator.threads = yes
 test-foreign_values-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-foreign_values-stubs tests-common
-test-foreign_values-stub-generator.deps = str bigarray bytes integers
+test-foreign_values-stub-generator.deps = str bigarray integers
 test-foreign_values-stub-generator: PROJECT=test-foreign_values-stub-generator
 test-foreign_values-stub-generator: $$(BEST_TARGET)
 
 test-foreign_values.dir = tests/test-foreign_values
 test-foreign_values.threads = yes
-test-foreign_values.deps = str bigarray oUnit bytes integers
+test-foreign_values.deps = str bigarray oUnit integers
 test-foreign_values.subproject_deps = ctypes ctypes-foreign-base \
   ctypes-foreign-threaded cstubs tests-common test-foreign_values-stubs
 test-foreign_values.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -484,13 +484,13 @@ test-unions-stub-generator.dir = tests/test-unions/stub-generator
 test-unions-stub-generator.threads = yes
 test-unions-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-unions-stubs tests-common
-test-unions-stub-generator.deps = str bigarray bytes integers
+test-unions-stub-generator.deps = str bigarray integers
 test-unions-stub-generator: PROJECT=test-unions-stub-generator
 test-unions-stub-generator: $$(BEST_TARGET)
 
 test-unions.dir = tests/test-unions
 test-unions.threads = yes
-test-unions.deps = str bigarray oUnit bytes integers
+test-unions.deps = str bigarray oUnit integers
 test-unions.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs test-unions-stubs tests-common
 test-unions.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -518,7 +518,7 @@ $(BUILDDIR)/tests/test-unions/generated_struct_stubs.c: $(BUILDDIR)/test-unions-
 
 test-custom_ops.dir = tests/test-custom_ops
 test-custom_ops.threads = yes
-test-custom_ops.deps = str bigarray oUnit bytes integers
+test-custom_ops.deps = str bigarray oUnit integers
 test-custom_ops.subproject_deps = ctypes ctypes-foreign-base ctypes-foreign-threaded
 test-custom_ops: PROJECT=test-custom_ops
 test-custom_ops: $$(BEST_TARGET)
@@ -534,13 +534,13 @@ test-arrays-stub-generator.dir = tests/test-arrays/stub-generator
 test-arrays-stub-generator.threads = yes
 test-arrays-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-arrays-stubs tests-common
-test-arrays-stub-generator.deps = str bigarray bytes integers
+test-arrays-stub-generator.deps = str bigarray integers
 test-arrays-stub-generator: PROJECT=test-arrays-stub-generator
 test-arrays-stub-generator: $$(BEST_TARGET)
 
 test-arrays.dir = tests/test-arrays
 test-arrays.threads = yes
-test-arrays.deps = str bigarray oUnit bytes integers
+test-arrays.deps = str bigarray oUnit integers
 test-arrays.subproject_deps = ctypes ctypes-foreign-base \
   ctypes-foreign-threaded cstubs test-arrays-stubs tests-common
 test-arrays.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -560,21 +560,21 @@ tests/test-arrays/generated_bindings.ml: $(BUILDDIR)/test-arrays-stub-generator.
 
 test-foreign-errno.dir = tests/test-foreign-errno
 test-foreign-errno.threads = yes
-test-foreign-errno.deps = str bigarray oUnit bytes integers
+test-foreign-errno.deps = str bigarray oUnit integers
 test-foreign-errno.subproject_deps = ctypes ctypes-foreign-base ctypes-foreign-threaded
 test-foreign-errno: PROJECT=test-foreign-errno
 test-foreign-errno: $$(BEST_TARGET)
 
 test-passable.dir = tests/test-passable
 test-passable.threads = yes
-test-passable.deps = str bigarray oUnit bytes integers
+test-passable.deps = str bigarray oUnit integers
 test-passable.subproject_deps = ctypes ctypes-foreign-base ctypes-foreign-threaded cstubs
 test-passable: PROJECT=test-passable
 test-passable: $$(BEST_TARGET)
 
 test-alignment.dir = tests/test-alignment
 test-alignment.threads = yes
-test-alignment.deps = str bigarray oUnit bytes integers
+test-alignment.deps = str bigarray oUnit integers
 test-alignment.subproject_deps = ctypes ctypes-foreign-base ctypes-foreign-threaded
 test-alignment: PROJECT=test-alignment
 test-alignment: $$(BEST_TARGET)
@@ -590,13 +590,13 @@ test-views-stub-generator.dir = tests/test-views/stub-generator
 test-views-stub-generator.threads = yes
 test-views-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-views-stubs tests-common
-test-views-stub-generator.deps = str bigarray bytes integers
+test-views-stub-generator.deps = str bigarray integers
 test-views-stub-generator: PROJECT=test-views-stub-generator
 test-views-stub-generator: $$(BEST_TARGET)
 
 test-views.dir = tests/test-views
 test-views.threads = yes
-test-views.deps = str bigarray oUnit bytes integers
+test-views.deps = str bigarray oUnit integers
 test-views.subproject_deps = ctypes ctypes-foreign-base ctypes-foreign-threaded cstubs test-views-stubs tests-common
 test-views.link_flags = -L$(BUILDDIR)/clib -ltest_functions
 test-views: PROJECT=test-views
@@ -624,13 +624,13 @@ test-oo_style-stub-generator.dir = tests/test-oo_style/stub-generator
 test-oo_style-stub-generator.threads = yes
 test-oo_style-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-oo_style-stubs tests-common
-test-oo_style-stub-generator.deps = str bigarray bytes integers
+test-oo_style-stub-generator.deps = str bigarray integers
 test-oo_style-stub-generator: PROJECT=test-oo_style-stub-generator
 test-oo_style-stub-generator: $$(BEST_TARGET)
 
 test-oo_style.dir = tests/test-oo_style
 test-oo_style.threads = yes
-test-oo_style.deps = str bigarray oUnit bytes integers
+test-oo_style.deps = str bigarray oUnit integers
 test-oo_style.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs test-oo_style-stubs tests-common
 test-oo_style.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -650,7 +650,7 @@ tests/test-oo_style/generated_bindings.ml: $(BUILDDIR)/test-oo_style-stub-genera
 
 test-marshal.dir = tests/test-marshal
 test-marshal.threads = yes
-test-marshal.deps = str bigarray oUnit bytes integers
+test-marshal.deps = str bigarray oUnit integers
 test-marshal.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs tests-common
 test-marshal.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -659,7 +659,7 @@ test-marshal: $$(BEST_TARGET)
 
 test-type_printing.dir = tests/test-type_printing
 test-type_printing.threads = yes
-test-type_printing.deps = str bigarray oUnit bytes integers
+test-type_printing.deps = str bigarray oUnit integers
 test-type_printing.subproject_deps = ctypes ctypes-foreign-base ctypes-foreign-threaded \
   cstubs test-type_printing-stubs tests-common
 test-type_printing.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -677,7 +677,7 @@ test-type_printing-stub-generator.dir = tests/test-type_printing/stub-generator
 test-type_printing-stub-generator.threads = yes
 test-type_printing-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-type_printing-stubs tests-common
-test-type_printing-stub-generator.deps = str bigarray bytes integers
+test-type_printing-stub-generator.deps = str bigarray integers
 test-type_printing-stub-generator: PROJECT=test-type_printing-stub-generator
 test-type_printing-stub-generator: $$(BEST_TARGET)
 
@@ -705,13 +705,13 @@ test-value_printing-stub-generator.dir = tests/test-value_printing/stub-generato
 test-value_printing-stub-generator.threads = yes
 test-value_printing-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-value_printing-stubs tests-common
-test-value_printing-stub-generator.deps = str bigarray bytes integers
+test-value_printing-stub-generator.deps = str bigarray integers
 test-value_printing-stub-generator: PROJECT=test-value_printing-stub-generator
 test-value_printing-stub-generator: $$(BEST_TARGET)
 
 test-value_printing.dir = tests/test-value_printing
 test-value_printing.threads = yes
-test-value_printing.deps = str bigarray oUnit bytes integers
+test-value_printing.deps = str bigarray oUnit integers
 test-value_printing.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs tests-common test-value_printing-stubs
 test-value_printing.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -740,13 +740,13 @@ test-complex-stub-generator.dir = tests/test-complex/stub-generator
 test-complex-stub-generator.threads = yes
 test-complex-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-complex-stubs tests-common
-test-complex-stub-generator.deps = str bigarray bytes integers
+test-complex-stub-generator.deps = str bigarray integers
 test-complex-stub-generator: PROJECT=test-complex-stub-generator
 test-complex-stub-generator: $$(BEST_TARGET)
 
 test-complex.dir = tests/test-complex
 test-complex.threads = yes
-test-complex.deps = str bigarray oUnit bytes integers
+test-complex.deps = str bigarray oUnit integers
 test-complex.subproject_deps = ctypes ctypes-foreign-base \
   ctypes-foreign-threaded cstubs tests-common test-complex-stubs
 test-complex.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -775,13 +775,13 @@ test-bools-stub-generator.dir = tests/test-bools/stub-generator
 test-bools-stub-generator.threads = yes
 test-bools-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-bools-stubs tests-common
-test-bools-stub-generator.deps = str bigarray bytes integers
+test-bools-stub-generator.deps = str bigarray integers
 test-bools-stub-generator: PROJECT=test-bools-stub-generator
 test-bools-stub-generator: $$(BEST_TARGET)
 
 test-bools.dir = tests/test-bools
 test-bools.threads = yes
-test-bools.deps = str bigarray oUnit bytes integers
+test-bools.deps = str bigarray oUnit integers
 test-bools.subproject_deps = ctypes ctypes-foreign-base \
   ctypes-foreign-threaded cstubs tests-common test-bools-stubs
 test-bools.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -810,13 +810,13 @@ test-callback_lifetime-stub-generator.dir = tests/test-callback_lifetime/stub-ge
 test-callback_lifetime-stub-generator.threads = yes
 test-callback_lifetime-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-callback_lifetime-stubs tests-common
-test-callback_lifetime-stub-generator.deps = str bigarray bytes integers
+test-callback_lifetime-stub-generator.deps = str bigarray integers
 test-callback_lifetime-stub-generator: PROJECT=test-callback_lifetime-stub-generator
 test-callback_lifetime-stub-generator: $$(BEST_TARGET)
 
 test-callback_lifetime.dir = tests/test-callback_lifetime
 test-callback_lifetime.threads = yes
-test-callback_lifetime.deps = str bigarray oUnit bytes integers
+test-callback_lifetime.deps = str bigarray oUnit integers
 test-callback_lifetime.subproject_deps = ctypes ctypes-foreign-base \
   ctypes-foreign-threaded cstubs test-callback_lifetime-stubs tests-common
 test-callback_lifetime.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -845,13 +845,13 @@ test-lifetime-stub-generator.dir = tests/test-lifetime/stub-generator
 test-lifetime-stub-generator.threads = yes
 test-lifetime-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-lifetime-stubs tests-common
-test-lifetime-stub-generator.deps = str bigarray bytes integers
+test-lifetime-stub-generator.deps = str bigarray integers
 test-lifetime-stub-generator: PROJECT=test-lifetime-stub-generator
 test-lifetime-stub-generator: $$(BEST_TARGET)
 
 test-lifetime.dir = tests/test-lifetime
 test-lifetime.threads = yes
-test-lifetime.deps = str bigarray oUnit bytes integers
+test-lifetime.deps = str bigarray oUnit integers
 test-lifetime.subproject_deps = ctypes ctypes-foreign-base \
   ctypes-foreign-threaded cstubs test-lifetime-stubs tests-common
 test-lifetime.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -871,7 +871,7 @@ tests/test-lifetime/generated_bindings.ml: $(BUILDDIR)/test-lifetime-stub-genera
 
 test-stubs.dir = tests/test-stubs
 test-stubs.threads = yes
-test-stubs.deps = str bigarray oUnit bytes integers
+test-stubs.deps = str bigarray oUnit integers
 test-stubs.subproject_deps = ctypes ctypes-foreign-base ctypes-foreign-threaded
 test-stubs: PROJECT=test-stubs
 test-stubs: $$(BEST_TARGET)
@@ -887,13 +887,13 @@ test-bigarrays-stub-generator.dir = tests/test-bigarrays/stub-generator
 test-bigarrays-stub-generator.threads = yes
 test-bigarrays-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-bigarrays-stubs tests-common
-test-bigarrays-stub-generator.deps = str bigarray bytes integers
+test-bigarrays-stub-generator.deps = str bigarray integers
 test-bigarrays-stub-generator: PROJECT=test-bigarrays-stub-generator
 test-bigarrays-stub-generator: $$(BEST_TARGET)
 
 test-bigarrays.dir = tests/test-bigarrays
 test-bigarrays.threads = yes
-test-bigarrays.deps = str bigarray oUnit bytes integers
+test-bigarrays.deps = str bigarray oUnit integers
 test-bigarrays.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs tests-common test-bigarrays-stubs
 test-bigarrays.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -922,13 +922,13 @@ test-coercions-stub-generator.dir = tests/test-coercions/stub-generator
 test-coercions-stub-generator.threads = yes
 test-coercions-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-coercions-stubs tests-common
-test-coercions-stub-generator.deps = str bigarray bytes integers
+test-coercions-stub-generator.deps = str bigarray integers
 test-coercions-stub-generator: PROJECT=test-coercions-stub-generator
 test-coercions-stub-generator: $$(BEST_TARGET)
 
 test-coercions.dir = tests/test-coercions
 test-coercions.threads = yes
-test-coercions.deps = str bigarray oUnit bytes integers
+test-coercions.deps = str bigarray oUnit integers
 test-coercions.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs tests-common test-coercions-stubs
 test-coercions.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -948,7 +948,7 @@ tests/test-coercions/generated_bindings.ml: $(BUILDDIR)/test-coercions-stub-gene
 
 test-roots.dir = tests/test-roots
 test-roots.threads = yes
-test-roots.deps = str bigarray oUnit bytes integers
+test-roots.deps = str bigarray oUnit integers
 test-roots.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs tests-common
 test-roots.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -966,13 +966,13 @@ test-passing-ocaml-values-stub-generator.dir = tests/test-passing-ocaml-values/s
 test-passing-ocaml-values-stub-generator.threads = yes
 test-passing-ocaml-values-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-passing-ocaml-values-stubs tests-common
-test-passing-ocaml-values-stub-generator.deps = str bigarray bytes integers
+test-passing-ocaml-values-stub-generator.deps = str bigarray integers
 test-passing-ocaml-values-stub-generator: PROJECT=test-passing-ocaml-values-stub-generator
 test-passing-ocaml-values-stub-generator: $$(BEST_TARGET)
 
 test-passing-ocaml-values.dir = tests/test-passing-ocaml-values
 test-passing-ocaml-values.threads = yes
-test-passing-ocaml-values.deps = str bigarray oUnit bytes integers
+test-passing-ocaml-values.deps = str bigarray oUnit integers
 test-passing-ocaml-values.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs tests-common test-passing-ocaml-values-stubs
 test-passing-ocaml-values.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -1001,13 +1001,13 @@ test-funptrs-stub-generator.dir = tests/test-funptrs/stub-generator
 test-funptrs-stub-generator.threads = yes
 test-funptrs-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-funptrs-stubs tests-common
-test-funptrs-stub-generator.deps = str bigarray bytes integers
+test-funptrs-stub-generator.deps = str bigarray integers
 test-funptrs-stub-generator: PROJECT=test-funptrs-stub-generator
 test-funptrs-stub-generator: $$(BEST_TARGET)
 
 test-funptrs.dir = tests/test-funptrs
 test-funptrs.threads = yes
-test-funptrs.deps = str bigarray oUnit bytes integers
+test-funptrs.deps = str bigarray oUnit integers
 test-funptrs.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs tests-common test-funptrs-stubs
 test-funptrs.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -1036,13 +1036,13 @@ test-lwt-jobs-stub-generator.dir = tests/test-lwt-jobs/stub-generator
 test-lwt-jobs-stub-generator.threads = yes
 test-lwt-jobs-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-lwt-jobs-stubs tests-common
-test-lwt-jobs-stub-generator.deps = str bigarray bytes integers
+test-lwt-jobs-stub-generator.deps = str bigarray integers
 test-lwt-jobs-stub-generator: PROJECT=test-lwt-jobs-stub-generator
 test-lwt-jobs-stub-generator: $$(BEST_TARGET)
 
 test-lwt-jobs.dir = tests/test-lwt-jobs
 test-lwt-jobs.threads = yes
-test-lwt-jobs.deps = str bigarray oUnit bytes integers lwt.unix
+test-lwt-jobs.deps = str bigarray oUnit integers lwt.unix
 test-lwt-jobs.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs tests-common test-lwt-jobs-stubs
 test-lwt-jobs.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -1079,13 +1079,13 @@ test-lwt-preemptive-stub-generator.dir = tests/test-lwt-preemptive/stub-generato
 test-lwt-preemptive-stub-generator.threads = yes
 test-lwt-preemptive-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-lwt-preemptive-stubs tests-common
-test-lwt-preemptive-stub-generator.deps = str bigarray bytes integers
+test-lwt-preemptive-stub-generator.deps = str bigarray integers
 test-lwt-preemptive-stub-generator: PROJECT=test-lwt-preemptive-stub-generator
 test-lwt-preemptive-stub-generator: $$(BEST_TARGET)
 
 test-lwt-preemptive.dir = tests/test-lwt-preemptive
 test-lwt-preemptive.threads = yes
-test-lwt-preemptive.deps = str bigarray oUnit bytes integers lwt.unix
+test-lwt-preemptive.deps = str bigarray oUnit integers lwt.unix
 test-lwt-preemptive.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs tests-common test-lwt-preemptive-stubs
 test-lwt-preemptive.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -1122,13 +1122,13 @@ test-returning-errno-lwt-jobs-stub-generator.dir = tests/test-returning-errno-lw
 test-returning-errno-lwt-jobs-stub-generator.threads = yes
 test-returning-errno-lwt-jobs-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-returning-errno-lwt-jobs-stubs tests-common
-test-returning-errno-lwt-jobs-stub-generator.deps = str bigarray bytes integers
+test-returning-errno-lwt-jobs-stub-generator.deps = str bigarray integers
 test-returning-errno-lwt-jobs-stub-generator: PROJECT=test-returning-errno-lwt-jobs-stub-generator
 test-returning-errno-lwt-jobs-stub-generator: $$(BEST_TARGET)
 
 test-returning-errno-lwt-jobs.dir = tests/test-returning-errno-lwt-jobs
 test-returning-errno-lwt-jobs.threads = yes
-test-returning-errno-lwt-jobs.deps = str bigarray oUnit bytes integers lwt.unix
+test-returning-errno-lwt-jobs.deps = str bigarray oUnit integers lwt.unix
 test-returning-errno-lwt-jobs.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs tests-common test-returning-errno-lwt-jobs-stubs
 test-returning-errno-lwt-jobs.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -1164,13 +1164,13 @@ test-returning-errno-lwt-preemptive-stub-generator.dir = tests/test-returning-er
 test-returning-errno-lwt-preemptive-stub-generator.threads = yes
 test-returning-errno-lwt-preemptive-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-returning-errno-lwt-preemptive-stubs tests-common
-test-returning-errno-lwt-preemptive-stub-generator.deps = str bigarray bytes integers
+test-returning-errno-lwt-preemptive-stub-generator.deps = str bigarray integers
 test-returning-errno-lwt-preemptive-stub-generator: PROJECT=test-returning-errno-lwt-preemptive-stub-generator
 test-returning-errno-lwt-preemptive-stub-generator: $$(BEST_TARGET)
 
 test-returning-errno-lwt-preemptive.dir = tests/test-returning-errno-lwt-preemptive
 test-returning-errno-lwt-preemptive.threads = yes
-test-returning-errno-lwt-preemptive.deps = str bigarray oUnit bytes integers lwt.unix
+test-returning-errno-lwt-preemptive.deps = str bigarray oUnit integers lwt.unix
 test-returning-errno-lwt-preemptive.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs tests-common test-returning-errno-lwt-preemptive-stubs
 test-returning-errno-lwt-preemptive.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -1206,13 +1206,13 @@ test-returning-errno-stub-generator.dir = tests/test-returning-errno/stub-genera
 test-returning-errno-stub-generator.threads = yes
 test-returning-errno-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-returning-errno-stubs tests-common
-test-returning-errno-stub-generator.deps = str bigarray bytes integers
+test-returning-errno-stub-generator.deps = str bigarray integers
 test-returning-errno-stub-generator: PROJECT=test-returning-errno-stub-generator
 test-returning-errno-stub-generator: $$(BEST_TARGET)
 
 test-returning-errno.dir = tests/test-returning-errno
 test-returning-errno.threads = yes
-test-returning-errno.deps = str bigarray oUnit bytes integers
+test-returning-errno.deps = str bigarray oUnit integers
 test-returning-errno.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs tests-common test-returning-errno-stubs
 test-returning-errno.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -1249,13 +1249,13 @@ test-threads-stub-generator.dir = tests/test-threads/stub-generator
 test-threads-stub-generator.threads = yes
 test-threads-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-threads-stubs tests-common
-test-threads-stub-generator.deps = str bigarray bytes integers
+test-threads-stub-generator.deps = str bigarray integers
 test-threads-stub-generator: PROJECT=test-threads-stub-generator
 test-threads-stub-generator: $$(BEST_TARGET)
 
 test-threads.dir = tests/test-threads
 test-threads.threads = yes
-test-threads.deps = str bigarray oUnit bytes integers
+test-threads.deps = str bigarray oUnit integers
 test-threads.subproject_deps = ctypes ctypes-foreign-base \
    ctypes-foreign-threaded cstubs tests-common test-threads-stubs
 test-threads.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -1284,13 +1284,13 @@ test-closure-type-promotion-stub-generator.dir = tests/test-closure-type-promoti
 test-closure-type-promotion-stub-generator.threads = yes
 test-closure-type-promotion-stub-generator.subproject_deps = ctypes cstubs \
      ctypes-foreign-base ctypes-foreign-threaded test-closure-type-promotion-stubs tests-common
-test-closure-type-promotion-stub-generator.deps = str bigarray bytes integers
+test-closure-type-promotion-stub-generator.deps = str bigarray integers
 test-closure-type-promotion-stub-generator: PROJECT=test-closure-type-promotion-stub-generator
 test-closure-type-promotion-stub-generator: $$(BEST_TARGET)
 
 test-closure-type-promotion.dir = tests/test-closure-type-promotion
 test-closure-type-promotion.threads = yes
-test-closure-type-promotion.deps = str bigarray oUnit bytes integers
+test-closure-type-promotion.deps = str bigarray oUnit integers
 test-closure-type-promotion.subproject_deps = ctypes ctypes-foreign-base \
   ctypes-foreign-threaded cstubs test-closure-type-promotion-stubs tests-common
 test-closure-type-promotion.link_flags = -L$(BUILDDIR)/clib -ltest_functions
@@ -1310,7 +1310,7 @@ tests/test-closure-type-promotion/generated_bindings.ml: $(BUILDDIR)/test-closur
 
 test-ldouble.dir = tests/test-ldouble
 test-ldouble.threads = yes
-test-ldouble.deps = str bigarray oUnit bytes integers
+test-ldouble.deps = str bigarray oUnit integers
 test-ldouble.subproject_deps = ctypes 
 test-ldouble: PROJECT=test-ldouble
 test-ldouble: $$(BEST_TARGET)

--- a/ctypes.opam
+++ b/ctypes.opam
@@ -21,7 +21,6 @@ install: [
 ]
 depends: [
    "ocaml" {>= "4.02.3"}
-   "base-bytes"
    "integers" { >= "0.3.0" }
    "ocamlfind" {build}
    "conf-pkg-config" {build}

--- a/src/cstubs/cstubs_generate_ml.ml
+++ b/src/cstubs/cstubs_generate_ml.ml
@@ -268,7 +268,7 @@ let rec ml_typ_of_arg_typ : type a. a typ -> ml_type = function
            [`Ident (path_of_string "string")])
   | OCaml Bytes ->
     `Appl (path_of_string "CI.ocaml",
-           [`Ident (path_of_string "Bytes.t")])
+           [`Ident (path_of_string "bytes")])
   | OCaml FloatArray ->
     `Appl (path_of_string "CI.ocaml",
            [`Appl (path_of_string "array",

--- a/src/ctypes/cstubs_internals.mli
+++ b/src/ctypes/cstubs_internals.mli
@@ -25,7 +25,7 @@ val make_fun_ptr : 'a fn -> voidp -> 'a Ctypes_static.static_funptr
 
 type 'a ocaml_type = 'a Ctypes_static.ocaml_type =
   String     : string ocaml_type
-| Bytes      : Bytes.t ocaml_type
+| Bytes      : bytes ocaml_type
 | FloatArray : float array ocaml_type
 
 type 'a typ = 'a Ctypes_static.typ =

--- a/src/ctypes/ctypes.mli
+++ b/src/ctypes/ctypes.mli
@@ -235,7 +235,7 @@ val ocaml_string_start : string -> string ocaml
 (** [ocaml_string_start s] allows to pass a pointer to the contents of an OCaml
     string directly to a C function. *)
 
-val ocaml_bytes_start : Bytes.t -> Bytes.t ocaml
+val ocaml_bytes_start : bytes -> bytes ocaml
 (** [ocaml_bytes_start s] allows to pass a pointer to the contents of an OCaml
     byte array directly to a C function. *)
 

--- a/src/ctypes/ctypes_static.ml
+++ b/src/ctypes/ctypes_static.ml
@@ -29,7 +29,7 @@ type abstract_type = {
 
 type _ ocaml_type =
   String     : string ocaml_type
-| Bytes      : Bytes.t ocaml_type
+| Bytes      : bytes ocaml_type
 | FloatArray : float array ocaml_type
 
 type _ typ =

--- a/src/ctypes/ctypes_static.mli
+++ b/src/ctypes/ctypes_static.mli
@@ -15,7 +15,7 @@ type abstract_type = {
 
 type _ ocaml_type =
   String     : string ocaml_type
-| Bytes      : Bytes.t ocaml_type
+| Bytes      : bytes ocaml_type
 | FloatArray : float array ocaml_type
 
 type incomplete_size = { mutable isize: int }
@@ -149,7 +149,7 @@ val ulong : Unsigned.ulong typ
 val ullong : Unsigned.ullong typ
 val array : int -> 'a typ -> 'a carray typ
 val ocaml_string : string ocaml typ
-val ocaml_bytes : Bytes.t ocaml typ
+val ocaml_bytes : bytes ocaml typ
 val ocaml_float_array : float array ocaml typ
 val ptr : 'a typ -> 'a ptr typ
 val ( @-> ) : 'a typ -> 'b fn -> ('a -> 'b) fn

--- a/src/ctypes/ctypes_types.mli
+++ b/src/ctypes/ctypes_types.mli
@@ -209,7 +209,7 @@ sig
   val ocaml_string : string Ctypes_static.ocaml typ
   (** Value representing the directly mapped storage of an OCaml string. *)
 
-  val ocaml_bytes : Bytes.t Ctypes_static.ocaml typ
+  val ocaml_bytes : bytes Ctypes_static.ocaml typ
   (** Value representing the directly mapped storage of an OCaml byte array. *)
 
   (** {3 Array types} *)


### PR DESCRIPTION
Since OCaml 4.02.0, [`bytes` has been supported as a built-in type in OCaml](https://github.com/ocaml/ocaml/blob/4.02.0/Changes#L15).

Since ctypes no longer supports OCaml 4.01, there's no need to depend on the `base-bytes` library; we can use `bytes` directly instead.