### PR TITLE
Move conf-pkg-config dependency to ctypes-foreign

### DIFF
--- a/ctypes-foreign.opam
+++ b/ctypes-foreign.opam
@@ -14,6 +14,9 @@ depexts: [
   ["libffi-dev"] {os-distribution = "alpine"}
   ["libffi-devel"] {os-family = "suse"}
 ]
+depends: [
+  "conf-pkg-config" {build}
+]
 tags: ["org:ocamllabs" "org:mirage"]
 post-messages: [
   "This package requires libffi on your system" {failure}

--- a/ctypes.opam
+++ b/ctypes.opam
@@ -23,7 +23,6 @@ depends: [
    "ocaml" {>= "4.02.3"}
    "integers" { >= "0.3.0" }
    "ocamlfind" {build}
-   "conf-pkg-config" {build}
    "lwt" {with-test & >= "3.2.0"}
    "ctypes-foreign" {with-test}
    "ounit" {with-test}


### PR DESCRIPTION
I tested this by installing Luv, which depends on ctypes, on a system without a `pkg-config` binary. `conf-pkg-config` did not get installed.

I saw that `pkg-config` is also used for something with Xen. I don't know how to best express that as a constraint. However, the Xen-related detection will still work if `pkg-config` happens to be installed, regardless of `conf-pkg-config`.

Fixes #630.