### PR TITLE
Fix some const-related warnings

### DIFF
--- a/src/ctypes-foreign-base/dl_stubs.c.unix
+++ b/src/ctypes-foreign-base/dl_stubs.c.unix
@@ -74,7 +74,7 @@ value ctypes_dlopen(value filename, value flag)
 {
   CAMLparam2(filename, flag);
 
-  char *cfilename = filename == Val_none ? NULL : String_val(Some_val(filename));
+  const char *cfilename = filename == Val_none ? NULL : String_val(Some_val(filename));
   int cflag = Int_val(flag);
 
   void *handle = dlopen(cfilename, cflag);
@@ -90,7 +90,7 @@ value ctypes_dlsym(value handle_option, value symbol)
     ? RTLD_DEFAULT
     : (void *)Some_val(handle_option);
 
-  char *s = String_val(symbol);
+  const char *s = String_val(symbol);
   void *result = dlsym(handle, s);
   CAMLreturn(result == NULL
              ? Val_none

--- a/src/ctypes-foreign-base/ffi_call_stubs.c
+++ b/src/ctypes-foreign-base/ffi_call_stubs.c
@@ -370,7 +370,7 @@ value ctypes_call(value fnname, value function, value callspec_,
   callback_val_arr = caml_alloc_tuple(nelements);
   caml_callback2(argwriter, callback_arg_buf, callback_val_arr);
 
-  void **val_refs = alloca(sizeof(void*) * nelements);
+  const void **val_refs = alloca(sizeof(void*) * nelements);
 
   unsigned arg_idx;
   for(arg_idx = 0; arg_idx < Wosize_val(callback_val_arr); arg_idx++) {
@@ -385,7 +385,7 @@ value ctypes_call(value fnname, value function, value callspec_,
     assert(Is_block(arg_ptr) && Tag_val(arg_ptr) == String_tag);
     val_refs[arg_idx] = String_val(arg_ptr) + Long_val(arg_offset);
 
-    ((void**)(callbuffer + arg_array_offset))[arg_idx] = &val_refs[arg_idx];
+    ((const void**)(callbuffer + arg_array_offset))[arg_idx] = &val_refs[arg_idx];
   }
 
   void (*cfunction)(void) = (void (*)(void)) CTYPES_ADDR_OF_FATPTR(function);

--- a/src/ctypes/ldouble_stubs.c
+++ b/src/ctypes/ldouble_stubs.c
@@ -392,7 +392,7 @@ CAMLprim value ctypes_ldouble_format(value width, value prec, value d) {
 
 CAMLprim value ctypes_ldouble_of_string(value v) {
   CAMLparam1(v);
-  char *str = String_val(v);
+  const char *str = String_val(v);
   int len = caml_string_length(v);
   char *end;
   long double r;

--- a/src/ctypes/raw_pointer_stubs.c
+++ b/src/ctypes/raw_pointer_stubs.c
@@ -39,7 +39,7 @@ value ctypes_string_of_array(value p, value vlen)
   if (len < 0)
     caml_invalid_argument("ctypes_string_of_array");
   dst = caml_alloc_string(len);
-  memcpy(String_val(dst), CTYPES_ADDR_OF_FATPTR(p), len);
+  memcpy((char *)String_val(dst), CTYPES_ADDR_OF_FATPTR(p), len);
   CAMLreturn(dst);
 }
 
@@ -52,7 +52,7 @@ value ctypes_cstring_of_string(value s)
   size_t len = caml_string_length(s);
   buffer = ctypes_allocate(Val_int(1), Val_long(len + 1));
   char *dst = CTYPES_TO_PTR(ctypes_block_address(buffer));
-  char *ss = String_val(s);
+  const char *ss = String_val(s);
   memcpy(dst, ss, len);
   dst[len] = '\0';
   CAMLreturn(buffer);

--- a/src/ctypes/type_info_stubs.c
+++ b/src/ctypes/type_info_stubs.c
@@ -179,7 +179,7 @@ value ctypes_string_of_prim(value prim_, value v)
     assert(0);
   }
   s = caml_alloc_string(len);
-  memcpy(String_val(s), buf, len);
+  memcpy((char *)String_val(s), buf, len);
   CAMLreturn (s);
 }
 

--- a/tests/test-type_printing/test_type_printing.ml
+++ b/tests/test-type_printing/test_type_printing.ml
@@ -12,7 +12,7 @@ open Ctypes
 module Struct_stubs = Types.Stubs(Generated_struct_bindings)
 
 
-let strip_whitespace = Str.(global_replace (regexp "[\n ]+") "")
+let strip_whitespace = Str.(global_replace (regexp "[\r\n ]+") "")
 
 let equal_ignoring_whitespace l r =
   strip_whitespace l = strip_whitespace r


### PR DESCRIPTION
In recent versions of OCaml, `String_val` returns `const char*`, not `char *`: https://github.com/ocaml/ocaml/pull/1274

Cf. https://github.com/ocamllabs/ocaml-ctypes/issues/134#issuecomment-605786250 (which is related, but not fixed by this PR).