### PR TITLE
bypass passability check in cstubs returns

### DIFF
--- a/src/cstubs/cstubs_structs.ml
+++ b/src/cstubs/cstubs_structs.ml
@@ -255,7 +255,11 @@ let gen_c () =
   let m =
     (module struct
       include Ctypes
-      let ( @-> ) f t = Ctypes_static.Function (f, t) (* bypass passability check *)
+
+      (* bypass passability checks *)
+      let ( @-> ) f t = Ctypes_static.Function (f, t)
+      let returning v = Ctypes_static.Returns v
+
       open Ctypes_static
       let rec field' : type a s r. string -> s typ -> string -> a typ -> (a, r) field =
         fun structname s fname ftype -> match s with 

--- a/tests/test-structs/stubs/types.ml
+++ b/tests/test-structs/stubs/types.ml
@@ -51,4 +51,5 @@ struct
   let () = seal s6
   
   let funptr = static_funptr (struct_s6 @-> returning int)
+  let funptr2 = static_funptr (int @-> returning struct_s6)
 end


### PR DESCRIPTION
Avoid an IncompleteType exception when generating stubs for a function type which returns a struct or union value.

This is related to https://github.com/yallop/ocaml-ctypes/pull/795 which fixes the issue for *passing* a struct or union value as a parameter.