### PR TITLE
Remove compatibility with OCaml 4.02 (makes ctypes stubs compatible with ocaml-multicore for free)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            ocaml-version: 4.02.3
-          - os: ubuntu-latest
             ocaml-version: 4.03.0
           - os: ubuntu-latest
             ocaml-version: 4.04.0

--- a/ctypes.opam
+++ b/ctypes.opam
@@ -20,7 +20,7 @@ install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
 ]
 depends: [
-   "ocaml" {>= "4.02.3"}
+   "ocaml" {>= "4.03.0"}
    "integers" { >= "0.3.0" }
    "ocamlfind" {build}
    "lwt" {with-test & >= "3.2.0"}

--- a/src/cstubs/cstubs_emit_c.ml
+++ b/src/cstubs/cstubs_emit_c.ml
@@ -93,8 +93,7 @@ let camlop fmt : camlop -> unit = function
   | `CAMLlocalN (e, c) -> Format.fprintf fmt "CAMLlocalN(@[%a@],@ @[%a@])"
     cexp e cexp c
   | `CAMLdrop ->
-    Format.fprintf fmt "caml_local_roots = caml__frame;"
-    (* Format.fprintf fmt "CAMLdrop()" *) (* 4.03+ only *)
+    Format.fprintf fmt "CAMLdrop()"
 
 let rec ceff fmt : ceff -> unit = function
   | #cexp as e -> cexp fmt e

--- a/src/ctypes-foreign/ffi_call_stubs.c
+++ b/src/ctypes-foreign/ffi_call_stubs.c
@@ -375,8 +375,8 @@ value ctypes_call(value fnname, value function, value callspec_,
   unsigned arg_idx;
   for(arg_idx = 0; arg_idx < Wosize_val(callback_val_arr); arg_idx++) {
     value arg_tuple = Field(callback_val_arr, arg_idx);
-    /* <4.02 initialize to 0; >=4.02 initialize to unit. */
-    if(arg_tuple == 0 || arg_tuple == Val_unit) continue;
+    /* >=4.02 initialize to unit. */
+    if(arg_tuple == Val_unit) continue;
 
     value arg_ptr    = Field(arg_tuple, 0);
     value arg_offset = Field(arg_tuple, 1);


### PR DESCRIPTION
The stubs generation part of ctypes doesn't seem to be compatible with ocaml-multicore at the moment. For instance, the following error message is raised when trying to compile `decompress` which uses ctypes' stubs generation:
```
#=== ERROR while compiling decompress.1.4.1 ===================================#
# context              2.1.0~beta4 | linux/x86_64 | ocaml-variants.4.12.0+domains | file:///home/opam/opam-repository
# path                 ~/.opam/4.12.0+domains/.opam-switch/build/decompress.1.4.1
# command              ~/.opam/4.12.0+domains/bin/dune runtest -p decompress -j 31
# exit-code            1
# env-file             ~/.opam/log/decompress-2686-ca0fe3.env
# output-file          ~/.opam/log/decompress-2686-ca0fe3.out
### output ###
#          gcc bindings/stubs/gen_decompress.o (exit 1)
# (cd _build/default/bindings/stubs && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -fPIC -D_FILE_OFFSET_BITS=64 -D_REENTRANT -O2 -fno-strict-aliasing -fwrapv -fPIC -g -I /home/opam/.opam/4.12.0+domains/lib/ocaml -I /home/opam/.opam/4.12.0+domains/lib/bigarray-compat -I /home/opam/.opam/4.12.0+domains/lib/bytes -I /home/opam/.opam/4.12.0+domains/lib/checkseum/c -I /home/opam/.opam/4.12.0+domains/lib/ctypes -I /home/opam/.opam/4.12.0+domains/lib/integers -I /home/opam/.opam/4.12.0+domains/lib/optint -I . -I ../../lib -o gen_decompress.o -c gen_decompress.c)
# gen_decompress.c: In function 'decompress_inflate':
# gen_decompress.c:38:4: error: 'caml_local_roots' undeclared (first use in this function); did you mean 'caml_local_roots_ptr'?
#    38 |    caml_local_roots = caml__frame;;
#       |    ^~~~~~~~~~~~~~~~
#       |    caml_local_roots_ptr
# gen_decompress.c:38:4: note: each undeclared identifier is reported only once for each function it appears in
```
Looking into it, it seems the direct use of `caml_local_roots` stems from a care for backwards compatibility. Given it is relatively easy to simply bump the required version and use the "new" `CAMLdrop()` macro I feel like it might be worth doing anyway.