### PR TITLE
README: fix link to api doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The documentation and source distribution contain more complex examples, involvi
 [rwo]: http://realworldocaml.org/
 [mirage-blogpost]: http://openmirage.org/blog/modular-foreign-function-bindings
 [tutorial]: https://github.com/ocamllabs/ocaml-ctypes/wiki/ctypes-tutorial
-[apidoc]: https://ocamllabs.io/ocaml-ctypes/
+[apidoc]: https://docs.ocaml.pro/docs/LIBRARY.ctypes@ctypes.0.17.1/index.html
 [mailing-list]: http://lists.ocaml.org/listinfo/ctypes
 [faq]: https://github.com/ocamllabs/ocaml-ctypes/wiki/FAQ
 [mirage]: http://openmirage.org

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The documentation and source distribution contain more complex examples, involvi
 [rwo]: http://realworldocaml.org/
 [mirage-blogpost]: http://openmirage.org/blog/modular-foreign-function-bindings
 [tutorial]: https://github.com/ocamllabs/ocaml-ctypes/wiki/ctypes-tutorial
-[apidoc]: https://docs.ocaml.pro/html/LIBRARY.ctypes@ctypes.0.17.1/index.html
+[apidoc]: https://ocamllabs.io/ocaml-ctypes/
 [mailing-list]: http://lists.ocaml.org/listinfo/ctypes
 [faq]: https://github.com/ocamllabs/ocaml-ctypes/wiki/FAQ
 [mirage]: http://openmirage.org


### PR DESCRIPTION
docs.ocaml.pro link is 404