### PR TITLE
define `CAML_COMPATIBILITY_H` to allow more idents

### DIFF
--- a/src/cstubs/cstubs_structs.ml
+++ b/src/cstubs/cstubs_structs.ml
@@ -30,6 +30,7 @@ let cstring s =
 let cprologue = [
   "#include <stdio.h>";
   "#include <stddef.h>";
+  "#define CAML_COMPATIBILITY_H";
   "#include \"ctypes_cstubs_internals.h\"";
   "";
   "int main(void)";


### PR DESCRIPTION
`compatibility.h` defines preprocessor macros which means certain identifiers, such as `alloc` cannot be used. The preprocessor expands the identifier into `caml_xxx` in the `offset_of`.

This is a problem when binding with cstubs when structs have fields with the same identifiers. Currently, you can manually add this `#define` in the preamble manually as a workaround.