### PR TITLE
Add support for unknown integer types.

### DIFF
--- a/Makefile.tests
+++ b/Makefile.tests
@@ -246,6 +246,7 @@ test-enums-struct-stubs: $$(LIB_TARGETS)
 test-enums-stubs.dir  = tests/test-enums/stubs
 test-enums-stubs.threads = yes
 test-enums-stubs.extra_mls = generated_struct_bindings.ml
+test-enums-stubs.deps = integers
 test-enums-stubs.subproject_deps = ctypes \
    test-enums-struct-stubs \
    test-enums-struct-stubs-generator \

--- a/src/cstubs/cstubs_structs.mli
+++ b/src/cstubs/cstubs_structs.mli
@@ -12,6 +12,12 @@ sig
   type 'a const
   val constant : string -> 'a typ -> 'a const
 
+  module type signed = sig include Signed.S val t : t typ end
+  val signed  : string -> (module signed)
+
+  module type unsigned = sig include Unsigned.S val t : t typ end
+  val unsigned : string -> (module unsigned)
+
   val enum : string -> ?typedef:bool -> ?unexpected:(int64 -> 'a) -> ('a * int64 const) list -> 'a typ
 end
 

--- a/src/ctypes/cstubs_internals.mli
+++ b/src/ctypes/cstubs_internals.mli
@@ -91,6 +91,14 @@ type 'a prim = 'a Ctypes_primitive_types.prim =
 | Complex64 : Complex.t prim
 | Complexld : ComplexL.t prim
 
+module type signed = sig include Signed.S val t : t typ end
+val build_signed_type :
+  string -> Ctypes_static.arithmetic -> (module signed)
+
+module type unsigned = sig include Unsigned.S val t : t typ end
+val build_unsigned_type :
+  string -> Ctypes_static.arithmetic -> (module unsigned)
+
 val build_enum_type :
   string -> Ctypes_static.arithmetic -> ?typedef:bool ->
   ?unexpected:(int64 -> 'a) -> ('a * int64) list -> 'a typ

--- a/src/ctypes/ctypes.ml
+++ b/src/ctypes/ctypes.ml
@@ -39,6 +39,14 @@ sig
 
   type 'a const
   val constant : string -> 'a typ -> 'a const
+
+  module type signed = sig include Signed.S val t : t typ end
+  val signed  : string -> (module signed)
+
+  module type unsigned = sig include Unsigned.S val t : t typ end
+  val unsigned : string -> (module unsigned)
+
   val enum : string -> ?typedef:bool ->
     ?unexpected:(int64 -> 'a) -> ('a * int64 const) list -> 'a typ
 end
+

--- a/src/ctypes/ctypes.mli
+++ b/src/ctypes/ctypes.mli
@@ -517,6 +517,12 @@ sig
 
          warning: overflow in implicit constant conversion *)
 
+  module type signed = sig include Signed.S val t : t typ end
+  val signed  : string -> (module signed)
+
+  module type unsigned = sig include Unsigned.S val t : t typ end
+  val unsigned : string -> (module unsigned)
+
   val enum : string -> ?typedef:bool ->
     ?unexpected:(int64 -> 'a) -> ('a * int64 const) list -> 'a typ
   (** [enum name ?unexpected alist] builds a type representation for the


### PR DESCRIPTION
### Aims and background

This PR adds support for using integer types of unknown properties (size, alignment requirements, signedness).

For example, POSIX [specifies][off_t_posix] that `off_t` is a signed integer type, but does not specify its size.  And it specifies that `dev_t` is an integer type, but does not specify its size or signedness.  This PR makes it possible to bind and use both types nonetheless.

Similarly, the C standard allows implementations to choose the properties of `enum` types.  Implementations sometimes also include extensions (such as GCC's `-fshort-enums`) that allow users to vary those properties.  That implementation freedom can make it difficult to use enums from ctypes (cf. #650).  This PR makes it easier to bind and use such types in ctypes code.

### Design

This PR adds two new functions, `signed` and `unsigned`, to the [`Ctypes.TYPE`][ctypes-type] signature:

```ocaml
val signed  : string -> (module signed)
val unsigned : string -> (module unsigned)
```

Users can apply these functions in type-binding functions to bind integer types of unknown properties:

```ocaml
module Types(C: Ctypes.TYPE) =
struct
  open C
  
  let dev_t = signed "dev_t"
  let flags = unsigned "enum flags"
end
```

and unpack the bindings to build modules with information about those types:

```ocaml
module Dev_t = (val dev_t)
module Flags = (val flags)
```

The signatures for `Dev_t` and `Flags` include  all the standard integer operations (from [`Signed.S`][signed_s] or [`Unsigned.S`][unsigned_s]) as well as a `typ` value that makes it possible to use the new types to create values, bind functions, etc.

```ocaml
module type signed = sig include Signed.S val t : t typ end
module type unsigned = sig include Unsigned.S val t : t typ end
```

### Limitations

Since the type binding interface currently requires that functors such as `Types` above are applicative, it is not possible to unpack `Dev_t` and `Flags` inside the functor.



[ctypes-type]: https://github.com/ocamllabs/ocaml-ctypes/blob/4f140c37/src/ctypes/ctypes.mli#L500-L567
[signed_s]: https://github.com/ocamllabs/ocaml-integers/blob/48522592/src/signed.mli#L20-L55
[unsigned_s]: https://github.com/ocamllabs/ocaml-integers/blob/48522592/src/unsigned.mli#L46-L135
[off_t_posix]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_types.h.html