### PR TITLE
Report names of missing symbols also under windows

### DIFF
--- a/src/ctypes-foreign-base/dl.ml.win
+++ b/src/ctypes-foreign-base/dl.ml.win
@@ -123,5 +123,7 @@ let dlsym ?handle ~symbol =
     | Dlsy_ok v -> v
     | Dlsy_unknown -> draise "dlsym" unknown
     | Dlsy_nomem -> draise "dlsym" nomem
-    | Dlsy_enoent -> draise "dlsym" "no such symbol"
+    | Dlsy_enoent ->
+       let msg = Printf.sprintf "no such symbol: %S" symbol in
+       draise "dlsym" msg
     | Dlsy_error x -> draise "dlsym" x


### PR DESCRIPTION
See: https://discuss.ocaml.org/t/runtime-error-on-missing-symbols-on-windows/5416