### PR TITLE
Enable GitHub Actions in master branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Ctypes
+on: [push, pull_request]
+jobs:
+  tests:
+    name: Tests
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      fail-fast: false
+      matrix:
+        ocaml-version: [ '4.09.0', '4.10.0' ]
+        operating-system: [macos-latest, ubuntu-latest, windows-latest]
+    steps:
+    - uses: actions/checkout@master
+    - uses: avsm/setup-ocaml@v1.0
+      with:
+        ocaml-version: ${{ matrix.ocaml-version }}
+    - name: Deps
+      run: |
+        opam pin add -n ctypes.dev .
+        opam pin add -n ctypes-foreign.dev .
+        opam depext -ty ctypes ctypes-foreign
+        opam install -t --deps-only .
+    - name: Build
+      run: opam exec -- make
+    - name: Test
+      run: opam exec -- make test

--- a/ctypes-foreign.opam
+++ b/ctypes-foreign.opam
@@ -10,6 +10,7 @@ depexts: [
   ["libffi"] {os = "macos" & os-distribution = "macports"}
   ["libffi-devel"] {os-distribution = "centos"}
   ["libffi-devel"] {os-distribution = "ol"}
+  ["libffi"] {os = "win32" & os-distribution = "cygwinports"}
   ["libffi-devel"] {os-distribution = "fedora"}
   ["libffi-dev"] {os-distribution = "alpine"}
   ["libffi-devel"] {os-family = "suse"}


### PR DESCRIPTION
This enables GitHub CI, which will in turn activate the CI in #588.  It also adds the depext for Cygwin which enables the Windows port to make progress (and fail in the tests)