### PR TITLE
Link to OCamlPro's API documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The documentation and source distribution contain more complex examples, involvi
 [rwo]: http://realworldocaml.org/
 [mirage-blogpost]: http://openmirage.org/blog/modular-foreign-function-bindings
 [tutorial]: https://github.com/ocamllabs/ocaml-ctypes/wiki/ctypes-tutorial
-[apidoc]: http://ocamllabs.github.io/ocaml-ctypes
+[apidoc]: https://docs.ocaml.pro/html/LIBRARY.ctypes@ctypes.0.17.1/index.html
 [mailing-list]: http://lists.ocaml.org/listinfo/ctypes
 [faq]: https://github.com/ocamllabs/ocaml-ctypes/wiki/FAQ
 [mirage]: http://openmirage.org


### PR DESCRIPTION
Update the README to use the `ctypes` API documentation with cross references ([example](https://docs.ocaml.pro/html/LIBRARY.ctypes@ctypes.0.17.1/Ctypes/index.html)) from OCamlPro's [documentation hub](https://docs.ocaml.pro) ([announcement](https://discuss.ocaml.org/t/ann-docs-ocaml-pro-an-ocaml-documentation-hub/7718)).