### PR TITLE
[WIP] Add `Obj.t typ` for OCaml values

### DIFF
--- a/src/cstubs/cstubs_analysis.ml
+++ b/src/cstubs/cstubs_analysis.ml
@@ -52,6 +52,7 @@ type _ alloc =
 | Alloc_complex : Complex.t alloc
 | Alloc_complexld : ComplexL.t alloc
 | Alloc_pointer : (_, _) pointer alloc
+| Alloc_value : Obj.t alloc
 | Alloc_funptr : _ static_funptr alloc
 | Alloc_structured : (_, _) structured alloc
 | Alloc_array : _ carray alloc
@@ -109,6 +110,7 @@ let rec allocation : type a. a typ -> a allocation = function
  | Array _ -> `Alloc Alloc_array
  | Bigarray ba -> `Alloc (Alloc_bigarray ba)
  | OCaml _ -> `Alloc Alloc_pointer
+ | Value -> `Alloc Alloc_value
 
 let rec may_allocate : type a. a fn -> bool = function
   | Returns t ->

--- a/src/cstubs/cstubs_generate_c.ml
+++ b/src/cstubs/cstubs_generate_c.ml
@@ -87,6 +87,16 @@ struct
                           (value @-> returning (ptr void)),
                    [x])
 
+  let value_to_intnat : cexp -> ccomp =
+    fun x -> `App (reader "CTYPES_INTNAT_OF_VALUE"
+                          (value @-> returning nativeint),
+                   [x])
+
+  let intnat_to_value : cexp -> ceff =
+    fun x -> `App (conser "CTYPES_VALUE_OF_INTNAT"
+                          (nativeint @-> returning value),
+                   [x])
+
   let from_ptr : cexp -> ceff =
     fun x -> `App (conser "CTYPES_FROM_PTR"
                           (ptr void @-> returning value),
@@ -150,6 +160,7 @@ struct
     | OCaml String -> Some (string_to_ptr x)
     | OCaml Bytes -> Some (bytes_to_ptr x)
     | OCaml FloatArray -> Some (float_array_to_ptr x)
+    | Value -> Some (value_to_intnat x)
 
   let prj ty x = prj ty ~orig:ty x
 
@@ -165,6 +176,7 @@ struct
     | View { ty } -> inj ty x
     | Array _ -> report_unpassable "arrays"
     | Bigarray _ -> report_unpassable "bigarrays"
+    | Value -> (intnat_to_value (x:>cexp))
     | OCaml _ -> report_unpassable "ocaml references as return values"
 
   type _ fn =

--- a/src/cstubs/cstubs_generate_ml.ml
+++ b/src/cstubs/cstubs_generate_ml.ml
@@ -249,6 +249,9 @@ let rec ml_typ_of_return_typ : type a. a typ -> ml_type =
     "cstubs does not support OCaml bytes values as return values"
   | OCaml FloatArray -> Ctypes_static.unsupported
     "cstubs does not support OCaml float arrays as return values"
+  | Value ->
+    `Ident (path_of_string "Obj.t")
+
 
 let rec ml_typ_of_arg_typ : type a. a typ -> ml_type = function
   | Void -> `Ident (path_of_string "unit")
@@ -273,6 +276,8 @@ let rec ml_typ_of_arg_typ : type a. a typ -> ml_type = function
     `Appl (path_of_string "CI.ocaml",
            [`Appl (path_of_string "array",
                    [`Ident (path_of_string "float")])])
