### PR TITLE
Hide the managed component in pointer values

### DIFF
--- a/src/ctypes/cstubs_internals.ml
+++ b/src/ctypes/cstubs_internals.ml
@@ -16,7 +16,7 @@ type ('m, 'a) fatfunptr = ('m, 'a Ctypes.fn) Ctypes_ptr.Fat.t
 let make_structured reftyp buf =
   let open Ctypes_static in
   let raw_ptr = Ctypes_memory_stubs.block_address buf in
-  { structured = CPointer (Ctypes_ptr.Fat.make ~managed:(Some buf) ~reftyp raw_ptr) }
+  { structured = CPointer (Ctypes_ptr.Fat.make ~managed:(Some (Obj.repr buf)) ~reftyp raw_ptr) }
 
 include Ctypes_static
 include Ctypes_primitive_types

--- a/src/ctypes/cstubs_internals.mli
+++ b/src/ctypes/cstubs_internals.mli
@@ -41,12 +41,12 @@ type 'a typ = 'a Ctypes_static.typ =
   | Bigarray        : (_, 'a, _) Ctypes_bigarray.t -> 'a typ
   | OCaml           : 'a ocaml_type             -> 'a ocaml typ
 and ('a, 'b) pointer = ('a, 'b) Ctypes_static.pointer =
-  CPointer : (_ option,'a typ) Ctypes_ptr.Fat.t -> ('a, [`C]) pointer
+  CPointer : (Obj.t option,'a typ) Ctypes_ptr.Fat.t -> ('a, [`C]) pointer
 | OCamlRef : int * 'a * 'a ocaml_type -> ('a, [`OCaml]) pointer
 and 'a ptr = ('a, [`C]) pointer
 and 'a ocaml = ('a, [`OCaml]) pointer
 and 'a static_funptr = 'a Ctypes_static.static_funptr =
-  Static_funptr : (_ option, 'a fn) Ctypes_ptr.Fat.t -> 'a static_funptr
+  Static_funptr : (Obj.t option, 'a fn) Ctypes_ptr.Fat.t -> 'a static_funptr
 and ('a, 'b) view = ('a, 'b) Ctypes_static.view = {
   read : 'b -> 'a;
   write : 'a -> 'b;

--- a/src/ctypes/ctypes_memory.ml
+++ b/src/ctypes/ctypes_memory.ml
@@ -26,7 +26,7 @@ let rec build : type a b. a typ -> (_, b typ) Fat.t -> a
     | Struct { spec = Complete { size } } as reftyp ->
       (fun buf ->
         let p = Stubs.allocate 1 size in
-        let dst = Fat.make ~managed:(Some p) ~reftyp (Stubs.block_address p) in
+        let dst = Fat.make ~managed:(Some (Obj.repr p)) ~reftyp (Stubs.block_address p) in
         let () = Stubs.memcpy ~size ~dst ~src:buf in
         { structured = CPointer dst})
     | Pointer reftyp ->
@@ -128,7 +128,7 @@ let allocate_n
   : type a. ?finalise:(a ptr -> unit) -> a typ -> count:int -> a ptr
   = fun ?finalise reftyp ~count ->
     let package p =
-      CPointer (Fat.make ~managed:(Some p) ~reftyp (Stubs.block_address p))
+      CPointer (Fat.make ~managed:(Some (Obj.repr p)) ~reftyp (Stubs.block_address p))
     in
     let finalise = match finalise with
       | Some f -> Gc.finalise (fun p -> f (package p))
@@ -290,7 +290,7 @@ open Bigarray
 let _bigarray_start kind ba =
   let raw_address = Ctypes_bigarray.unsafe_address ba in
   let reftyp = Primitive (Ctypes_bigarray.prim_of_kind kind) in
-  CPointer (Fat.make ~managed:(Some ba) ~reftyp raw_address)
+  CPointer (Fat.make ~managed:(Some (Obj.repr ba)) ~reftyp raw_address)
 
 let bigarray_kind : type a b c d f l.
   < element: a;

--- a/src/ctypes/ctypes_static.ml
+++ b/src/ctypes/ctypes_static.ml
@@ -51,12 +51,12 @@ and 'a union = ('a, [`Union]) structured
 and 'a structure = ('a, [`Struct]) structured
 and 'a abstract = ('a, [`Abstract]) structured
 and (_, _) pointer =
-  CPointer : (_ option,'a typ) Ctypes_ptr.Fat.t -> ('a, [`C]) pointer
+  CPointer : (Obj.t option,'a typ) Ctypes_ptr.Fat.t -> ('a, [`C]) pointer
 | OCamlRef : int * 'a * 'a ocaml_type -> ('a, [`OCaml]) pointer
 and 'a ptr = ('a, [`C]) pointer
 and 'a ocaml = ('a, [`OCaml]) pointer
 and 'a static_funptr =
-  Static_funptr : (_ option, 'a fn) Ctypes_ptr.Fat.t -> 'a static_funptr
+  Static_funptr : (Obj.t option, 'a fn) Ctypes_ptr.Fat.t -> 'a static_funptr
 and ('a, 'b) view = {
   read : 'b -> 'a;
   write : 'a -> 'b;

--- a/src/ctypes/ctypes_static.mli
+++ b/src/ctypes/ctypes_static.mli
@@ -45,12 +45,12 @@ and 'a union = ('a, [`Union]) structured
 and 'a structure = ('a, [`Struct]) structured
 and 'a abstract = ('a, [`Abstract]) structured
 and (_, _) pointer =
-  CPointer : (_ option,'a typ) Ctypes_ptr.Fat.t -> ('a, [`C]) pointer
+  CPointer : (Obj.t option,'a typ) Ctypes_ptr.Fat.t -> ('a, [`C]) pointer
 | OCamlRef : int * 'a * 'a ocaml_type -> ('a, [`OCaml]) pointer
 and 'a ptr = ('a, [`C]) pointer
 and 'a ocaml = ('a, [`OCaml]) pointer
 and 'a static_funptr =
-  Static_funptr : (_ option, 'a fn) Ctypes_ptr.Fat.t -> 'a static_funptr
+  Static_funptr : (Obj.t option, 'a fn) Ctypes_ptr.Fat.t -> 'a static_funptr
 and ('a, 'b) view = {
   read : 'b -> 'a;
   write : 'a -> 'b;

--- a/src/ctypes/ctypes_std_views.ml
+++ b/src/ctypes/ctypes_std_views.ml
@@ -11,7 +11,7 @@ let string_of_char_ptr (Ctypes_static.CPointer p) =
 let char_ptr_of_string s =
   let p = Ctypes_std_view_stubs.cstring_of_string s in
   Ctypes_static.CPointer (Ctypes_ptr.Fat.make
-                            ~managed:(Some p) ~reftyp:Ctypes_static.char
+                            ~managed:(Some (Obj.repr p)) ~reftyp:Ctypes_static.char
                      (Ctypes_memory_stubs.block_address p))
 
 let string = Ctypes_static.(view (ptr char))


### PR DESCRIPTION
The existential type representing the "managed" component in `CPointer` and `Static_funptr` can sometimes escape in generated code (e.g. for inverted stubs: see #628).  Turning it into the concrete type `Obj.t` side-steps the problem.