### PR TITLE
Eliminate some warnings

### DIFF
--- a/src/ctypes-foreign/dl.ml.unix
+++ b/src/ctypes-foreign/dl.ml.unix
@@ -5,6 +5,8 @@
  * See the file LICENSE for details.
  *)
 
+[@@@ocaml.warning "-16"]
+
 type library
 
 type flag = 

--- a/src/ctypes-foreign/dl.ml.win
+++ b/src/ctypes-foreign/dl.ml.win
@@ -3,6 +3,8 @@
  * See the file LICENSE for details.
  *)
 
+[@@@ocaml.warning "-16"]
+
 type library
 
 type dlsym_ret =

--- a/tests/clib/test_functions.c
+++ b/tests/clib/test_functions.c
@@ -35,19 +35,19 @@
 static int add(int x, int y) { return x + y; }
 static int times(int x, int y) { return x * y; }
 
-int higher_order_1(intfun *callback, int x, int y)
+int higher_order_1(intfun *f, int x, int y)
 {
-  return callback(x, y) == x + y;
+  return f(x, y) == x + y;
 }
 
-int higher_order_3(acceptor *callback, intfun *fn, int x, int y)
+int higher_order_3(acceptor *f, intfun *fn, int x, int y)
 {
-  return callback(fn, x, y);
+  return f(fn, x, y);
 }
 
-int higher_order_simplest(vintfun *callback)
+int higher_order_simplest(vintfun *f)
 {
-  return callback(22);
+  return f(22);
 }
 
 intfun *returning_funptr(int v)
@@ -96,10 +96,10 @@ int is_null(void *p)
   return p == NULL;
 }
 
-int callback_returns_funptr(vintfun *(*callback)(int), int x)
+int callback_returns_funptr(vintfun *(*f)(int), int x)
 {
-  vintfun *v1 = callback(x);
-  vintfun *v2 = callback(x + 1);
+  vintfun *v1 = f(x);
+  vintfun *v2 = f(x + 1);
 
   return v1(10) + v2(20);
 }
@@ -496,9 +496,9 @@ float rotdist_complexf_val(float _Complex c, float r) {
 
 static int (*global_stored_callback)(int) = NULL;
 
-void store_callback(int (*callback)(int))
+void store_callback(int (*f)(int))
 {
-  global_stored_callback = callback;
+  global_stored_callback = f;
 }
 
 int invoke_stored_callback(int x)
@@ -506,9 +506,9 @@ int invoke_stored_callback(int x)
   return global_stored_callback(x);
 }
 
-vintfun *return_callback(vintfun *callback)
+vintfun *return_callback(vintfun *f)
 {
-  return callback;
+  return f;
 }
 
 struct one_int return_struct_by_value(void)
@@ -558,9 +558,9 @@ int sum_range_with_plus_callback(int a, int b)
 
 static callback_t *registered_callback = NULL;
 
-void register_callback(callback_t *callback)
+void register_callback(callback_t *f)
 {
-  registered_callback = callback;
+  registered_callback = f;
 }
 
 void call_registered_callback(int times, int starting_value)

--- a/tests/clib/test_functions.h
+++ b/tests/clib/test_functions.h
@@ -158,7 +158,7 @@ long double rotdist_complexld_val(long double _Complex, long double);
 float _Complex add_complexf_val(float _Complex, float _Complex);
 float _Complex mul_complexf_val(float _Complex, float _Complex);
 float rotdist_complexf_val(float _Complex, float);
-void store_callback(int (*callback)(int));
+void store_callback(int (*)(int));
 int invoke_stored_callback(int);
 vintfun *return_callback(vintfun *);
 struct one_int { int i; };

--- a/tests/test-foreign_values/test_foreign_values.ml
+++ b/tests/test-foreign_values/test_foreign_values.ml
@@ -76,7 +76,7 @@ struct
   let test_environ _ =
     let parse_entry s =
       match Str.(bounded_split (regexp "=") s 2), "" with
-        [k; v], _ | [k], v -> (String.uppercase k, v)
+        [k; v], _ | [k], v -> (String.uppercase_ascii k, v)
       | _ -> Printf.ksprintf failwith "Parsing %S failed" s
     in
     let rec copy_environ acc env =

--- a/tests/test-pointers/test_pointers.ml
+++ b/tests/test-pointers/test_pointers.ml
@@ -5,6 +5,8 @@
  * See the file LICENSE for details.
  *)
 
+[@@@ocaml.warning "-6"]
+
 open OUnit2
 open Ctypes
 open Foreign

--- a/tests/test-raw/test_raw.ml
+++ b/tests/test-raw/test_raw.ml
@@ -5,6 +5,8 @@
  * See the file LICENSE for details.
  *)
 
+[@@@ocaml.warning "-6"]
+
 open OUnit2
 open Ctypes_memory_stubs
 open Ctypes_std_view_stubs

--- a/tests/test-variadic/test_variadic.ml
+++ b/tests/test-variadic/test_variadic.ml
@@ -7,6 +7,8 @@
 
 (* Tests for binding variadic functions. *)
 
+[@@@ocaml.warning "-6"]
+
 open OUnit2
 open Ctypes
 

--- a/tests/test-views/test_views.ml
+++ b/tests/test-views/test_views.ml
@@ -94,8 +94,8 @@ struct
       assert_equal 0
         ~printer:(Printf.sprintf "%d")
         (strcmp
-           (String.copy "abcdefg")
-           (String.copy "abcdefg"));
+           (Bytes.to_string (Bytes.copy (Bytes.of_string "abcdefg")))
+           (Bytes.to_string (Bytes.copy (Bytes.of_string "abcdefg"))));
       (* Gc.compact ();  *)
     done
 end


### PR DESCRIPTION
- Rename local variables to avoid clashes with OCaml's unprefixed exported names
- Replace some calls to deprecated `String` functions
- Disable warnings for unerasable optional arguments and omitted labels