### PR TITLE
Remove circular dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ endif
 all: libffi.config $(PROJECTS)
 
 ctypes-base: $(BASE_PROJECTS)
-ctypes-foreign: ctypes-base $(FOREIGN_PROJECTS)
+ctypes-foreign: ctypes-base test-libffi
 ctypes-stubs: ctypes-base $(STUB_PROJECTS)
 
 clean: clean-examples clean-tests


### PR DESCRIPTION
Drop circular dependency in the `ctypes-foreign` target.  See: https://github.com/ocaml/opam-repository/pull/17614#issuecomment-727623389