### PR TITLE
ocaml_bytes corresponds to 'unsigned char *', not 'char *'.

### DIFF
--- a/src/ctypes/ctypes_type_printing.ml
+++ b/src/ctypes/ctypes_type_printing.ml
@@ -74,7 +74,7 @@ let rec format_typ' : type a. a typ ->
       fprintf fmt "%s%t%t" name (k `array)
         (fun fmt -> (Array.iter (Format.fprintf fmt "[%d]") dims))
     | OCaml String -> format_typ' (ptr char) k context fmt
-    | OCaml Bytes -> format_typ' (ptr char) k context fmt
+    | OCaml Bytes -> format_typ' (ptr uchar) k context fmt
     | OCaml FloatArray -> format_typ' (ptr double) k context fmt
 
 and format_fields : type a. a boxed_field list -> Format.formatter -> unit =


### PR DESCRIPTION
See @fdopen's comment for details: https://github.com/ocamllabs/ocaml-ctypes/pull/622#issuecomment-577394529