### PR TITLE
Update CI compiler versions; retire broken Windows+4.12.0 build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,14 +33,12 @@ jobs:
             ocaml-compiler: 4.11.1
           - os: ubuntu-latest
             ocaml-compiler: 4.12.0
+          - os: ubuntu-latest
+            ocaml-compiler: 4.13.1
           - os: windows-latest
-            ocaml-compiler: 4.11.1
-          - os: windows-latest
-            ocaml-compiler: 4.12.0
+            ocaml-compiler: 4.13.1
           - os: macos-latest
-            ocaml-compiler: 4.11.1
-          - os: macos-latest
-            ocaml-compiler: 4.12.0
+            ocaml-compiler: 4.13.1
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Closes #677.