### PR TITLE
Add support for C functions which directly handle OCaml `value`s

### DIFF
--- a/Makefile.tests
+++ b/Makefile.tests
@@ -799,6 +799,41 @@ tests/test-bools/generated_stubs.c: $(BUILDDIR)/test-bools-stub-generator.$(BEST
 tests/test-bools/generated_bindings.ml: $(BUILDDIR)/test-bools-stub-generator.$(BEST)
 	$< --ml-file $@
 
+test-values-stubs.dir  = tests/test-values/stubs
+test-values-stubs.threads = yes
+test-values-stubs.subproject_deps = ctypes \
+   ctypes-foreign tests-common
+test-values-stubs: PROJECT=test-values-stubs
+test-values-stubs: $$(LIB_TARGETS)
+
+test-values-stub-generator.dir = tests/test-values/stub-generator
+test-values-stub-generator.threads = yes
+test-values-stub-generator.subproject_deps = ctypes cstubs \
+     ctypes-foreign test-values-stubs tests-common
+test-values-stub-generator.deps = str bigarray integers
+test-values-stub-generator: PROJECT=test-values-stub-generator
+test-values-stub-generator: $$(BEST_TARGET)
+
+test-values.dir = tests/test-values
+test-values.threads = yes
+test-values.deps = str bigarray oUnit integers
+test-values.subproject_deps = ctypes ctypes-foreign \
+  cstubs tests-common test-values-stubs
+test-values.link_flags = -L$(BUILDDIR)/clib -ltest_functions
+test-values: PROJECT=test-values
+test-values: $$(BEST_TARGET)
+
+test-values-generated= \
+  tests/test-values/generated_bindings.ml \
+  tests/test-values/generated_stubs.c
+
+test-values-generated: $(test-values-generated)
+
+tests/test-values/generated_stubs.c: $(BUILDDIR)/test-values-stub-generator.$(BEST)
+	$< --c-file $@
+tests/test-values/generated_bindings.ml: $(BUILDDIR)/test-values-stub-generator.$(BEST)
+	$< --ml-file $@
+
 test-callback_lifetime-stubs.dir  = tests/test-callback_lifetime/stubs
 test-callback_lifetime-stubs.threads = yes
 test-callback_lifetime-stubs.subproject_deps = ctypes \
@@ -1359,6 +1394,7 @@ TESTS += test-returning-errno-stubs test-returning-errno-stub-generator test-ret
 TESTS += test-closure-type-promotion-stubs test-closure-type-promotion-stub-generator test-closure-type-promotion-generated test-closure-type-promotion
 TESTS += test-threads-stubs test-threads-stub-generator test-threads-generated test-threads
 TESTS += test-ldouble
+TESTS += test-values-stubs test-values-stub-generator test-values-generated test-values
 
 ifneq (,$(filter mingw%,$(OSYSTEM)))
 WINLDFLAGS=-Wl,--out-implib,libtest_functions.dll.a

--- a/src/cstubs/cstubs_analysis.ml
+++ b/src/cstubs/cstubs_analysis.ml
@@ -21,7 +21,7 @@ let rec float : type a. a fn -> bool = function
 
 (* A value of type 'a noalloc says that reading a value of type 'a
    will not cause an OCaml allocation in C code. *)
-type _ noalloc =
+type 'a noalloc =
   Noalloc_unit : unit noalloc
 | Noalloc_int : int noalloc
 | Noalloc_uint8_t : Unsigned.uint8 noalloc
@@ -29,6 +29,7 @@ type _ noalloc =
 | Noalloc_char : char noalloc
 | Noalloc_bool : bool noalloc
 | Noalloc_view : ('a, 'b) view * 'b noalloc -> 'a noalloc
+| Noalloc_value : 'a noalloc
 
 (* A value of type 'a alloc says that reading a value of type 'a
    may cause an OCaml allocation in C code. *)
@@ -109,6 +110,7 @@ let rec allocation : type a. a typ -> a allocation = function
  | Array _ -> `Alloc Alloc_array
  | Bigarray ba -> `Alloc (Alloc_bigarray ba)
  | OCaml _ -> `Alloc Alloc_pointer
+ | Value -> `Noalloc Noalloc_value
 
 let rec may_allocate : type a. a fn -> bool = function
   | Returns t ->

--- a/src/cstubs/cstubs_generate_c.ml
+++ b/src/cstubs/cstubs_generate_c.ml
@@ -150,6 +150,7 @@ struct
     | OCaml String -> Some (string_to_ptr x)
     | OCaml Bytes -> Some (bytes_to_ptr x)
     | OCaml FloatArray -> Some (float_array_to_ptr x)
+    | Value -> Some (x :> ccomp)
 
   let prj ty x = prj ty ~orig:ty x
 
@@ -166,6 +167,7 @@ struct
     | Array _ -> report_unpassable "arrays"
     | Bigarray _ -> report_unpassable "bigarrays"
     | OCaml _ -> report_unpassable "ocaml references as return values"
+    | Value -> (x :> ceff)
 
   type _ fn =
   | Returns  : 'a typ   -> 'a fn

--- a/src/cstubs/cstubs_generate_ml.ml
+++ b/src/cstubs/cstubs_generate_ml.ml
@@ -239,6 +239,7 @@ let rec ml_typ_of_return_typ : type a. a typ -> ml_type =
   | Pointer _   -> voidp
   | Funptr _    -> voidp
   | View { ty } -> ml_typ_of_return_typ ty
+  | Value       -> `Ident (path_of_string "_")
   | Array _    as a -> internal_error
     "Unexpected array type in the return type: %s" (Ctypes.string_of_typ a)
   | Bigarray _ as a -> internal_error
@@ -273,6 +274,7 @@ let rec ml_typ_of_arg_typ : type a. a typ -> ml_type = function
     `Appl (path_of_string "CI.ocaml",
            [`Appl (path_of_string "array",
                    [`Ident (path_of_string "float")])])
