### PR TITLE
Fix warning 9 [missing-record-field-pattern] in generated OCaml code

### DIFF
--- a/src/cstubs/cstubs_structs.ml
+++ b/src/cstubs/cstubs_structs.ml
@@ -95,7 +95,7 @@ let write_field fmt specs =
    "let rec field : type t a. t typ -> string -> a typ -> (a, t) field =";
    "  fun s fname ftype -> match s, fname with";]
   ~case
-  ["  | View { ty }, _ ->";
+  ["  | View { ty; _ }, _ ->";
    "    let { ftype; foffset; fname } = field ty fname ftype in";
    "    { ftype; foffset; fname }";
    "  | _ -> failwith (\"Unexpected field \"^ fname)"]
@@ -123,7 +123,7 @@ let write_seal fmt specs =
      "    raise (ModifyingSealedType tag)";
      "  | Union { utag; uspec = Some _; _ } ->";
      "    raise (ModifyingSealedType utag)";
-     "  | View { ty } -> seal ty";
+     "  | View { ty; _ } -> seal ty";
      "  | _ ->";
      "    raise (Unsupported \"Sealing a non-structured type\")";
      ""]


### PR DESCRIPTION
Example problem:

    File "lib/bindings_stubs_field_info.ml", line 17, characters 9-15:
    17 |   | View { ty } -> seal ty
                  ^^^^^^
    Error (warning 9 [missing-record-field-pattern]): the following labels are not bound in this record pattern:
    read, write, format_typ, format
    Either bind these labels explicitly or add '; _' to the pattern.