### PR TITLE
fix complex allocation size

### DIFF
--- a/src/ctypes/complex_stubs.c
+++ b/src/ctypes/complex_stubs.c
@@ -13,7 +13,7 @@
 
 static value allocate_complex_value(double r, double i)
 {
-  value v = caml_alloc(2 * sizeof(double), Double_array_tag);
+  value v = caml_alloc(2 * Double_wosize, Double_array_tag);
   Store_double_field(v, 0, r);
   Store_double_field(v, 1, i);
   return v;

--- a/tests/test-complex/test_complex.ml
+++ b/tests/test-complex/test_complex.ml
@@ -130,8 +130,13 @@ struct
       assert_equal ~cmp:complex32_eq (Complex.mul l r) (mul_complexf_val l r);
 
       let zinf = { re = 0.; im = infinity } in
-      assert_equal 0. (add_complexd_val zinf zinf).re;
+      let res = add_complexd_val zinf zinf in
+      assert_equal 0. res.re;
       assert_equal 0. (add_complexf_val zinf zinf).re;
+      let ozinf = Obj.repr zinf in
+      let ores = Obj.repr res in
+      assert_equal (Obj.tag ozinf) (Obj.tag ores);
+      assert_equal (Obj.size ozinf) (Obj.size ores);
 
       (* test long double complex *)
       let re x = LDouble.(to_float (ComplexL.re x)) in


### PR DESCRIPTION
If too much memory is allocated, the polymorphic comparison function
doesn't work 😜