### PR TITLE
Speed-up CArray.make with initial value

### DIFF
--- a/src/ctypes/ctypes_memory.ml
+++ b/src/ctypes/ctypes_memory.ml
@@ -186,8 +186,12 @@ struct
   let length { alength } = alength
   let from_ptr astart alength = { astart; alength }
 
-  let fill ({ alength } as arr) v =
-    for i = 0 to alength - 1 do unsafe_set arr i v done
+  let fill ({ alength; astart = (CPointer p as astart) } as arr) v =
+    let size = sizeof (Fat.reftype p) in
+    let w = write (Fat.reftype p) v in
+    for i = 0 to alength - 1 do
+      w (Fat.add_bytes p (i * size))
+    done
 
   let make : type a. ?finalise:(a t -> unit) -> a typ -> ?initial:a -> int -> a t
     = fun ?finalise reftype ?initial count ->

--- a/src/ctypes/ctypes_memory_stubs.ml
+++ b/src/ctypes/ctypes_memory_stubs.ml
@@ -27,7 +27,7 @@ external read : 'a Ctypes_primitive_types.prim -> _ Fat.t -> 'a
 
 (* Write a C value to a block of memory *)
 external write : 'a Ctypes_primitive_types.prim -> 'a -> _ Fat.t -> unit
-  = "ctypes_write"
+  = "ctypes_write" [@@noalloc]
 
 module Pointer =
 struct

--- a/src/ctypes/type_info_stubs.c
+++ b/src/ctypes/type_info_stubs.c
@@ -79,7 +79,7 @@ value ctypes_read(value prim_, value buffer_)
 
 /* Read a C value from a block of memory */
 /* write : 'a prim -> 'a -> fat_pointer -> unit */
-value ctypes_write(value prim_, value v, value buffer_)
+value ctypes_write(value prim_, value v, value buffer_) /* noalloc */
 {
   CAMLparam3(prim_, v, buffer_);
   void *buf = CTYPES_ADDR_OF_FATPTR(buffer_);


### PR DESCRIPTION
See #597.  This makes the function around twice as fast on my machine.  The changes are:
- Mark `ctypes_write` `[@@noalloc]`
- Improve `CArray.fill` by eliminating some allocations and moving some type dispatch out of the loop