+  | Value       -> `Ident (path_of_string "_")
 
 type polarity = In | Out
 
@@ -440,6 +442,8 @@ let rec pattern_and_exp_of_typ : type a. concurrency:concurrency_policy -> errno
     | Out, FloatArray -> Ctypes_static.unsupported
       "cstubs does not support OCaml float arrays as return values"
     end
+  | Value   ->
+    (static_con "Value" [], None, binds)
   | Abstract _ as ty -> internal_error
     "Unexpected abstract type encountered during ML code generation: %s"
     (Ctypes.string_of_typ ty)
@@ -484,6 +488,9 @@ let rec pattern_of_typ : type a. a typ -> ml_pat = function
     internal_error
       "Unexpected abstract type encountered during ML code generation: %s"
       (Ctypes.string_of_typ ty)
+  | Value ->
+    Ctypes_static.unsupported
+      "cstubs does not support OCaml values as global values"
 
 type wrapper_state = {
   pat: ml_pat;

--- a/src/ctypes-foreign/ctypes_ffi.ml
+++ b/src/ctypes-foreign/ctypes_ffi.ml
@@ -74,6 +74,7 @@ struct
     (* The following case should never happen; incomplete types are excluded
        during type construction. *)
     | Struct { spec = Incomplete _ }      -> report_unpassable "incomplete types"
+    | Value                               -> ArgType (Ctypes_ffi_stubs.value_ffitype ())
   and struct_arg_type : type s. s structure_type -> arg_type =
      fun ({fields} as s) ->
        let bufspec = Ctypes_ffi_stubs.allocate_struct_ffitype (List.length fields) in

--- a/src/ctypes-foreign/ctypes_ffi_stubs.ml
+++ b/src/ctypes-foreign/ctypes_ffi_stubs.ml
@@ -22,6 +22,9 @@ external pointer_ffitype : unit -> voidp ffitype
 external void_ffitype : unit -> unit ffitype
  = "ctypes_void_ffitype"
 
+external value_ffitype : unit -> 'a ffitype
+ = "ctypes_value_ffitype"
+
 
 (* Allocate a new C typed buffer specification *)
 external allocate_struct_ffitype : int -> struct_ffitype

--- a/src/ctypes-foreign/ffi_type_stubs.c
+++ b/src/ctypes-foreign/ffi_type_stubs.c
@@ -113,6 +113,23 @@ value ctypes_void_ffitype(value _)
   return CTYPES_FROM_PTR(&ffi_type_void);
 }
 
+/* value_ffitype : unit -> value ffitype */
+value ctypes_value_ffitype(value _)
+{
+#if SIZEOF_PTR == SIZEOF_LONG
+/* Standard models: ILP32 or I32LP64 */
+  return CTYPES_FROM_PTR(&ffi_type_slong);
+#elif SIZEOF_PTR == SIZEOF_INT
+/* Hypothetical IP32L64 model */
+  return CTYPES_FROM_PTR(&ffi_type_sint);
+#elif SIZEOF_PTR == 8
+/* Win64 model: IL32P64 */
+  return CTYPES_FROM_PTR(&ffi_type_sint64);
+#else
+#error "No integer type available to represent pointers"
+#endif
+}
+
 #define Struct_ffitype_val(v) (*(ffi_type **)Data_custom_val(v))
 
 /* allocate_struct_ffitype : int -> managed_buffer */

--- a/src/ctypes/cstubs_internals.mli
+++ b/src/ctypes/cstubs_internals.mli
@@ -40,6 +40,7 @@ type 'a typ = 'a Ctypes_static.typ =
   | Array           : 'a typ * int              -> 'a Ctypes_static.carray typ
   | Bigarray        : (_, 'a, _) Ctypes_bigarray.t -> 'a typ
   | OCaml           : 'a ocaml_type             -> 'a ocaml typ
+  | Value           :                              'a typ
 and ('a, 'b) pointer = ('a, 'b) Ctypes_static.pointer =
   CPointer : (Obj.t option,'a typ) Ctypes_ptr.Fat.t -> ('a, [`C]) pointer
 | OCamlRef : int * 'a * 'a ocaml_type -> ('a, [`OCaml]) pointer

--- a/src/ctypes/ctypes_memory.ml
+++ b/src/ctypes/ctypes_memory.ml
@@ -37,6 +37,7 @@ let rec build : type a b. a typ -> (_, b typ) Fat.t -> a
       let buildty = build ty in
       (fun buf -> read (buildty buf))
     | OCaml _ -> (fun buf -> assert false)
+    | Value -> (fun buf -> Stubs.Value.read buf)
     (* The following cases should never happen; non-struct aggregate
        types are excluded during type construction. *)
     | Union _ -> assert false
@@ -75,6 +76,7 @@ let rec write : type a b. a typ -> a -> (_, b) Fat.t -> unit
       let writety = write ty in
       (fun v -> writety (w v))
     | OCaml _ -> raise IncompleteType
+    | Value -> (fun v dst -> Stubs.Value.write v dst)
 
 let null : unit ptr = CPointer (Fat.make ~managed:None ~reftyp:Void Raw.null)
 
@@ -93,6 +95,7 @@ let rec (!@) : type a. a ptr -> a
       | Bigarray b -> Ctypes_bigarray.view b cptr
       | Abstract _ -> { structured = ptr }
       | OCaml _ -> raise IncompleteType
+      | Value -> raise IncompleteType
       (* If it's a value type then we cons a new value. *)
       | _ -> build (Fat.reftype cptr) cptr
 

--- a/src/ctypes/ctypes_memory_stubs.ml
+++ b/src/ctypes/ctypes_memory_stubs.ml
@@ -38,6 +38,15 @@ struct
   = "ctypes_write_pointer"
 end
 
+module Value =
+struct
+  external read : _ Fat.t -> _
+    = "ctypes_read_value"
+
+  external write : _ -> _ Fat.t -> unit
+    = "ctypes_write_value"
+end
+
 (* Copy [size] bytes from [src] to [dst]. *)
 external memcpy : dst:_ Fat.t -> src:_ Fat.t -> size:int -> unit
   = "ctypes_memcpy"

--- a/src/ctypes/ctypes_static.mli
+++ b/src/ctypes/ctypes_static.mli
@@ -26,7 +26,7 @@ type 'a structspec =
     Incomplete of incomplete_size
   | Complete of structured_spec
 
-type _ typ =
+type 'a typ =
     Void            :                       unit typ
   | Primitive       : 'a Ctypes_primitive_types.prim -> 'a typ
   | Pointer         : 'a typ             -> 'a ptr typ
@@ -39,6 +39,7 @@ type _ typ =
   | Bigarray        : (_, 'a, _) Ctypes_bigarray.t
                                          -> 'a typ
   | OCaml           : 'a ocaml_type      -> 'a ocaml typ
+  | Value           :                       'a typ
 and 'a carray = { astart : 'a ptr; alength : int }
 and ('a, 'kind) structured = { structured : ('a, 'kind) structured ptr } [@@unboxed]
 and 'a union = ('a, [`Union]) structured
@@ -180,6 +181,12 @@ val union : string -> 'a union typ
 val offsetof : ('a, 'b) field -> int
 val field_type : ('a, 'b) field -> 'a typ
 val field_name : ('a, 'b) field -> string
+
+module Value () : sig
+  type t
+
+  val typ : t typ
+end
 
 exception IncompleteType
 exception ModifyingSealedType of string

--- a/src/ctypes/ctypes_type_printing.ml
+++ b/src/ctypes/ctypes_type_printing.ml
@@ -76,6 +76,7 @@ let rec format_typ' : type a. a typ ->
     | OCaml String -> format_typ' (ptr char) k context fmt
     | OCaml Bytes -> format_typ' (ptr uchar) k context fmt
     | OCaml FloatArray -> format_typ' (ptr double) k context fmt
+    | Value -> fprintf fmt "value%t" (k `nonarray)
 
 and format_fields : type a. a boxed_field list -> Format.formatter -> unit =
   fun fields fmt ->

--- a/src/ctypes/ctypes_types.mli
+++ b/src/ctypes/ctypes_types.mli
@@ -42,6 +42,16 @@ sig
       {!IncompleteType}.
   *)
 
+  (** {3 Value types}
+
+      The scalar types consist of the {!arithmetic_types} and the {!pointer_types}.
+  *)
+  module Value () : sig
+    type t
+
+    val typ : t typ
+  end
+
   (** {3 Scalar types}
 
       The scalar types consist of the {!arithmetic_types} and the {!pointer_types}.

--- a/src/ctypes/ctypes_value_printing.ml
+++ b/src/ctypes/ctypes_value_printing.ml
@@ -27,6 +27,7 @@ let rec format : type a. a typ -> Format.formatter -> a -> unit
       | None -> format ty fmt (write v)
       | Some f -> f fmt v
     end
+  | Value -> Format.pp_print_string fmt "<abstract>"
 and format_structured : type a b. Format.formatter -> (a, b) structured -> unit
   = fun fmt ({structured = CPointer p} as s) ->
     let open Format in

--- a/src/ctypes/type_info_stubs.c
+++ b/src/ctypes/type_info_stubs.c
@@ -200,6 +200,23 @@ value ctypes_write_pointer(value p_, value dst_)
   CAMLreturn(Val_unit);
 }
 
+/* read_value : fat_pointer -> value */
+value ctypes_read_value(value src_)
+{
+  CAMLparam1(src_);
+  void *src = CTYPES_ADDR_OF_FATPTR(src_);
+  CAMLreturn(*(value *)src);
+}
+
+/* write_value : _ -> dst:fat_pointer -> unit */
+value ctypes_write_value(value v_, value dst_)
+{
+  CAMLparam2(v_, dst_);
+  void *dst = CTYPES_ADDR_OF_FATPTR(dst_);
+  *(value *)dst = v_;
+  CAMLreturn(Val_unit);
+}
+
 /* string_of_pointer : fat_pointer -> string */
 value ctypes_string_of_pointer(value p_)
 {

--- a/tests/clib/test_functions.c
+++ b/tests/clib/test_functions.c
@@ -910,3 +910,41 @@ int call_saved_dynamic_funptr(int n) {
 
 int call_dynamic_funptr_struct(struct simple_closure x) { return x.f(x.n); }
 int call_dynamic_funptr_struct_ptr(struct simple_closure *x) { return x->f(x->n); }
+
+value caml_copy_nativeint(intnat);
+
+value int_to_nativeint(int i) { return caml_copy_nativeint((intnat) i); }
+
+#include <caml/mlvalues.h>
+
+int nativeint_to_int(value i) {
+  return ((int) (Nativeint_val(i)));
+}
+
+#include <caml/custom.h>
+
+struct custom_operations test_ops = {
+  "my_custom_array",
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL
+};
+
+value create_custom_array(int i)
+{
+  value res = caml_alloc_custom(&test_ops, i * sizeof(int), 0, 1);
+  return res;
+}
+
+void set_custom_array(value array, int i, int x)
+{
+  ((int *) Data_custom_val(array))[i] = x;
+}
+
+int get_custom_array(value array, int i)
+{
+  return ((int *) Data_custom_val(array))[i];
+}

--- a/tests/clib/test_functions.h
+++ b/tests/clib/test_functions.h
@@ -282,4 +282,11 @@ struct simple_closure { int (*f)(int); int n; };
 int call_dynamic_funptr_struct(struct simple_closure);
 int call_dynamic_funptr_struct_ptr(struct simple_closure*);
 
+value int_to_nativeint(int i);
+int nativeint_to_int(value i);
+
+value create_custom_array(int i);
+void set_custom_array(value array, int i, int x);
+int get_custom_array(value array, int i);
+
 #endif /* TEST_FUNCTIONS_H */

--- a/tests/test-values/stub-generator/driver.ml
+++ b/tests/test-values/stub-generator/driver.ml
@@ -1,0 +1,10 @@
+(*
+ * Copyright (c) 2014 Jeremy Yallop.
+ *
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+(* Stub generation driver for the OCaml value tests. *)
+
+let () = Tests_common.run Sys.argv (module Functions.Common)

--- a/tests/test-values/stubs/functions.ml
+++ b/tests/test-values/stubs/functions.ml
@@ -1,0 +1,26 @@
+(*
+ * Copyright (c) 2014 Jeremy Yallop.
+ *
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+(* Foreign function bindings for the OCaml value tests. *)
+
+open Ctypes
+
+module T = Value ()
+
+module Custom_array = Value ()
+
+(* These functions can be bound either dynamically using Foreign or statically
+   using stub generation. *)
+module Common(F : Ctypes.FOREIGN) =
+struct
+  let int_to_nativeint = F.(foreign "int_to_nativeint" (int @-> returning T.typ))
+  let nativeint_to_int = F.(foreign "nativeint_to_int" (T.typ @-> returning int))
+
+  let create_custom_array = F.(foreign "create_custom_array" (int @-> returning Custom_array.typ))
+  let set_custom_array = F.(foreign "set_custom_array" (Custom_array.typ @-> int @-> int @-> returning void))
+  let get_custom_array = F.(foreign "get_custom_array" (Custom_array.typ @-> int @-> returning int))
+end

--- a/tests/test-values/test_values.ml
+++ b/tests/test-values/test_values.ml
@@ -1,0 +1,85 @@
+(*
+ * Copyright (c) 2013 Jeremy Yallop.
+ *
+ * This file is distributed under the terms of the MIT License.
+ * See the file LICENSE for details.
+ *)
+
+open OUnit2
+open Ctypes
+
+
+module Common_tests(S : Cstubs.FOREIGN with type 'a result = 'a
+                                        and type 'a return = 'a) =
+struct
+  module M = Functions.Common(S)
+  open M
+
+  (*
+    Test passing values.
+  *)
+  let test_passing_values _ =
+    let max_int = 2147483647 in
+    let min_int = -2147483647 in
+    begin
+      assert_equal 1 (M.int_to_nativeint 1 |> M.nativeint_to_int);
+      assert_equal 10000000 (M.int_to_nativeint 10000000 |> M.nativeint_to_int);
+      assert_equal max_int (M.int_to_nativeint max_int |> M.nativeint_to_int);
+      assert_equal min_int (M.int_to_nativeint min_int |> M.nativeint_to_int);
+      assert_equal (Nativeint.of_int 1) (M.int_to_nativeint 1 |> Obj.magic);
+      assert_equal (Nativeint.of_int 10000000) (M.int_to_nativeint 10000000 |> Obj.magic);
+      assert_equal (Nativeint.of_int max_int) (M.int_to_nativeint max_int |> Obj.magic);
+      assert_equal (Nativeint.of_int min_int) (M.int_to_nativeint min_int |> Obj.magic);
+      assert_equal 1 (Nativeint.of_int 1 |> Obj.magic |> M.nativeint_to_int);
+      assert_equal 10000000 (Nativeint.of_int 10000000 |> Obj.magic |> M.nativeint_to_int);
+      assert_equal max_int (Nativeint.of_int max_int |> Obj.magic |> M.nativeint_to_int);
+      assert_equal min_int (Nativeint.of_int min_int |> Obj.magic |> M.nativeint_to_int);
+    end
+
+  let test_array _ =
+    let arr1 = M.create_custom_array 15 in
+    let arr2 = M.create_custom_array 150 in
+    begin
+      M.set_custom_array arr1 0 0;
+      M.set_custom_array arr1 1 1;
+      M.set_custom_array arr1 2 100;
+      M.set_custom_array arr1 3 1000;
+      M.set_custom_array arr1 7 100000;
+      assert_equal 0 (M.get_custom_array arr1 0);
+      assert_equal 1 (M.get_custom_array arr1 1);
+      assert_equal 100 (M.get_custom_array arr1 2);
+      assert_equal 1000 (M.get_custom_array arr1 3);
+      assert_equal 100000 (M.get_custom_array arr1 7);
+      M.set_custom_array arr2 0 0;
+      M.set_custom_array arr2 5 1;
+      M.set_custom_array arr2 30 100;
+      M.set_custom_array arr2 70 1000;
+      M.set_custom_array arr2 147 100000;
+      assert_equal 0 (M.get_custom_array arr2 0);
+      assert_equal 1 (M.get_custom_array arr2 5);
+      assert_equal 100 (M.get_custom_array arr2 30);
+      assert_equal 1000 (M.get_custom_array arr2 70);
+      assert_equal 100000 (M.get_custom_array arr2 147);
+    end
+end
+
+
+module Foreign_tests = Common_tests(Tests_common.Foreign_binder)
+module Stub_tests = Common_tests(Generated_bindings)
+
+
+let suite = "Values tests" >:::
+  ["passing values (foreign)"
+   >:: Foreign_tests.test_passing_values;
+   "passing larger values (foreign)"
+   >:: Foreign_tests.test_array;
+
+   "passing values (stubs)"
+   >:: Stub_tests.test_passing_values;
+   "passing larger values (stubs)"
+   >:: Stub_tests.test_array;
+  ]
+
+
+let _ =
+  run_test_tt_main suite


### PR DESCRIPTION
This PR adds support for handling native OCaml values as arguments to and return values from C functions.

This makes it easy to use the OCaml allocator via `caml_alloc_custom`, while still allowing Ctypes to handle the other details of bindings, and without having to entirely rewrite existing binding systems. For example, in the [Mina project](https://github.com/MinaProtocol/Mina) we use bindings that currently [allocate using rust's `Box`](https://github.com/o1-labs/zexe/blob/383372dfe6678aeac2af5342f17cb94912408702/snarky-bn382/src/tweedledee.rs#L789); it would be extremely useful to allocate on the OCaml heap without needing large changes to the bindings or the OCaml side.

The implementation roughly
* adds a new `typ` constructor `Value`, where the parameter may be any OCaml type
* fills out the generation code to pass the value directly and expose the `_` OCaml type on the bindings
* adds a `Value ()` functor to the main interface
  - this creates a fresh type associated with a `typ` for the value
  - the type is deliberately abstract, so that there is still some discipline enforced around distinct types being kept separate
* adds a few small tests, namely a `intnat` clone and an `[int]`
  - these aren't particularly extensive (custom types only), but they work as expected.

Example usage:
```ocaml
module My_foreign_type = Value ()

let create = foreign "my_foreign_type_create" (int @-> bool @-> My_foreign_type.typ)
let get_int = foreign "my_foreign_type_get_int" (My_foreign_type.typ @-> returning int)
let get_bool = foreign "my_foreign_type_get_bool" (My_foreign_type.typ @-> returning bool)
let set_bool = foreign "my_foreign_type_set_bool" (My_foreign_type.typ @-> bool @-> returning void)
```
Corresponding C header:
```c
value my_foreign_type_create(int i, bool b);
int my_foreign_type_get_int(value x);
bool my_foreign_type_get_bool(value x);
void my_foreign_type_set_bool(value x, bool b);
```