### PR TITLE
Pervasives is removed in OCaml 5.00.0+trunk

### DIFF
--- a/tests/test-arrays/test_array.ml
+++ b/tests/test-arrays/test_array.ml
@@ -6,6 +6,7 @@
  *)
 
 open OUnit2
+module Float_ = struct let float = float end (*has to be above the module Ctypes*)
 open Ctypes
 
 
@@ -47,7 +48,7 @@ let test_multidimensional_arrays _ =
 
   (* three dimensions *)
   let three = Array.make (array 2 (array 5 float)) 10 in
-  let float = Pervasives.float in
+  let float = Float_.float in
 
   for i = 0 to 9 do
     for j = 0 to 1 do

--- a/tests/test-cstdlib/test_cstdlib.ml
+++ b/tests/test-cstdlib/test_cstdlib.ml
@@ -180,7 +180,7 @@ struct
     let cmpi m1 m2 =
       let mi1 = from_voidp mi m1 in
       let mi2 = from_voidp mi m2 in
-      Pervasives.compare
+      compare
         (as_string (!@(mi1 |-> name)))
         (as_string (!@(mi2 |-> name)))
 

--- a/tests/test-pointers/test_pointers.ml
+++ b/tests/test-pointers/test_pointers.ml
@@ -63,7 +63,7 @@ struct
       (allocate (ptr (ptr int)) (allocate (ptr int) (allocate int 4))) in
 
     assert_equal ~msg:"Passing pointers to pointers"
-      Pervasives.(1 + 2 + 3 + 4)
+      (1 + 2 + 3 + 4)
       (accept_pointers_to_pointers p pp ppp pppp)
 
 

--- a/tests/test-views/test_views.ml
+++ b/tests/test-views/test_views.ml
@@ -79,7 +79,7 @@ struct
         (-1) (accepting_possibly_null_funptr None 2 3);
 
       assert_equal ~msg:"passing non-null function pointer"
-        5 (accepting_possibly_null_funptr (Some Pervasives.(+)) 2 3);
+        5 (accepting_possibly_null_funptr (Some (+)) 2 3);
 
       assert_equal ~msg:"passing non-null function pointer obtained from C"
         6 (accepting_possibly_null_funptr (returning_funptr 1) 2 3);


### PR DESCRIPTION
Pervasives is no longer supported in 5.00.0 and is replaced by Stdlib. To be compatible with old version it's not nice to just replace it by Stdlib.