+  | Value ->
+    `Ident (path_of_string "Obj.t")
 
 type polarity = In | Out
 
@@ -440,6 +445,11 @@ let rec pattern_and_exp_of_typ : type a. concurrency:concurrency_policy -> errno
     | Out, FloatArray -> Ctypes_static.unsupported
       "cstubs does not support OCaml float arrays as return values"
     end
+  | Value ->
+   begin  match pol with
+     | In -> (static_con "Value" [], None, binds)
+     | Out -> (static_con "Value" [], None, binds)
+   end
   | Abstract _ as ty -> internal_error
     "Unexpected abstract type encountered during ML code generation: %s"
     (Ctypes.string_of_typ ty)
@@ -480,6 +490,9 @@ let rec pattern_of_typ : type a. a typ -> ml_pat = function
   | OCaml FloatArray ->
     Ctypes_static.unsupported
       "cstubs does not support OCaml float arrays as global values"
+  | Value ->
+    Ctypes_static.unsupported
+      "cstubs does not support OCaml value as global values"
   | Abstract _ as ty ->
     internal_error
       "Unexpected abstract type encountered during ML code generation: %s"

--- a/src/ctypes-foreign/ctypes_ffi_stubs.ml
+++ b/src/ctypes-foreign/ctypes_ffi_stubs.ml
@@ -42,7 +42,7 @@ type callspec
 
 (* Allocate a new C call specification *)
 external allocate_callspec : check_errno:bool -> runtime_lock:bool ->
-  thread_registration:bool -> callspec
+  thread_registration:bool -> return_ocaml_value:bool -> callspec
   = "ctypes_allocate_callspec"
 
 (* Add an argument to the C buffer specification *)
@@ -57,7 +57,7 @@ external prep_callspec : callspec -> int -> _ ffitype -> unit
    The callback functions write the arguments to the buffer and read
    the return value. *)
 external call : string -> (_, _ Ctypes_static.fn) Fat.t -> callspec ->
-  (voidp -> (Obj.t * int) array -> unit) -> (voidp -> 'a) -> 'a
+  (voidp -> (Obj.t * int) array -> unit) -> (Obj.t -> 'a) -> 'a
   = "ctypes_call"
 
 

--- a/src/ctypes/cstubs_internals.mli
+++ b/src/ctypes/cstubs_internals.mli
@@ -40,6 +40,7 @@ type 'a typ = 'a Ctypes_static.typ =
   | Array           : 'a typ * int              -> 'a Ctypes_static.carray typ
   | Bigarray        : (_, 'a, _) Ctypes_bigarray.t -> 'a typ
   | OCaml           : 'a ocaml_type             -> 'a ocaml typ
+  | Value           :                               Obj.t typ
 and ('a, 'b) pointer = ('a, 'b) Ctypes_static.pointer =
   CPointer : (Obj.t option,'a typ) Ctypes_ptr.Fat.t -> ('a, [`C]) pointer
 | OCamlRef : int * 'a * 'a ocaml_type -> ('a, [`OCaml]) pointer

--- a/src/ctypes/ctypes_cstubs_internals.h
+++ b/src/ctypes/ctypes_cstubs_internals.h
@@ -30,6 +30,9 @@
 #define CTYPES_PTR_OF_OCAML_BYTES(s) CTYPES_PTR_OF_OCAML_STRING(s)
 #endif
 
+#define CTYPES_INTNAT_OF_VALUE(s) (s)
+#define CTYPES_VALUE_OF_INTNAT(s) (s)
+
 #define Ctypes_val_char(c) \
   (Val_int((c + 256) % 256))
 #define CTYPES_PAIR_WITH_ERRNO(v)

--- a/src/ctypes/ctypes_memory.ml
+++ b/src/ctypes/ctypes_memory.ml
@@ -37,6 +37,7 @@ let rec build : type a b. a typ -> (_, b typ) Fat.t -> a
       let buildty = build ty in
       (fun buf -> read (buildty buf))
     | OCaml _ -> (fun buf -> assert false)
+    | Value   -> (fun buf -> assert false)
     (* The following cases should never happen; non-struct aggregate
        types are excluded during type construction. *)
     | Union _ -> assert false
@@ -74,6 +75,7 @@ let rec write : type a b. a typ -> a -> (_, b) Fat.t -> unit
     | View { write = w; ty } ->
       let writety = write ty in
       (fun v -> writety (w v))
+    | Value -> (fun _ -> assert false)
     | OCaml _ -> raise IncompleteType
 
 let null : unit ptr = CPointer (Fat.make ~managed:None ~reftyp:Void Raw.null)

--- a/src/ctypes/ctypes_static.mli
+++ b/src/ctypes/ctypes_static.mli
@@ -39,6 +39,7 @@ type _ typ =
   | Bigarray        : (_, 'a, _) Ctypes_bigarray.t
                                          -> 'a typ
   | OCaml           : 'a ocaml_type      -> 'a ocaml typ
+  | Value           :                       Obj.t typ
 and 'a carray = { astart : 'a ptr; alength : int }
 and ('a, 'kind) structured = { structured : ('a, 'kind) structured ptr } [@@unboxed]
 and 'a union = ('a, [`Union]) structured
@@ -151,6 +152,7 @@ val array : int -> 'a typ -> 'a carray typ
 val ocaml_string : string ocaml typ
 val ocaml_bytes : bytes ocaml typ
 val ocaml_float_array : float array ocaml typ
+val ocaml_value : Obj.t typ
 val ptr : 'a typ -> 'a ptr typ
 val ( @-> ) : 'a typ -> 'b fn -> ('a -> 'b) fn
 val abstract : name:string -> size:int -> alignment:int -> 'a abstract typ

--- a/src/ctypes/ctypes_type_printing.ml
+++ b/src/ctypes/ctypes_type_printing.ml
@@ -76,6 +76,8 @@ let rec format_typ' : type a. a typ ->
     | OCaml String -> format_typ' (ptr char) k context fmt
     | OCaml Bytes -> format_typ' (ptr uchar) k context fmt
     | OCaml FloatArray -> format_typ' (ptr double) k context fmt
+    | Value            -> fprintf fmt "value%t" (k `nonarray)
+
 
 and format_fields : type a. a boxed_field list -> Format.formatter -> unit =
   fun fields fmt ->

--- a/src/ctypes/ctypes_types.mli
+++ b/src/ctypes/ctypes_types.mli
@@ -212,6 +212,9 @@ sig
   val ocaml_bytes : bytes Ctypes_static.ocaml typ
   (** Value representing the directly mapped storage of an OCaml byte array. *)
 
+  val ocaml_value : Obj.t typ
+  (** Value representing the direct OCaml value. *)
+
   (** {3 Array types} *)
 
   (** {4 C array types} *)

--- a/src/ctypes/ctypes_value_printing.ml
+++ b/src/ctypes/ctypes_value_printing.ml
@@ -21,6 +21,7 @@ let rec format : type a. a typ -> Format.formatter -> a -> unit
   | Bigarray ba -> Format.fprintf fmt "<bigarray %a>"
     (fun fmt -> Ctypes_type_printing.format_typ fmt) typ
   | Abstract _ -> format_structured fmt v
+  | Value -> Format.fprintf fmt "Obj.t"
   | OCaml _ -> format_ocaml fmt v
   | View {write; ty; format=f} ->
     begin match f with
@@ -70,6 +71,7 @@ and format_ocaml : type a. Format.formatter -> a ocaml -> unit =
   | String -> Format.fprintf fmt "%S%a" obj offset off
   | Bytes -> Format.fprintf fmt "%S%a" (Bytes.to_string obj) offset off
   | FloatArray -> Format.fprintf fmt "%a%a" float_array obj offset off
+
 and format_fields : type a b. string -> (a, b) structured boxed_field list ->
                               Format.formatter -> (a, b) structured -> unit
   = fun sep fields fmt s ->

--- a/tests/clib/test_functions.c
+++ b/tests/clib/test_functions.c
@@ -910,3 +910,7 @@ int call_saved_dynamic_funptr(int n) {
 
 int call_dynamic_funptr_struct(struct simple_closure x) { return x.f(x.n); }
 int call_dynamic_funptr_struct_ptr(struct simple_closure *x) { return x->f(x->n); }
+
+intnat get_first_field(intnat a){
+  return *((intnat*)a);
+}

--- a/tests/clib/test_functions.h
+++ b/tests/clib/test_functions.h
@@ -282,4 +282,6 @@ struct simple_closure { int (*f)(int); int n; };
 int call_dynamic_funptr_struct(struct simple_closure);
 int call_dynamic_funptr_struct_ptr(struct simple_closure*);
 
+intnat get_first_field(intnat);
+
 #endif /* TEST_FUNCTIONS_H */

--- a/tests/test-passing-ocaml-values/stubs/functions.ml
+++ b/tests/test-passing-ocaml-values/stubs/functions.ml
@@ -29,4 +29,8 @@ struct
 
   let strdup = foreign name_strdup
     (ocaml_string @-> returning string)
+
+  let get_first_field = foreign "get_first_field"
+    (ocaml_value @-> returning ocaml_value)
+
 end

--- a/tests/test-passing-ocaml-values/test_passing_ocaml_values.ml
+++ b/tests/test-passing-ocaml-values/test_passing_ocaml_values.ml
@@ -71,6 +71,11 @@ struct
         (strdup (ocaml_string_start "klmnopqrstuvwxyz"))
         (strdup (s +@ 10))
     end
+
+  let test_obj_value _ =
+    let r = ref (ref 1) in
+    let r' = Obj.obj (get_first_field (Obj.repr r)) in
+    assert_equal true (!r == r')
 end
 
 
@@ -138,6 +143,12 @@ let suite = "Tests passing OCaml values" >:::
 
    "pointer arithmetic on OCaml values (stubs)"
     >:: Stub_tests.test_pointer_arithmetic;
+
+   "passing an OCaml values (foreign)"
+    >:: Foreign_tests.test_obj_value;
+
+   "passing an OCaml values (stubs)"
+    >:: Stub_tests.test_obj_value;
 
    "ocaml_string values aren't addressable"
     >:: test_ocaml_types_rejected_as_pointer_reference_types;

--- a/tests/test-raw/test_raw.ml
+++ b/tests/test-raw/test_raw.ml
@@ -28,6 +28,7 @@ let test_fabs _ =
       ~check_errno:false
       ~runtime_lock:false
       ~thread_registration:false
+      ~return_ocaml_value:false
     in
     let arg_1_offset = add_argument callspec double_ffitype in
     let () = prep_callspec callspec Libffi_abi.(abi_code default_abi)
@@ -42,7 +43,7 @@ let test_fabs _ =
         (fun p _values ->
           write Ctypes_primitive_types.Double x
             Ctypes_ptr.(make_unmanaged ~reftyp:Ctypes_static.Void (Raw.(add p (of_int arg_1_offset)))))
-        (fun p -> read Ctypes_primitive_types.Double (make_unmanaged ~reftyp:Ctypes_static.Void p))
+        (fun p -> read Ctypes_primitive_types.Double (make_unmanaged ~reftyp:Ctypes_static.Void (Obj.obj p:Ctypes_ptr.voidp)))
     in
 
     assert_equal 2.0 (fabs (-2.0)) ~printer:string_of_float;
@@ -62,6 +63,7 @@ let test_pow _ =
       ~check_errno:false
       ~runtime_lock:false
       ~thread_registration:false
+      ~return_ocaml_value:false
     in
     let arg_1_offset = add_argument callspec double_ffitype in
     let arg_2_offset = add_argument callspec double_ffitype in
@@ -79,7 +81,7 @@ let test_pow _ =
             Ctypes_ptr.(make_unmanaged ~reftyp:Ctypes_static.Void (Raw.(add buffer (of_int arg_1_offset))));
           write Ctypes_primitive_types.Double y
             Ctypes_ptr.(make_unmanaged ~reftyp:Ctypes_static.Void (Raw.(add buffer (of_int arg_2_offset)))))
-        (fun p -> read Ctypes_primitive_types.Double (make_unmanaged ~reftyp:Ctypes_static.Void p))
+        (fun p -> read Ctypes_primitive_types.Double (make_unmanaged ~reftyp:Ctypes_static.Void (Obj.obj p:Ctypes_ptr.voidp)))
     in
 
     assert_equal 8.0 (pow 2.0 3.0);


### PR DESCRIPTION
Allows to have C function with `value` argument and result. Should fix #643 in a more satisfactory way.

WIP because it remains ugly part in ffi and choice between `Obj.t typ` and `'a typ`.

Duplicate of #569 opened 3 years ago. I hope there are now more interesting use cases for this feature.

CC @disteph @gasche
