### PR TITLE
More rigorous testing for homebrew

### DIFF
--- a/src/discover/discover.ml
+++ b/src/discover/discover.ml
@@ -257,7 +257,9 @@ let () =
   is_homebrew :=
     test_feature "brew"
       (fun () ->
-         (Commands.command "brew ls --versions").Commands.stdout <> "");
+         let out = Commands.command "brew ls --versions" in
+         out.status == 0 && out.stdout <> ""
+         );
 
   (* Test for MacOS X MacPorts. *)
   is_macports :=


### PR DESCRIPTION
Instead of just checking of existence of the `brew` command, make sure that the
existsing `brew ls --versions` command does not end with error.  Still not
really a proper fix for people with a different `brew` command than homebrew,
but it fixes the build in such circumstances at least.

Signed-off-by: Martin Kletzander <nert.pinx@gmail.com>